### PR TITLE
Import built docker image to local registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && \
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
 # install python dependencies
+RUN mkdir cleanrl_utils && touch cleanrl_utils/__init__.py
 RUN pip install poetry
 COPY pyproject.toml pyproject.toml
 COPY poetry.lock poetry.lock

--- a/cleanrl_utils/submit_exp.py
+++ b/cleanrl_utils/submit_exp.py
@@ -48,7 +48,7 @@ args = parser.parse_args()
 if args.build:
     push_str = "--push" if args.push else ""
     subprocess.run(
-        f"docker buildx build {push_str} --cache-to type=local,mode=max,dest=cloud/docker_cache/cleanrl --cache-from type=local,src=cloud/docker_cache/cleanrl --platform {args.archs} -t {args.docker_tag} .",
+        f"docker buildx build {push_str} --load --cache-to type=local,mode=max,dest=cloud/docker_cache/cleanrl --cache-from type=local,src=cloud/docker_cache/cleanrl --platform {args.archs} -t {args.docker_tag} .",
         shell=True,
         check=True,
     )


### PR DESCRIPTION
Currently running the following commands

```bash
poetry run python -m cleanrl_utils.submit_exp \
    --docker-tag vwxyzjn/cleanrl-new:latest \
    --command "poetry run python cleanrl/ppo.py --gym-id CartPole-v1 --total-timesteps 100000 --track --capture-video" \
    --build

docker run vwxyzjn/cleanrl-new:latest /bin/bash -c "poetry run python cleanrl/ppo.py --gym-id CartPole-v1 --total-timesteps 100000 --track --capture-video --seed 1"
```

results in the following error.

```
docker: Error response from daemon: manifest for vwxyzjn/cleanrl-new:latest not found: manifest unknown: manifest unknown.
```


This PR adds the `--load` flag, so buildx will import the docker image to the local registry.
