### PR TITLE
Only run tests given changes to the `cleanrl` directory

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,6 +1,8 @@
 name: tests
 on:
   push:
+    paths:
+      - cleanrl/**
 jobs:
   ci:
     strategy:


### PR DESCRIPTION
This PR modifies the github action workflows such that they only run tests given changes to the `cleanrl` directory.