### PR TITLE
Downgrade setuptools

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,6 +26,8 @@ jobs:
       # classic control tests
       - name: Install core dependencies
         run: poetry install -E pytest
+      - name: Downgrade setuptools
+        run: poetry run pip install setuptools==59.5.0
       - name: Run core tests
         run: poetry run pytest tests/test_classic_control.py
 
@@ -52,6 +54,8 @@ jobs:
         run: poetry install -E pytest
       - name: Install atari dependencies
         run: poetry install -E atari
+      - name: Downgrade setuptools
+        run: poetry run pip install setuptools==59.5.0
       - name: Run atari tests
         run: poetry run pytest tests/test_atari.py
 
@@ -78,5 +82,7 @@ jobs:
         run: poetry install -E pytest
       - name: Install pybullet dependencies
         run: poetry install -E pybullet
+      - name: Downgrade setuptools
+        run: poetry run pip install setuptools==59.5.0
       - name: Run pybullet tests
         run: poetry run pytest tests/test_pybullet.py

--- a/.github/workflows/utils_test.yaml
+++ b/.github/workflows/utils_test.yaml
@@ -27,5 +27,7 @@ jobs:
         run: poetry install -E pytest
       - name: Install cloud dependencies
         run: poetry install -E cloud
+      - name: Downgrade setuptools
+        run: poetry run pip install setuptools==59.5.0
       - name: Run utils tests
         run: poetry run pytest tests/test_utils.py

--- a/tests/test_atari.py
+++ b/tests/test_atari.py
@@ -11,7 +11,7 @@ def test_ppo():
 
 def test_dqn():
     subprocess.run(
-        "python cleanrl/dqn_atari.py --learning-starts 200 --total-timesteps 205",
+        "python cleanrl/dqn_atari.py --learning-starts 200 --total-timesteps 204",
         shell=True,
         check=True,
     )
@@ -19,7 +19,7 @@ def test_dqn():
 
 def test_c51():
     subprocess.run(
-        "python cleanrl/c51_atari.py --learning-starts 200 --total-timesteps 205",
+        "python cleanrl/c51_atari.py --learning-starts 200 --total-timesteps 204",
         shell=True,
         check=True,
     )


### PR DESCRIPTION
The latest github action envs are giving weird issue: `AttributeError: module 'setuptools._distutils' has no attribute 'version'.` Hence we are downgrading setuptools.