### PR TITLE
Set the correct SPOT allocation strategy

### DIFF
--- a/cloud/modules/cleanrl/variables.tf
+++ b/cloud/modules/cleanrl/variables.tf
@@ -13,7 +13,7 @@ variable "on_demand_allocation_strategy" {
 variable "spot_allocation_strategy" {
   description = "The allocation strateg for the on-demand computing environment (e.g. `BEST_FIT`, `BEST_FIT_PROGRESSIVE`, or `SPOT_CAPACITY_OPTIMIZED`; see https://docs.aws.amazon.com/batch/latest/userguide/allocation-strategies.html)"
   type        = string
-  default     = "BEST_FIT"
+  default     = "SPOT_CAPACITY_OPTIMIZED"
 }
 
 variable "spot_bid_percentage" {


### PR DESCRIPTION
For some reason, the `BEST_FIT` strategy doesn't work and I cannot spin up any runs using the AWS spot computing environments. In this PR we change the allocation strategy to `SPOT_CAPACITY_OPTIMIZED`, which seems to be working.

![image](https://user-images.githubusercontent.com/5555347/141865605-c93cc8e4-4b33-4944-99c6-605504cd2f36.png)
