### PR TITLE
Video length increase for Procgen

### DIFF
--- a/cleanrl/ppg_procgen_fast.py
+++ b/cleanrl/ppg_procgen_fast.py
@@ -188,7 +188,7 @@ venv = VecMonitor(venv=venv)
 envs = VecNormalize(venv=venv, norm_obs=False)
 envs = VecPyTorch(envs, device)
 if args.capture_video:
-	envs = VecVideoRecorder(envs, f'videos/{experiment_name}', record_video_trigger=lambda x: x % 1000000== 0, video_length=100)
+	envs = VecVideoRecorder(envs, f'videos/{experiment_name}', record_video_trigger=lambda x: x % 1000000== 0, video_length=600)
 assert isinstance(envs.action_space, Discrete), "only discrete action space is supported"
 
 # ALGO LOGIC: initialize agent here:

--- a/cleanrl/ppo_procgen_fast.py
+++ b/cleanrl/ppo_procgen_fast.py
@@ -11,7 +11,6 @@ import numpy as np
 import gym
 from procgen import ProcgenEnv
 from gym.wrappers import TimeLimit, Monitor
-import pybullet_envs
 from gym.spaces import Discrete, Box, MultiBinary, MultiDiscrete, Space
 import time
 import random
@@ -178,7 +177,7 @@ envs = VecNormalize(venv=venv, norm_obs=False)
 envs = VecPyTorch(envs, device)
 if args.capture_video:
     envs = VecVideoRecorder(envs, f'videos/{experiment_name}', 
-                            record_video_trigger=lambda x: x % 1000000== 0, video_length=100)
+                            record_video_trigger=lambda x: x % 1000000== 0, video_length=600)
 assert isinstance(envs.action_space, Discrete), "only discrete action space is supported"
 
 # ALGO LOGIC: initialize agent here:


### PR DESCRIPTION
Video length increased to 600 from prior value of 100 for ppo_procgen_fast.py and ppg_procgen_fast.py. Video length of 100 proved to be too short for truly assessing or watching the gameplay of some games in the Procgen benchmark. Additionally, pybullet import was removed from ppo_procgen_fast.py as it was an unnecessary import.