### PR TITLE
Refactor value based methods

### DIFF
--- a/cleanrl/apex_dqn_atari.py
+++ b/cleanrl/apex_dqn_atari.py
@@ -853,7 +853,7 @@ def learn(args, rb, global_step, data_process_queue, data_process_back_queues, s
         
         stats_queue.put(("losses/td_loss", loss.item(), update_step+args.learning_starts))
     
-        # optimize the midel
+        # optimize the model
         optimizer.zero_grad()
         loss.backward()
         nn.utils.clip_grad_norm_(list(learn_q_network.parameters()), args.max_grad_norm)

--- a/cleanrl/c51.py
+++ b/cleanrl/c51.py
@@ -91,7 +91,7 @@ class QNetwork(nn.Module):
         super(QNetwork, self).__init__()
         self.env = env
         self.n_atoms = n_atoms
-        self.atoms = torch.linspace(v_min, v_max, steps=n_atoms)
+        self.register_buffer("atoms", torch.linspace(v_min, v_max, steps=n_atoms))
         self.n = env.single_action_space.n
         self.network = nn.Sequential(
             nn.Linear(np.array(env.single_observation_space.shape).prod(), 120),

--- a/cleanrl/c51.py
+++ b/cleanrl/c51.py
@@ -17,7 +17,7 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
         help="the name of this experiment")
-    parser.add_argument("--gym-id", type=str, default="CartPole-v0",
+    parser.add_argument("--gym-id", type=str, default="CartPole-v1",
         help="the id of the gym environment")
     parser.add_argument("--learning-rate", type=float, default=2.5e-4,
         help="the learning rate of the optimizer")

--- a/cleanrl/c51.py
+++ b/cleanrl/c51.py
@@ -218,7 +218,7 @@ if __name__ == "__main__":
                     target_pmfs[i].index_add_(0, u[i].long(), d_m_u[i])
             
             _, old_pmfs = q_network.get_action(data.observations, data.actions.flatten())
-            loss = (-(target_pmfs * old_pmfs.clamp(min=1e-5).log()).sum(-1)).mean()
+            loss = (-(target_pmfs.clamp(min=1e-5) * old_pmfs.clamp(min=1e-5).log()).sum(-1)).mean()
 
             if global_step % 100 == 0:
                 writer.add_scalar("losses/td_loss", loss, global_step)

--- a/cleanrl/c51.py
+++ b/cleanrl/c51.py
@@ -223,7 +223,7 @@ if __name__ == "__main__":
             if global_step % 100 == 0:
                 writer.add_scalar("losses/td_loss", loss, global_step)
 
-            # optimize the midel
+            # optimize the model
             optimizer.zero_grad()
             loss.backward()
             nn.utils.clip_grad_norm_(list(q_network.parameters()), args.max_grad_norm)

--- a/cleanrl/c51.py
+++ b/cleanrl/c51.py
@@ -1,258 +1,237 @@
-# Reference: https://arxiv.org/pdf/1707.06887.pdf
-# https://github.com/ShangtongZhang/DeepRL/blob/master/deep_rl/agent/CategoricalDQN_agent.py
+import argparse
+import os
+import random
+import time
+from distutils.util import strtobool
 
+import gym
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.optim as optim
-import torch.nn.functional as F
 from torch.utils.tensorboard import SummaryWriter
+from stable_baselines3.common.buffers import ReplayBuffer
 
-import argparse
-from distutils.util import strtobool
-import collections
-import numpy as np
-import gym
-from gym.wrappers import TimeLimit, Monitor
-from gym.spaces import Discrete, Box, MultiBinary, MultiDiscrete, Space
-import time
-import random
-import os
+def parse_args():
+    # fmt: off
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
+        help="the name of this experiment")
+    parser.add_argument("--gym-id", type=str, default="CartPole-v0",
+        help="the id of the gym environment")
+    parser.add_argument("--learning-rate", type=float, default=2.5e-4,
+        help="the learning rate of the optimizer")
+    parser.add_argument("--seed", type=int, default=1,
+        help="seed of the experiment")
+    parser.add_argument("--total-timesteps", type=int, default=50000,
+        help="total timesteps of the experiments")
+    parser.add_argument("--torch-deterministic", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
+        help="if toggled, `torch.backends.cudnn.deterministic=False`")
+    parser.add_argument("--cuda", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
+        help="if toggled, cuda will be enabled by default")
+    parser.add_argument("--track", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="if toggled, this experiment will be tracked with Weights and Biases")
+    parser.add_argument("--wandb-project-name", type=str, default="cleanRL",
+        help="the wandb's project name")
+    parser.add_argument("--wandb-entity", type=str, default=None,
+        help="the entity (team) of wandb's project")
+    parser.add_argument("--capture-video", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="weather to capture videos of the agent performances (check out `videos` folder)")
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='C51 agent')
-    # Common arguments
-    parser.add_argument('--exp-name', type=str, default=os.path.basename(__file__).rstrip(".py"),
-                        help='the name of this experiment')
-    parser.add_argument('--gym-id', type=str, default="CartPole-v0",
-                        help='the id of the gym environment')
-    parser.add_argument('--learning-rate', type=float, default=1e-4,
-                        help='the learning rate of the optimizer')
-    parser.add_argument('--seed', type=int, default=2,
-                        help='seed of the experiment')
-    parser.add_argument('--total-timesteps', type=int, default=50000,
-                        help='total timesteps of the experiments')
-    parser.add_argument('--torch-deterministic', type=lambda x:bool(strtobool(x)), default=True, nargs='?', const=True,
-                        help='if toggled, `torch.backends.cudnn.deterministic=False`')
-    parser.add_argument('--cuda', type=lambda x:bool(strtobool(x)), default=True, nargs='?', const=True,
-                        help='if toggled, cuda will not be enabled by default')
-    parser.add_argument('--track', type=lambda x:bool(strtobool(x)), default=False, nargs='?', const=True,
-                        help='run the script in production mode and use wandb to log outputs')
-    parser.add_argument('--capture-video', type=lambda x:bool(strtobool(x)), default=False, nargs='?', const=True,
-                        help='weather to capture videos of the agent performances (check out `videos` folder)')
-    parser.add_argument('--wandb-project-name', type=str, default="cleanRL",
-                        help="the wandb's project name")
-    parser.add_argument('--wandb-entity', type=str, default=None,
-                        help="the entity (team) of wandb's project")
-    
     # Algorithm specific arguments
-    parser.add_argument('--n-atoms', type=int, default=101,
-                        help="the number of atoms")
-    parser.add_argument('--v-min', type=float, default=-100,
-                        help="the number of atoms")
-    parser.add_argument('--v-max', type=float, default=100,
-                        help="the number of atoms")
-    parser.add_argument('--buffer-size', type=int, default=10000,
-                         help='the replay memory buffer size')
-    parser.add_argument('--gamma', type=float, default=0.99,
-                        help='the discount factor gamma')
-    parser.add_argument('--target-network-frequency', type=int, default=1000,
-                        help="the timesteps it takes to update the target network")
-    parser.add_argument('--max-grad-norm', type=float, default=0.5,
-                        help='the maximum norm for the gradient clipping')
-    parser.add_argument('--batch-size', type=int, default=32,
-                        help="the batch size of sample from the reply memory")
-    parser.add_argument('--start-e', type=float, default=1,
-                        help="the starting epsilon for exploration")
-    parser.add_argument('--end-e', type=float, default=0.02,
-                        help="the ending epsilon for exploration")
-    parser.add_argument('--exploration-fraction', type=float, default=0.50,
-                        help="the fraction of `total-timesteps` it takes from start-e to go end-e")
-    parser.add_argument('--learning-starts', type=int, default=10000,
-                        help="timestep to start learning")
-    parser.add_argument('--train-frequency', type=int, default=1,
-                        help="the frequency of training")
+    parser.add_argument("--n-atoms", type=int, default=101,
+        help="the number of atoms")
+    parser.add_argument("--v-min", type=float, default=-100,
+        help="the number of atoms")
+    parser.add_argument("--v-max", type=float, default=100,
+        help="the number of atoms")
+    parser.add_argument("--buffer-size", type=int, default=10000,
+        help="the replay memory buffer size")
+    parser.add_argument("--gamma", type=float, default=0.99,
+        help="the discount factor gamma")
+    parser.add_argument("--target-network-frequency", type=int, default=1000,
+        help="the timesteps it takes to update the target network")
+    parser.add_argument("--max-grad-norm", type=float, default=0.5,
+        help="the maximum norm for the gradient clipping")
+    parser.add_argument("--batch-size", type=int, default=32,
+        help="the batch size of sample from the reply memory")
+    parser.add_argument("--start-e", type=float, default=1,
+        help="the starting epsilon for exploration")
+    parser.add_argument("--end-e", type=float, default=0.02,
+        help="the ending epsilon for exploration")
+    parser.add_argument("--exploration-fraction", type=float, default=0.5,
+        help="the fraction of `total-timesteps` it takes from start-e to go end-e")
+    parser.add_argument("--learning-starts", type=int, default=10000,
+        help="timestep to start learning")
+    parser.add_argument("--train-frequency", type=int, default=1,
+        help="the frequency of training")
     args = parser.parse_args()
-    if not args.seed:
-        args.seed = int(time.time())
-
-def one_hot(a, size):
-    b = np.zeros((size))
-    b[a] = 1
-    return b
-
-class ProcessObsInputEnv(gym.ObservationWrapper):
-    """
-    This wrapper handles inputs from `Discrete` and `Box` observation space.
-    If the `env.observation_space` is of `Discrete` type, 
-    it returns the one-hot encoding of the state
-    """
-    def __init__(self, env):
-        super().__init__(env)
-        self.n = None
-        if isinstance(self.env.observation_space, Discrete):
-            self.n = self.env.observation_space.n
-            self.observation_space = Box(0, 1, (self.n,))
-
-    def observation(self, obs):
-        if self.n:
-            return one_hot(np.array(obs), self.n)
-        return obs
-
-# TRY NOT TO MODIFY: setup the environment
-experiment_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
-writer = SummaryWriter(f"runs/{experiment_name}")
-writer.add_text('hyperparameters', "|param|value|\n|-|-|\n%s" % (
-        '\n'.join([f"|{key}|{value}|" for key, value in vars(args).items()])))
-if args.track:
-    import wandb
-    wandb.init(project=args.wandb_project_name, entity=args.wandb_entity, sync_tensorboard=True, config=vars(args), name=experiment_name, monitor_gym=True, save_code=True)
-    writer = SummaryWriter(f"/tmp/{experiment_name}")
+    # fmt: on
+    return args
 
 
-# TRY NOT TO MODIFY: seeding
-device = torch.device('cuda' if torch.cuda.is_available() and args.cuda else 'cpu')
-env = ProcessObsInputEnv(gym.make(args.gym_id))
-random.seed(args.seed)
-np.random.seed(args.seed)
-torch.manual_seed(args.seed)
-torch.backends.cudnn.deterministic = args.torch_deterministic
-env.seed(args.seed)
-env.action_space.seed(args.seed)
-env.observation_space.seed(args.seed)
-# respect the default timelimit
-assert isinstance(env.action_space, Discrete), "only discrete action space is supported"
-if args.capture_video:
-    env = Monitor(env, f'videos/{experiment_name}')
+def make_env(gym_id, seed, idx, capture_video, run_name):
+    def thunk():
+        env = gym.make(gym_id)
+        env = gym.wrappers.RecordEpisodeStatistics(env)
+        if capture_video:
+            if idx == 0:
+                env = gym.wrappers.RecordVideo(env, f"videos/{run_name}")
+        env.seed(seed)
+        env.action_space.seed(seed)
+        env.observation_space.seed(seed)
+        return env
 
-# modified from https://github.com/seungeunrho/minimalRL/blob/master/dqn.py#
-class ReplayBuffer():
-    def __init__(self, buffer_limit):
-        self.buffer = collections.deque(maxlen=buffer_limit)
-    
-    def put(self, transition):
-        self.buffer.append(transition)
-    
-    def sample(self, n):
-        mini_batch = random.sample(self.buffer, n)
-        s_lst, a_lst, r_lst, s_prime_lst, done_mask_lst = [], [], [], [], []
-        
-        for transition in mini_batch:
-            s, a, r, s_prime, done_mask = transition
-            s_lst.append(s)
-            a_lst.append(a)
-            r_lst.append(r)
-            s_prime_lst.append(s_prime)
-            done_mask_lst.append(done_mask)
+    return thunk
 
-        return np.array(s_lst), np.array(a_lst), \
-               np.array(r_lst), np.array(s_prime_lst), \
-               np.array(done_mask_lst)
 
 # ALGO LOGIC: initialize agent here:
 class QNetwork(nn.Module):
-    def __init__(self, frames=4, n_atoms=101, v_min=-100, v_max=100, device=None, env=None):
+    def __init__(self, env, n_atoms=101, v_min=-100, v_max=100):
         super(QNetwork, self).__init__()
-        if device is not None:
-            self.n_atoms = n_atoms
-            self.atoms = torch.linspace(v_min, v_max, steps=n_atoms).to(device)
-            self.network = nn.Sequential(
-                nn.Linear(np.array(env.observation_space.shape).prod(), 120),
-                nn.ReLU(),
-                nn.Linear(120, 84),
-                nn.ReLU(),
-                nn.Linear(84, env.action_space.n * n_atoms)
-            )
+        self.env = env
+        self.n_atoms = n_atoms
+        self.atoms = torch.linspace(v_min, v_max, steps=n_atoms)
+        self.n = env.single_action_space.n
+        self.network = nn.Sequential(
+            nn.Linear(np.array(env.single_observation_space.shape).prod(), 120),
+            nn.ReLU(),
+            nn.Linear(120, 84),
+            nn.ReLU(),
+            nn.Linear(84, self.n * n_atoms)
+        )
 
-    def forward(self, x, device):
-        x = torch.Tensor(x).to(device)
+    def forward(self, x):
         return self.network(x)
 
-    def get_action(self, x, device, env, action=None):
-        logits = self.forward(x, device)
+    def get_action(self, x, action=None):
+        logits = self.forward(x)
         # probability mass function for each action
-        pmfs = torch.softmax(logits.view(len(x), env.action_space.n, self.n_atoms), dim=2)
+        pmfs = torch.softmax(logits.view(len(x), self.n, self.n_atoms), dim=2)
         q_values = (pmfs*self.atoms).sum(2)
         if action is None:
             action = torch.argmax(q_values, 1)
         return action, pmfs[torch.arange(len(x)), action]
 
+
 def linear_schedule(start_e: float, end_e: float, duration: int, t: int):
     slope =  (end_e - start_e) / duration
     return max(slope * t + start_e, end_e)
 
-rb = ReplayBuffer(args.buffer_size)
-q_network = QNetwork(n_atoms=args.n_atoms, v_min=args.v_min, v_max=args.v_max, device=device, env=env).to(device)
-target_network = QNetwork(n_atoms=args.n_atoms, v_min=args.v_min, v_max=args.v_max, device=device, env=env).to(device)
-target_network.load_state_dict(q_network.state_dict())
-optimizer = optim.Adam(q_network.parameters(), lr=args.learning_rate)
-loss_fn = nn.MSELoss()
-print(device.__repr__())
-print(q_network)
 
-# TRY NOT TO MODIFY: start the game
-obs = env.reset()
-episode_reward = 0
-for global_step in range(args.total_timesteps):
-    # ALGO LOGIC: put action logic here
-    epsilon = linear_schedule(args.start_e, args.end_e, args.exploration_fraction*args.total_timesteps, global_step)
-    if random.random() < epsilon:
-        action = env.action_space.sample()
-    else:
-        action, pmf = target_network.get_action(obs.reshape((1,)+obs.shape), device=device, env=env)
-        action = action.tolist()[0]
+if __name__ == "__main__":
+    args = parse_args()
+    run_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    if args.track:
+        import wandb
 
-    # TRY NOT TO MODIFY: execute the game and log data.
-    next_obs, reward, done, _ = env.step(action)
-    episode_reward += reward
+        wandb.init(
+            project=args.wandb_project_name,
+            entity=args.wandb_entity,
+            sync_tensorboard=True,
+            config=vars(args),
+            name=run_name,
+            monitor_gym=True,
+            save_code=True,
+        )
+    writer = SummaryWriter(f"runs/{run_name}")
+    writer.add_text(
+        "hyperparameters",
+        "|param|value|\n|-|-|\n%s" % ("\n".join([f"|{key}|{value}|" for key, value in vars(args).items()])),
+    )
 
-    # ALGO LOGIC: training.
-    rb.put((obs, action, reward, next_obs, done))
-    if global_step > args.learning_starts and global_step % args.train_frequency == 0:
-        s_obs, s_actions, s_rewards, s_next_obses, s_dones = rb.sample(args.batch_size)
-        with torch.no_grad():
-            _, next_pmfs = q_network.get_action(s_next_obses, device=device, env=env)
-            next_atoms = torch.Tensor(s_rewards).to(device).unsqueeze(-1) + args.gamma * q_network.atoms  * (1 - torch.Tensor(s_dones).to(device).unsqueeze(-1))
-            # projection
-            delta_z = q_network.atoms[1]-q_network.atoms[0]
-            tz = next_atoms.clamp(args.v_min, args.v_max)
-            
-            b = (tz - args.v_min)/ delta_z
-            l = b.floor().clamp(0, args.n_atoms-1)
-            u = b.ceil().clamp(0, args.n_atoms-1)
-            # (l == u).float() handles the case where bj is exactly an integer
-            # example bj = 1, then the upper ceiling should be uj= 2, and lj= 1
-            d_m_l = (u + (l == u).float() - b) * next_pmfs
-            d_m_u = (b - l) * next_pmfs
-            target_pmfs = torch.zeros_like(next_pmfs)
-            for i in range(target_pmfs.size(0)):
-                target_pmfs[i].index_add_(0, l[i].long(), d_m_l[i])
-                target_pmfs[i].index_add_(0, u[i].long(), d_m_u[i])
-        
-        _, old_pmfs = q_network.get_action(s_obs, device, env, s_actions)
-        loss = (-(target_pmfs.detach() * old_pmfs.log()).sum(-1)).mean()
-        
-        if global_step % 100 == 0:
-            writer.add_scalar("losses/td_loss", loss, global_step)
+    # TRY NOT TO MODIFY: seeding
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.backends.cudnn.deterministic = args.torch_deterministic
 
-        # optimize the midel
-        optimizer.zero_grad()
-        loss.backward()
-        nn.utils.clip_grad_norm_(list(q_network.parameters()), args.max_grad_norm)
-        optimizer.step()
+    device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
 
-        # update the target network
-        if global_step % args.target_network_frequency == 0:
-            target_network.load_state_dict(q_network.state_dict())
+    # env setup
+    envs = gym.vector.SyncVectorEnv(
+        [make_env(args.gym_id, 0, 0, args.capture_video, run_name)]
+    )
+    assert isinstance(envs.single_action_space, gym.spaces.Discrete), "only discrete action space is supported"
 
-    # TRY NOT TO MODIFY: CRUCIAL step easy to overlook 
-    obs = next_obs
+    q_network = QNetwork(envs, n_atoms=args.n_atoms, v_min=args.v_min, v_max=args.v_max).to(device)
+    optimizer = optim.Adam(q_network.parameters(), lr=args.learning_rate)
+    target_network = QNetwork(envs, n_atoms=args.n_atoms, v_min=args.v_min, v_max=args.v_max).to(device)
+    target_network.load_state_dict(q_network.state_dict())
 
-    if done:
+    rb = ReplayBuffer(args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device, optimize_memory_usage=True)
+    loss_fn = nn.MSELoss()
+
+    # TRY NOT TO MODIFY: start the game
+    obs = envs.reset()
+    for global_step in range(args.total_timesteps):
+        # ALGO LOGIC: put action logic here
+        epsilon = linear_schedule(args.start_e, args.end_e, args.exploration_fraction*args.total_timesteps, global_step)
+        if random.random() < epsilon:
+            actions = envs.action_space.sample()
+        else:
+            actions, pmf = q_network.get_action(torch.Tensor(obs).to(device))
+            actions = actions.cpu().numpy()
+
+        # TRY NOT TO MODIFY: execute the game and log data.
+        next_obs, rewards, dones, infos = envs.step(actions)
+
         # TRY NOT TO MODIFY: record rewards for plotting purposes
-        print(f"global_step={global_step}, episode_reward={episode_reward}")
-        writer.add_scalar("charts/episodic_return", episode_reward, global_step)
-        writer.add_scalar("charts/epsilon", epsilon, global_step)
-        obs, episode_reward = env.reset(), 0
+        for info in infos:
+            if "episode" in info.keys():
+                print(f"global_step={global_step}, episode_reward={info['episode']['r']}")
+                writer.add_scalar("charts/episodic_return", info["episode"]["r"], global_step)
+                writer.add_scalar("charts/epsilon", epsilon, global_step)
+                break
 
-env.close()
-writer.close()
+        # TRY NOT TO MODIFY: save data to reply buffer; handle `terminal_observation`
+        real_next_obs = next_obs.copy()
+        for idx, d in enumerate(dones):
+            if d:
+                real_next_obs[idx] = infos[idx]["terminal_observation"]
+        rb.add(obs, real_next_obs, actions, rewards, dones, infos)
+
+        # TRY NOT TO MODIFY: CRUCIAL step easy to overlook
+        obs = next_obs
+
+        # ALGO LOGIC: training.
+        if global_step > args.learning_starts and global_step % args.train_frequency == 0:
+            data = rb.sample(args.batch_size)
+
+            with torch.no_grad():
+                _, next_pmfs = target_network.get_action(data.next_observations)
+                next_atoms = data.rewards + args.gamma * target_network.atoms * (1 - data.dones)
+                # projection
+                delta_z = target_network.atoms[1] - target_network.atoms[0]
+                tz = next_atoms.clamp(args.v_min, args.v_max)
+                
+                b = (tz - args.v_min)/ delta_z
+                l = b.floor().clamp(0, args.n_atoms-1)
+                u = b.ceil().clamp(0, args.n_atoms-1)
+                # (l == u).float() handles the case where bj is exactly an integer
+                # example bj = 1, then the upper ceiling should be uj= 2, and lj= 1
+                d_m_l = (u + (l == u).float() - b) * next_pmfs
+                d_m_u = (b - l) * next_pmfs
+                target_pmfs = torch.zeros_like(next_pmfs)
+                for i in range(target_pmfs.size(0)):
+                    target_pmfs[i].index_add_(0, l[i].long(), d_m_l[i])
+                    target_pmfs[i].index_add_(0, u[i].long(), d_m_u[i])
+            
+            _, old_pmfs = q_network.get_action(data.observations, data.actions.flatten())
+            loss = (-(target_pmfs.detach() * old_pmfs.log()).sum(-1)).mean()
+
+            if global_step % 100 == 0:
+                writer.add_scalar("losses/td_loss", loss, global_step)
+
+            # optimize the midel
+            optimizer.zero_grad()
+            loss.backward()
+            nn.utils.clip_grad_norm_(list(q_network.parameters()), args.max_grad_norm)
+            optimizer.step()
+
+            # update the target network
+            if global_step % args.target_network_frequency == 0:
+                target_network.load_state_dict(q_network.state_dict())
+            # raise
+    envs.close()
+    writer.close()

--- a/cleanrl/c51.py
+++ b/cleanrl/c51.py
@@ -155,7 +155,7 @@ if __name__ == "__main__":
     assert isinstance(envs.single_action_space, gym.spaces.Discrete), "only discrete action space is supported"
 
     q_network = QNetwork(envs, n_atoms=args.n_atoms, v_min=args.v_min, v_max=args.v_max).to(device)
-    optimizer = optim.Adam(q_network.parameters(), lr=args.learning_rate)
+    optimizer = optim.Adam(q_network.parameters(), lr=args.learning_rate, eps=0.01/args.batch_size)
     target_network = QNetwork(envs, n_atoms=args.n_atoms, v_min=args.v_min, v_max=args.v_max).to(device)
     target_network.load_state_dict(q_network.state_dict())
 
@@ -218,7 +218,7 @@ if __name__ == "__main__":
                     target_pmfs[i].index_add_(0, u[i].long(), d_m_u[i])
             
             _, old_pmfs = q_network.get_action(data.observations, data.actions.flatten())
-            loss = (-(target_pmfs.detach() * old_pmfs.log()).sum(-1)).mean()
+            loss = (-(target_pmfs * old_pmfs.clamp(min=1e-5).log()).sum(-1)).mean()
 
             if global_step % 100 == 0:
                 writer.add_scalar("losses/td_loss", loss, global_step)
@@ -232,6 +232,6 @@ if __name__ == "__main__":
             # update the target network
             if global_step % args.target_network_frequency == 0:
                 target_network.load_state_dict(q_network.state_dict())
-            # raise
+
     envs.close()
     writer.close()

--- a/cleanrl/c51.py
+++ b/cleanrl/c51.py
@@ -218,7 +218,7 @@ if __name__ == "__main__":
                     target_pmfs[i].index_add_(0, u[i].long(), d_m_u[i])
             
             _, old_pmfs = q_network.get_action(data.observations, data.actions.flatten())
-            loss = (-(target_pmfs.clamp(min=1e-5) * old_pmfs.clamp(min=1e-5).log()).sum(-1)).mean()
+            loss = (-(target_pmfs * old_pmfs.clamp(min=1e-5, max=1-1e-5).log()).sum(-1)).mean()
 
             if global_step % 100 == 0:
                 writer.add_scalar("losses/td_loss", loss, global_step)

--- a/cleanrl/c51_atari.py
+++ b/cleanrl/c51_atari.py
@@ -26,7 +26,7 @@ def parse_args():
         help="the name of this experiment")
     parser.add_argument("--gym-id", type=str, default="BreakoutNoFrameskip-v4",
         help="the id of the gym environment")
-    parser.add_argument("--learning-rate", type=float, default=1e-4,
+    parser.add_argument("--learning-rate", type=float, default=25e-4,
         help="the learning rate of the optimizer")
     parser.add_argument("--seed", type=int, default=1,
         help="seed of the experiment")
@@ -56,7 +56,7 @@ def parse_args():
         help="the replay memory buffer size")
     parser.add_argument("--gamma", type=float, default=0.99,
         help="the discount factor gamma")
-    parser.add_argument("--target-network-frequency", type=int, default=1000,
+    parser.add_argument("--target-network-frequency", type=int, default=10000,
         help="the timesteps it takes to update the target network")
     parser.add_argument("--max-grad-norm", type=float, default=0.5,
         help="the maximum norm for the gradient clipping")

--- a/cleanrl/c51_atari.py
+++ b/cleanrl/c51_atari.py
@@ -239,7 +239,7 @@ if __name__ == "__main__":
                     target_pmfs[i].index_add_(0, u[i].long(), d_m_u[i])
             
             _, old_pmfs = q_network.get_action(data.observations, data.actions.flatten())
-            loss = (-(target_pmfs.clamp(min=1e-5) * old_pmfs.clamp(min=1e-5).log()).sum(-1)).mean()
+            loss = (-(target_pmfs * old_pmfs.clamp(min=1e-5, max=1-1e-5).log()).sum(-1)).mean()
 
             if global_step % 100 == 0:
                 writer.add_scalar("losses/td_loss", loss, global_step)

--- a/cleanrl/c51_atari.py
+++ b/cleanrl/c51_atari.py
@@ -26,7 +26,7 @@ def parse_args():
         help="the name of this experiment")
     parser.add_argument("--gym-id", type=str, default="BreakoutNoFrameskip-v4",
         help="the id of the gym environment")
-    parser.add_argument("--learning-rate", type=float, default=25e-4,
+    parser.add_argument("--learning-rate", type=float, default=2.5e-4,
         help="the learning rate of the optimizer")
     parser.add_argument("--seed", type=int, default=1,
         help="seed of the experiment")
@@ -239,7 +239,7 @@ if __name__ == "__main__":
                     target_pmfs[i].index_add_(0, u[i].long(), d_m_u[i])
             
             _, old_pmfs = q_network.get_action(data.observations, data.actions.flatten())
-            loss = (-(target_pmfs * old_pmfs.clamp(min=1e-5).log()).sum(-1)).mean()
+            loss = (-(target_pmfs.clamp(min=1e-5) * old_pmfs.clamp(min=1e-5).log()).sum(-1)).mean()
 
             if global_step % 100 == 0:
                 writer.add_scalar("losses/td_loss", loss, global_step)

--- a/cleanrl/c51_atari.py
+++ b/cleanrl/c51_atari.py
@@ -107,7 +107,7 @@ class QNetwork(nn.Module):
         super(QNetwork, self).__init__()
         self.env = env
         self.n_atoms = n_atoms
-        self.atoms = torch.linspace(v_min, v_max, steps=n_atoms)
+        self.register_buffer("atoms", torch.linspace(v_min, v_max, steps=n_atoms))
         self.n = env.single_action_space.n
         self.network = nn.Sequential(
             nn.Conv2d(4, 32, 8, stride=4),

--- a/cleanrl/c51_atari.py
+++ b/cleanrl/c51_atari.py
@@ -244,7 +244,7 @@ if __name__ == "__main__":
             if global_step % 100 == 0:
                 writer.add_scalar("losses/td_loss", loss, global_step)
 
-            # optimize the midel
+            # optimize the model
             optimizer.zero_grad()
             loss.backward()
             nn.utils.clip_grad_norm_(list(q_network.parameters()), args.max_grad_norm)

--- a/cleanrl/c51_atari.py
+++ b/cleanrl/c51_atari.py
@@ -1,461 +1,116 @@
-# https://github.com/facebookresearch/torchbeast/blob/master/torchbeast/core/environment.py
+import argparse
+import os
+import random
+import time
+from distutils.util import strtobool
 
-import numpy as np
-from collections import deque
 import gym
-from gym import spaces
-import cv2
-cv2.ocl.setUseOpenCL(False)
-
-
-class NoopResetEnv(gym.Wrapper):
-    def __init__(self, env, noop_max=30):
-        """Sample initial states by taking random number of no-ops on reset.
-        No-op is assumed to be action 0.
-        """
-        gym.Wrapper.__init__(self, env)
-        self.noop_max = noop_max
-        self.override_num_noops = None
-        self.noop_action = 0
-        assert env.unwrapped.get_action_meanings()[0] == 'NOOP'
-
-    def reset(self, **kwargs):
-        """ Do no-op action for a number of steps in [1, noop_max]."""
-        self.env.reset(**kwargs)
-        if self.override_num_noops is not None:
-            noops = self.override_num_noops
-        else:
-            noops = self.unwrapped.np_random.randint(1, self.noop_max + 1) #pylint: disable=E1101
-        assert noops > 0
-        obs = None
-        for _ in range(noops):
-            obs, _, done, _ = self.env.step(self.noop_action)
-            if done:
-                obs = self.env.reset(**kwargs)
-        return obs
-
-    def step(self, ac):
-        return self.env.step(ac)
-
-class FireResetEnv(gym.Wrapper):
-    def __init__(self, env):
-        """Take action on reset for environments that are fixed until firing."""
-        gym.Wrapper.__init__(self, env)
-        assert env.unwrapped.get_action_meanings()[1] == 'FIRE'
-        assert len(env.unwrapped.get_action_meanings()) >= 3
-
-    def reset(self, **kwargs):
-        self.env.reset(**kwargs)
-        obs, _, done, _ = self.env.step(1)
-        if done:
-            self.env.reset(**kwargs)
-        obs, _, done, _ = self.env.step(2)
-        if done:
-            self.env.reset(**kwargs)
-        return obs
-
-    def step(self, ac):
-        return self.env.step(ac)
-
-class EpisodicLifeEnv(gym.Wrapper):
-    def __init__(self, env):
-        """Make end-of-life == end-of-episode, but only reset on true game over.
-        Done by DeepMind for the DQN and co. since it helps value estimation.
-        """
-        gym.Wrapper.__init__(self, env)
-        self.lives = 0
-        self.was_real_done  = True
-
-    def step(self, action):
-        obs, reward, done, info = self.env.step(action)
-        self.was_real_done = done
-        # check current lives, make loss of life terminal,
-        # then update lives to handle bonus lives
-        lives = self.env.unwrapped.ale.lives()
-        if lives < self.lives and lives > 0:
-            # for Qbert sometimes we stay in lives == 0 condition for a few frames
-            # so it's important to keep lives > 0, so that we only reset once
-            # the environment advertises done.
-            done = True
-        self.lives = lives
-        return obs, reward, done, info
-
-    def reset(self, **kwargs):
-        """Reset only when lives are exhausted.
-        This way all states are still reachable even though lives are episodic,
-        and the learner need not know about any of this behind-the-scenes.
-        """
-        if self.was_real_done:
-            obs = self.env.reset(**kwargs)
-        else:
-            # no-op step to advance from terminal/lost life state
-            obs, _, _, _ = self.env.step(0)
-        self.lives = self.env.unwrapped.ale.lives()
-        return obs
-
-class MaxAndSkipEnv(gym.Wrapper):
-    def __init__(self, env, skip=4):
-        """Return only every `skip`-th frame"""
-        gym.Wrapper.__init__(self, env)
-        # most recent raw observations (for max pooling across time steps)
-        self._obs_buffer = np.zeros((2,)+env.observation_space.shape, dtype=np.uint8)
-        self._skip       = skip
-
-    def step(self, action):
-        """Repeat action, sum reward, and max over last observations."""
-        total_reward = 0.0
-        done = None
-        for i in range(self._skip):
-            obs, reward, done, info = self.env.step(action)
-            if i == self._skip - 2: self._obs_buffer[0] = obs
-            if i == self._skip - 1: self._obs_buffer[1] = obs
-            total_reward += reward
-            if done:
-                break
-        # Note that the observation on the done=True frame
-        # doesn't matter
-        max_frame = self._obs_buffer.max(axis=0)
-
-        return max_frame, total_reward, done, info
-
-    def reset(self, **kwargs):
-        return self.env.reset(**kwargs)
-
-class ClipRewardEnv(gym.RewardWrapper):
-    def __init__(self, env):
-        gym.RewardWrapper.__init__(self, env)
-
-    def reward(self, reward):
-        """Bin reward to {+1, 0, -1} by its sign."""
-        return np.sign(reward)
-
-
-class WarpFrame(gym.ObservationWrapper):
-    def __init__(self, env, width=84, height=84, grayscale=True, dict_space_key=None):
-        """
-        Warp frames to 84x84 as done in the Nature paper and later work.
-        If the environment uses dictionary observations, `dict_space_key` can be specified which indicates which
-        observation should be warped.
-        """
-        super().__init__(env)
-        self._width = width
-        self._height = height
-        self._grayscale = grayscale
-        self._key = dict_space_key
-        if self._grayscale:
-            num_colors = 1
-        else:
-            num_colors = 3
-
-        new_space = gym.spaces.Box(
-            low=0,
-            high=255,
-            shape=(self._height, self._width, num_colors),
-            dtype=np.uint8,
-        )
-        if self._key is None:
-            original_space = self.observation_space
-            self.observation_space = new_space
-        else:
-            original_space = self.observation_space.spaces[self._key]
-            self.observation_space.spaces[self._key] = new_space
-        assert original_space.dtype == np.uint8 and len(original_space.shape) == 3
-
-    def observation(self, obs):
-        if self._key is None:
-            frame = obs
-        else:
-            frame = obs[self._key]
-
-        if self._grayscale:
-            frame = cv2.cvtColor(frame, cv2.COLOR_RGB2GRAY)
-        frame = cv2.resize(
-            frame, (self._width, self._height), interpolation=cv2.INTER_AREA
-        )
-        if self._grayscale:
-            frame = np.expand_dims(frame, -1)
-
-        if self._key is None:
-            obs = frame
-        else:
-            obs = obs.copy()
-            obs[self._key] = frame
-        return obs
-
-
-class FrameStack(gym.Wrapper):
-    def __init__(self, env, k):
-        """Stack k last frames.
-        Returns lazy array, which is much more memory efficient.
-        See Also
-        --------
-        baselines.common.atari_wrappers.LazyFrames
-        """
-        gym.Wrapper.__init__(self, env)
-        self.k = k
-        self.frames = deque([], maxlen=k)
-        shp = env.observation_space.shape
-        self.observation_space = spaces.Box(low=0, high=255, shape=(shp[:-1] + (shp[-1] * k,)), dtype=env.observation_space.dtype)
-
-    def reset(self):
-        ob = self.env.reset()
-        for _ in range(self.k):
-            self.frames.append(ob)
-        return self._get_ob()
-
-    def step(self, action):
-        ob, reward, done, info = self.env.step(action)
-        self.frames.append(ob)
-        return self._get_ob(), reward, done, info
-
-    def _get_ob(self):
-        assert len(self.frames) == self.k
-        return LazyFrames(list(self.frames))
-
-class ScaledFloatFrame(gym.ObservationWrapper):
-    def __init__(self, env):
-        gym.ObservationWrapper.__init__(self, env)
-        self.observation_space = gym.spaces.Box(low=0, high=1, shape=env.observation_space.shape, dtype=np.float32)
-
-    def observation(self, observation):
-        # careful! This undoes the memory optimization, use
-        # with smaller replay buffers only.
-        return np.array(observation).astype(np.float32) / 255.0
-
-class LazyFrames(object):
-    def __init__(self, frames):
-        """This object ensures that common frames between the observations are only stored once.
-        It exists purely to optimize memory usage which can be huge for DQN's 1M frames replay
-        buffers.
-        This object should only be converted to numpy array before being passed to the model.
-        You'd not believe how complex the previous solution was."""
-        self._frames = frames
-        self._out = None
-
-    def _force(self):
-        if self._out is None:
-            self._out = np.concatenate(self._frames, axis=-1)
-            self._frames = None
-        return self._out
-
-    def __array__(self, dtype=None):
-        out = self._force()
-        if dtype is not None:
-            out = out.astype(dtype)
-        return out
-
-    def __len__(self):
-        return len(self._force())
-
-    def __getitem__(self, i):
-        return self._force()[i]
-
-    def count(self):
-        frames = self._force()
-        return frames.shape[frames.ndim - 1]
-
-    def frame(self, i):
-        return self._force()[..., i]
-
-def wrap_atari(env, max_episode_steps=None):
-    assert 'NoFrameskip' in env.spec.id
-    env = NoopResetEnv(env, noop_max=30)
-    env = MaxAndSkipEnv(env, skip=4)
-
-    assert max_episode_steps is None
-
-    return env
-
-def wrap_deepmind(env, episode_life=True, clip_rewards=True, frame_stack=False, scale=False):
-    """Configure environment for DeepMind-style Atari.
-    """
-    if episode_life:
-        env = EpisodicLifeEnv(env)
-    if 'FIRE' in env.unwrapped.get_action_meanings():
-        env = FireResetEnv(env)
-    env = WarpFrame(env)
-    if scale:
-        env = ScaledFloatFrame(env)
-    if clip_rewards:
-        env = ClipRewardEnv(env)
-    if frame_stack:
-        env = FrameStack(env, 4)
-    return env
-
-
-class ImageToPyTorch(gym.ObservationWrapper):
-    """
-    Image shape to channels x weight x height
-    """
-
-    def __init__(self, env):
-        super(ImageToPyTorch, self).__init__(env)
-        old_shape = self.observation_space.shape
-        self.observation_space = gym.spaces.Box(
-            low=0,
-            high=255,
-            shape=(old_shape[-1], old_shape[0], old_shape[1]),
-            dtype=np.uint8,
-        )
-
-    def observation(self, observation):
-        return np.transpose(observation, axes=(2, 0, 1))
-
-def wrap_pytorch(env):
-    return ImageToPyTorch(env)
-
-# Reference: https://arxiv.org/pdf/1707.06887.pdf
-# https://github.com/ShangtongZhang/DeepRL/blob/master/deep_rl/agent/CategoricalDQN_agent.py
-
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.optim as optim
-import torch.nn.functional as F
 from torch.utils.tensorboard import SummaryWriter
-
-import argparse
-from distutils.util import strtobool
-import collections
-import numpy as np
-import gym
-from gym.wrappers import TimeLimit, Monitor
-from gym.spaces import Discrete, Box, MultiBinary, MultiDiscrete, Space
-import time
-import random
-import os
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='C51 agent')
-    # Common arguments
-    parser.add_argument('--exp-name', type=str, default=os.path.basename(__file__).rstrip(".py"),
-                        help='the name of this experiment')
-    parser.add_argument('--gym-id', type=str, default="BreakoutNoFrameskip-v4",
-                        help='the id of the gym environment')
-    parser.add_argument('--learning-rate', type=float, default=1e-4,
-                        help='the learning rate of the optimizer')
-    parser.add_argument('--seed', type=int, default=2,
-                        help='seed of the experiment')
-    parser.add_argument('--total-timesteps', type=int, default=10000000,
-                        help='total timesteps of the experiments')
-    parser.add_argument('--torch-deterministic', type=lambda x:bool(strtobool(x)), default=True, nargs='?', const=True,
-                        help='if toggled, `torch.backends.cudnn.deterministic=False`')
-    parser.add_argument('--cuda', type=lambda x:bool(strtobool(x)), default=True, nargs='?', const=True,
-                        help='if toggled, cuda will not be enabled by default')
-    parser.add_argument('--track', type=lambda x:bool(strtobool(x)), default=False, nargs='?', const=True,
-                        help='run the script in production mode and use wandb to log outputs')
-    parser.add_argument('--capture-video', type=lambda x:bool(strtobool(x)), default=False, nargs='?', const=True,
-                        help='weather to capture videos of the agent performances (check out `videos` folder)')
-    parser.add_argument('--wandb-project-name', type=str, default="cleanRL",
-                        help="the wandb's project name")
-    parser.add_argument('--wandb-entity', type=str, default=None,
-                        help="the entity (team) of wandb's project")
-    
-    # Algorithm specific arguments
-    parser.add_argument('--n-atoms', type=int, default=51,
-                        help="the number of atoms")
-    parser.add_argument('--v-min', type=float, default=-10,
-                        help="the number of atoms")
-    parser.add_argument('--v-max', type=float, default=10,
-                        help="the number of atoms")
-    parser.add_argument('--buffer-size', type=int, default=1000000,
-                         help='the replay memory buffer size')
-    parser.add_argument('--gamma', type=float, default=0.99,
-                        help='the discount factor gamma')
-    parser.add_argument('--target-network-frequency', type=int, default=1000,
-                        help="the timesteps it takes to update the target network")
-    parser.add_argument('--max-grad-norm', type=float, default=0.5,
-                        help='the maximum norm for the gradient clipping')
-    parser.add_argument('--batch-size', type=int, default=32,
-                        help="the batch size of sample from the reply memory")
-    parser.add_argument('--start-e', type=float, default=1.,
-                        help="the starting epsilon for exploration")
-    parser.add_argument('--end-e', type=float, default=0.01,
-                        help="the ending epsilon for exploration")
-    parser.add_argument('--exploration-fraction', type=float, default=0.10,
-                        help="the fraction of `total-timesteps` it takes from start-e to go end-e")
-    parser.add_argument('--learning-starts', type=int, default=80000,
-                        help="timestep to start learning")
-    parser.add_argument('--train-frequency', type=int, default=4,
-                        help="the frequency of training")
-    args = parser.parse_args()
-    if not args.seed:
-        args.seed = int(time.time())
-
-# TRY NOT TO MODIFY: setup the environment
-experiment_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
-writer = SummaryWriter(f"runs/{experiment_name}")
-writer.add_text('hyperparameters', "|param|value|\n|-|-|\n%s" % (
-        '\n'.join([f"|{key}|{value}|" for key, value in vars(args).items()])))
-if args.track:
-    import wandb
-    wandb.init(project=args.wandb_project_name, entity=args.wandb_entity, sync_tensorboard=True, config=vars(args), name=experiment_name, monitor_gym=True, save_code=True)
-    writer = SummaryWriter(f"/tmp/{experiment_name}")
-
-# TRY NOT TO MODIFY: seeding
-device = torch.device('cuda' if torch.cuda.is_available() and args.cuda else 'cpu')
-env = gym.make(args.gym_id)
-env = wrap_atari(env)
-env = gym.wrappers.RecordEpisodeStatistics(env) # records episode reward in `info['episode']['r']`
-if args.capture_video:
-    env = Monitor(env, f'videos/{experiment_name}')
-env = wrap_pytorch(
-    wrap_deepmind(
-        env,
-        clip_rewards=True,
-        frame_stack=True,
-        scale=False,
-    )
+from stable_baselines3.common.buffers import ReplayBuffer
+from stable_baselines3.common.atari_wrappers import (
+    ClipRewardEnv,
+    EpisodicLifeEnv,
+    FireResetEnv,
+    MaxAndSkipEnv,
+    NoopResetEnv,
 )
-random.seed(args.seed)
-np.random.seed(args.seed)
-torch.manual_seed(args.seed)
-torch.backends.cudnn.deterministic = args.torch_deterministic
-env.seed(args.seed)
-env.action_space.seed(args.seed)
-env.observation_space.seed(args.seed)
-# respect the default timelimit
-assert isinstance(env.action_space, Discrete), "only discrete action space is supported"
 
-# modified from https://github.com/seungeunrho/minimalRL/blob/master/dqn.py#
-class ReplayBuffer():
-    def __init__(self, buffer_limit):
-        self.buffer = collections.deque(maxlen=buffer_limit)
-    
-    def put(self, transition):
-        self.buffer.append(transition)
-    
-    def sample(self, n):
-        mini_batch = random.sample(self.buffer, n)
-        s_lst, a_lst, r_lst, s_prime_lst, done_mask_lst = [], [], [], [], []
-        
-        for transition in mini_batch:
-            s, a, r, s_prime, done_mask = transition
-            s_lst.append(s)
-            a_lst.append(a)
-            r_lst.append(r)
-            s_prime_lst.append(s_prime)
-            done_mask_lst.append(done_mask)
+def parse_args():
+    # fmt: off
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
+        help="the name of this experiment")
+    parser.add_argument("--gym-id", type=str, default="BreakoutNoFrameskip-v4",
+        help="the id of the gym environment")
+    parser.add_argument("--learning-rate", type=float, default=1e-4,
+        help="the learning rate of the optimizer")
+    parser.add_argument("--seed", type=int, default=1,
+        help="seed of the experiment")
+    parser.add_argument("--total-timesteps", type=int, default=10000000,
+        help="total timesteps of the experiments")
+    parser.add_argument("--torch-deterministic", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
+        help="if toggled, `torch.backends.cudnn.deterministic=False`")
+    parser.add_argument("--cuda", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
+        help="if toggled, cuda will be enabled by default")
+    parser.add_argument("--track", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="if toggled, this experiment will be tracked with Weights and Biases")
+    parser.add_argument("--wandb-project-name", type=str, default="cleanRL",
+        help="the wandb's project name")
+    parser.add_argument("--wandb-entity", type=str, default=None,
+        help="the entity (team) of wandb's project")
+    parser.add_argument("--capture-video", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="weather to capture videos of the agent performances (check out `videos` folder)")
 
-        return np.array(s_lst), np.array(a_lst), \
-               np.array(r_lst), np.array(s_prime_lst), \
-               np.array(done_mask_lst)
+    # Algorithm specific arguments
+    parser.add_argument("--n-atoms", type=int, default=51,
+        help="the number of atoms")
+    parser.add_argument("--v-min", type=float, default=-10,
+        help="the number of atoms")
+    parser.add_argument("--v-max", type=float, default=10,
+        help="the number of atoms")
+    parser.add_argument("--buffer-size", type=int, default=1000000,
+        help="the replay memory buffer size")
+    parser.add_argument("--gamma", type=float, default=0.99,
+        help="the discount factor gamma")
+    parser.add_argument("--target-network-frequency", type=int, default=1000,
+        help="the timesteps it takes to update the target network")
+    parser.add_argument("--max-grad-norm", type=float, default=0.5,
+        help="the maximum norm for the gradient clipping")
+    parser.add_argument("--batch-size", type=int, default=32,
+        help="the batch size of sample from the reply memory")
+    parser.add_argument("--start-e", type=float, default=1,
+        help="the starting epsilon for exploration")
+    parser.add_argument("--end-e", type=float, default=0.01,
+        help="the ending epsilon for exploration")
+    parser.add_argument("--exploration-fraction", type=float, default=0.1,
+        help="the fraction of `total-timesteps` it takes from start-e to go end-e")
+    parser.add_argument("--learning-starts", type=int, default=80000,
+        help="timestep to start learning")
+    parser.add_argument("--train-frequency", type=int, default=4,
+        help="the frequency of training")
+    args = parser.parse_args()
+    # fmt: on
+    return args
+
+
+def make_env(gym_id, seed, idx, capture_video, run_name):
+    def thunk():
+        env = gym.make(gym_id)
+        env = gym.wrappers.RecordEpisodeStatistics(env)
+        if capture_video:
+            if idx == 0:
+                env = gym.wrappers.RecordVideo(env, f"videos/{run_name}")
+        env = NoopResetEnv(env, noop_max=30)
+        env = MaxAndSkipEnv(env, skip=4)
+        env = EpisodicLifeEnv(env)
+        if "FIRE" in env.unwrapped.get_action_meanings():
+            env = FireResetEnv(env)
+        env = ClipRewardEnv(env)
+        env = gym.wrappers.ResizeObservation(env, (84, 84))
+        env = gym.wrappers.GrayScaleObservation(env)
+        env = gym.wrappers.FrameStack(env, 4)
+        env.seed(seed)
+        env.action_space.seed(seed)
+        env.observation_space.seed(seed)
+        return env
+
+    return thunk
+
 
 # ALGO LOGIC: initialize agent here:
-class Scale(nn.Module):
-    def __init__(self, scale):
-        super().__init__()
-        self.scale = scale
-
-    def forward(self, x):
-        return x * self.scale
 class QNetwork(nn.Module):
-    def __init__(self, env, device, frames=4, n_atoms=51, v_min=-10, v_max=10):
+    def __init__(self, env, n_atoms=101, v_min=-100, v_max=100):
         super(QNetwork, self).__init__()
+        self.env = env
         self.n_atoms = n_atoms
-        self.atoms = torch.linspace(v_min, v_max, steps=n_atoms).to(device)
+        self.atoms = torch.linspace(v_min, v_max, steps=n_atoms)
+        self.n = env.single_action_space.n
         self.network = nn.Sequential(
-            Scale(1/255),
-            nn.Conv2d(frames, 32, 8, stride=4),
+            nn.Conv2d(4, 32, 8, stride=4),
             nn.ReLU(),
             nn.Conv2d(32, 64, 4, stride=2),
             nn.ReLU(),
@@ -464,104 +119,140 @@ class QNetwork(nn.Module):
             nn.Flatten(),
             nn.Linear(3136, 512),
             nn.ReLU(),
-            nn.Linear(512, env.action_space.n * n_atoms)
+            nn.Linear(512, self.n * n_atoms)
         )
 
-    def forward(self, x, device):
-        x = torch.Tensor(x).to(device)
-        return self.network(x)
+    def forward(self, x):
+        return self.network(x / 255.)
 
-    def get_action(self, env, device, x,action=None):
-        logits = self.forward(x, device)
+    def get_action(self, x, action=None):
+        logits = self.forward(x)
         # probability mass function for each action
-        pmfs = torch.softmax(logits.view(len(x), env.action_space.n, self.n_atoms), dim=2)
+        pmfs = torch.softmax(logits.view(len(x), self.n, self.n_atoms), dim=2)
         q_values = (pmfs*self.atoms).sum(2)
         if action is None:
             action = torch.argmax(q_values, 1)
         return action, pmfs[torch.arange(len(x)), action]
 
+
 def linear_schedule(start_e: float, end_e: float, duration: int, t: int):
     slope =  (end_e - start_e) / duration
     return max(slope * t + start_e, end_e)
 
-rb = ReplayBuffer(args.buffer_size)
-q_network = QNetwork(env, device, n_atoms=args.n_atoms, v_min=args.v_min, v_max=args.v_max).to(device)
-target_network = QNetwork(env, device, n_atoms=args.n_atoms, v_min=args.v_min, v_max=args.v_max).to(device)
-target_network.load_state_dict(q_network.state_dict())
-optimizer = optim.Adam(q_network.parameters(), lr=args.learning_rate, eps=0.01/args.batch_size)
-loss_fn = nn.MSELoss()
-print(device.__repr__())
-print(q_network)
 
-# TRY NOT TO MODIFY: start the game
-obs = env.reset()
-episode_reward = 0
-for global_step in range(args.total_timesteps):
-    # ALGO LOGIC: put action logic here
-    epsilon = linear_schedule(args.start_e, args.end_e, args.exploration_fraction*args.total_timesteps, global_step)
-    if random.random() < epsilon:
-        action = env.action_space.sample()
-    else:
-        action, pmf = target_network.get_action(env, device, obs.reshape((1,)+obs.shape))
-        action = action.tolist()[0]
+if __name__ == "__main__":
+    args = parse_args()
+    run_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    if args.track:
+        import wandb
 
-    # TRY NOT TO MODIFY: execute the game and log data.
-    next_obs, reward, done, info = env.step(action)
-    episode_reward += reward
+        wandb.init(
+            project=args.wandb_project_name,
+            entity=args.wandb_entity,
+            sync_tensorboard=True,
+            config=vars(args),
+            name=run_name,
+            monitor_gym=True,
+            save_code=True,
+        )
+    writer = SummaryWriter(f"runs/{run_name}")
+    writer.add_text(
+        "hyperparameters",
+        "|param|value|\n|-|-|\n%s" % ("\n".join([f"|{key}|{value}|" for key, value in vars(args).items()])),
+    )
 
-    # TRY NOT TO MODIFY: record rewards for plotting purposes
-    if 'episode' in info.keys():
-        print(f"global_step={global_step}, episode_reward={info['episode']['r']}")
-        writer.add_scalar("charts/episodic_return", info['episode']['r'], global_step)
-        writer.add_scalar("charts/epsilon", epsilon, global_step)
+    # TRY NOT TO MODIFY: seeding
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.backends.cudnn.deterministic = args.torch_deterministic
 
-    # ALGO LOGIC: training.
-    rb.put((obs, action, reward, next_obs, done))
-    if global_step > args.learning_starts and global_step % args.train_frequency == 0:
-        s_obs, s_actions, s_rewards, s_next_obses, s_dones = rb.sample(args.batch_size)
-        with torch.no_grad():
-            _, next_pmfs = q_network.get_action(env, device, s_next_obses)
-            next_atoms = torch.Tensor(s_rewards).to(device).unsqueeze(-1) + args.gamma * q_network.atoms  * (1 - torch.Tensor(s_dones).to(device).unsqueeze(-1))
-            # projection
-            delta_z = q_network.atoms[1]-q_network.atoms[0]
-            tz = next_atoms.clamp(args.v_min, args.v_max)
+    device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
+
+    # env setup
+    envs = gym.vector.SyncVectorEnv(
+        [make_env(args.gym_id, 0, 0, args.capture_video, run_name)]
+    )
+    assert isinstance(envs.single_action_space, gym.spaces.Discrete), "only discrete action space is supported"
+
+    q_network = QNetwork(envs, n_atoms=args.n_atoms, v_min=args.v_min, v_max=args.v_max).to(device)
+    optimizer = optim.Adam(q_network.parameters(), lr=args.learning_rate)
+    target_network = QNetwork(envs, n_atoms=args.n_atoms, v_min=args.v_min, v_max=args.v_max).to(device)
+    target_network.load_state_dict(q_network.state_dict())
+
+    rb = ReplayBuffer(args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device, optimize_memory_usage=True)
+    loss_fn = nn.MSELoss()
+
+    # TRY NOT TO MODIFY: start the game
+    obs = envs.reset()
+    for global_step in range(args.total_timesteps):
+        # ALGO LOGIC: put action logic here
+        epsilon = linear_schedule(args.start_e, args.end_e, args.exploration_fraction*args.total_timesteps, global_step)
+        if random.random() < epsilon:
+            actions = envs.action_space.sample()
+        else:
+            actions, pmf = q_network.get_action(torch.Tensor(obs).to(device))
+            actions = actions.cpu().numpy()
+
+        # TRY NOT TO MODIFY: execute the game and log data.
+        next_obs, rewards, dones, infos = envs.step(actions)
+
+        # TRY NOT TO MODIFY: record rewards for plotting purposes
+        for info in infos:
+            if "episode" in info.keys():
+                print(f"global_step={global_step}, episode_reward={info['episode']['r']}")
+                writer.add_scalar("charts/episodic_return", info["episode"]["r"], global_step)
+                writer.add_scalar("charts/epsilon", epsilon, global_step)
+                break
+
+        # TRY NOT TO MODIFY: save data to reply buffer; handle `terminal_observation`
+        real_next_obs = next_obs.copy()
+        for idx, d in enumerate(dones):
+            if d:
+                real_next_obs[idx] = infos[idx]["terminal_observation"]
+        rb.add(obs, real_next_obs, actions, rewards, dones, infos)
+
+        # TRY NOT TO MODIFY: CRUCIAL step easy to overlook
+        obs = next_obs
+
+        # ALGO LOGIC: training.
+        if global_step > args.learning_starts and global_step % args.train_frequency == 0:
+            data = rb.sample(args.batch_size)
+
+            with torch.no_grad():
+                _, next_pmfs = target_network.get_action(data.next_observations)
+                next_atoms = data.rewards + args.gamma * target_network.atoms * (1 - data.dones)
+                # projection
+                delta_z = target_network.atoms[1] - target_network.atoms[0]
+                tz = next_atoms.clamp(args.v_min, args.v_max)
+                
+                b = (tz - args.v_min)/ delta_z
+                l = b.floor().clamp(0, args.n_atoms-1)
+                u = b.ceil().clamp(0, args.n_atoms-1)
+                # (l == u).float() handles the case where bj is exactly an integer
+                # example bj = 1, then the upper ceiling should be uj= 2, and lj= 1
+                d_m_l = (u + (l == u).float() - b) * next_pmfs
+                d_m_u = (b - l) * next_pmfs
+                target_pmfs = torch.zeros_like(next_pmfs)
+                for i in range(target_pmfs.size(0)):
+                    target_pmfs[i].index_add_(0, l[i].long(), d_m_l[i])
+                    target_pmfs[i].index_add_(0, u[i].long(), d_m_u[i])
             
-            b = (tz - args.v_min)/ delta_z
-            l = b.floor().clamp(0, args.n_atoms-1)
-            u = b.ceil().clamp(0, args.n_atoms-1)
-            # (l == u).float() handles the case where bj is exactly an integer
-            # example bj = 1, then the upper ceiling should be uj= 2, and lj= 1
-            d_m_l = (u + (l == u).float() - b) * next_pmfs
-            d_m_u = (b - l) * next_pmfs
-            target_pmfs = torch.zeros_like(next_pmfs)
-            for i in range(target_pmfs.size(0)):
-                target_pmfs[i].index_add_(0, l[i].long(), d_m_l[i])
-                target_pmfs[i].index_add_(0, u[i].long(), d_m_u[i])
-        
-        _, old_pmfs = q_network.get_action(env, device, s_obs, s_actions)
-        loss = (-(target_pmfs * old_pmfs.clamp(min=1e-5).log()).sum(-1)).mean()
-        # loss = (target_pmfs * (target_pmfs.clamp(min=1e-5).log() - old_pmfs.clamp(min=1e-5).log())).sum(-1).mean()
-        
-        if global_step % 100 == 0:
-            writer.add_scalar("losses/td_loss", loss, global_step)
+            _, old_pmfs = q_network.get_action(data.observations, data.actions.flatten())
+            loss = (-(target_pmfs.detach() * old_pmfs.log()).sum(-1)).mean()
 
-        # optimize the midel
-        optimizer.zero_grad()
-        loss.backward()
-        nn.utils.clip_grad_norm_(list(q_network.parameters()), args.max_grad_norm)
-        optimizer.step()
+            if global_step % 100 == 0:
+                writer.add_scalar("losses/td_loss", loss, global_step)
 
-        # update the target network
-        if global_step % args.target_network_frequency == 0:
-            target_network.load_state_dict(q_network.state_dict())
+            # optimize the midel
+            optimizer.zero_grad()
+            loss.backward()
+            nn.utils.clip_grad_norm_(list(q_network.parameters()), args.max_grad_norm)
+            optimizer.step()
 
-    # TRY NOT TO MODIFY: CRUCIAL step easy to overlook
-    obs = next_obs
-    if done:
-        # important to note that because `EpisodicLifeEnv` wrapper is applied,
-        # the real episode reward is actually the sum of episode reward of 5 lives
-        # which we record through `info['episode']['r']` provided by gym.wrappers.RecordEpisodeStatistics
-        obs, episode_reward = env.reset(), 0
-
-env.close()
-writer.close()
+            # update the target network
+            if global_step % args.target_network_frequency == 0:
+                target_network.load_state_dict(q_network.state_dict())
+            # raise
+    envs.close()
+    writer.close()

--- a/cleanrl/ddpg_continuous_action.py
+++ b/cleanrl/ddpg_continuous_action.py
@@ -6,7 +6,7 @@ from distutils.util import strtobool
 
 import gym
 import numpy as np
-# import pybullet_envs  # noqa
+import pybullet_envs  # noqa
 import torch
 import torch.nn as nn
 import torch.optim as optim

--- a/cleanrl/ddpg_continuous_action.py
+++ b/cleanrl/ddpg_continuous_action.py
@@ -1,144 +1,94 @@
-# Reference: https://arxiv.org/pdf/1509.02971.pdf
-# https://github.com/seungeunrho/minimalRL/blob/master/ddpg.py
-# https://github.com/openai/spinningup/blob/master/spinup/algos/pytorch/ddpg/ddpg.py
+import argparse
+import os
+import random
+import time
+from distutils.util import strtobool
 
+import gym
+import numpy as np
+# import pybullet_envs  # noqa
 import torch
 import torch.nn as nn
 import torch.optim as optim
 import torch.nn.functional as F
 from torch.utils.tensorboard import SummaryWriter
+from stable_baselines3.common.buffers import ReplayBuffer
 
-import argparse
-from distutils.util import strtobool
-import collections
-import numpy as np
-import gym
-import pybullet_envs
-from gym.wrappers import TimeLimit, Monitor
-from gym.spaces import Discrete, Box, MultiBinary, MultiDiscrete, Space
-import time
-import random
-import os
+def parse_args():
+    # fmt: off
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
+        help="the name of this experiment")
+    parser.add_argument("--gym-id", type=str, default="Pendulum-v1",
+        help="the id of the gym environment")
+    parser.add_argument("--learning-rate", type=float, default=3e-4,
+        help="the learning rate of the optimizer")
+    parser.add_argument("--seed", type=int, default=1,
+        help="seed of the experiment")
+    parser.add_argument("--total-timesteps", type=int, default=1000000,
+        help="total timesteps of the experiments")
+    parser.add_argument("--torch-deterministic", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
+        help="if toggled, `torch.backends.cudnn.deterministic=False`")
+    parser.add_argument("--cuda", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
+        help="if toggled, cuda will be enabled by default")
+    parser.add_argument("--track", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="if toggled, this experiment will be tracked with Weights and Biases")
+    parser.add_argument("--wandb-project-name", type=str, default="cleanRL",
+        help="the wandb's project name")
+    parser.add_argument("--wandb-entity", type=str, default=None,
+        help="the entity (team) of wandb's project")
+    parser.add_argument("--capture-video", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="weather to capture videos of the agent performances (check out `videos` folder)")
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='DDPG agent')
-    # Common arguments
-    parser.add_argument('--exp-name', type=str, default=os.path.basename(__file__).rstrip(".py"),
-                        help='the name of this experiment')
-    parser.add_argument('--gym-id', type=str, default="HopperBulletEnv-v0",
-                        help='the id of the gym environment')
-    parser.add_argument('--learning-rate', type=float, default=3e-4,
-                        help='the learning rate of the optimizer')
-    parser.add_argument('--seed', type=int, default=1,
-                        help='seed of the experiment')
-    parser.add_argument('--episode-length', type=int, default=0,
-                        help='the maximum length of each episode')
-    parser.add_argument('--total-timesteps', type=int, default=1000000,
-                        help='total timesteps of the experiments')
-    parser.add_argument('--torch-deterministic', type=lambda x:bool(strtobool(x)), default=True, nargs='?', const=True,
-                        help='if toggled, `torch.backends.cudnn.deterministic=False`')
-    parser.add_argument('--cuda', type=lambda x:bool(strtobool(x)), default=True, nargs='?', const=True,
-                        help='if toggled, cuda will not be enabled by default')
-    parser.add_argument('--track', type=lambda x:bool(strtobool(x)), default=False, nargs='?', const=True,
-                        help='run the script in production mode and use wandb to log outputs')
-    parser.add_argument('--capture-video', type=lambda x:bool(strtobool(x)), default=False, nargs='?', const=True,
-                        help='weather to capture videos of the agent performances (check out `videos` folder)')
-    parser.add_argument('--wandb-project-name', type=str, default="cleanRL",
-                        help="the wandb's project name")
-    parser.add_argument('--wandb-entity', type=str, default=None,
-                        help="the entity (team) of wandb's project")
-    
     # Algorithm specific arguments
-    parser.add_argument('--buffer-size', type=int, default=int(1e6),
-                         help='the replay memory buffer size')
-    parser.add_argument('--gamma', type=float, default=0.99,
-                        help='the discount factor gamma')
-    parser.add_argument('--tau', type=float, default=0.005,
-                        help="target smoothing coefficient (default: 0.005)")
-    parser.add_argument('--max-grad-norm', type=float, default=0.5,
-                        help='the maximum norm for the gradient clipping')
-    parser.add_argument('--batch-size', type=int, default=256,
-                        help="the batch size of sample from the reply memory")
-    parser.add_argument('--exploration-noise', type=float, default=0.1,
-                        help='the scale of exploration noise')
-    parser.add_argument('--learning-starts', type=int, default=25e3,
-                        help="timestep to start learning")
-    parser.add_argument('--policy-frequency', type=int, default=2,
-                        help="the frequency of training policy (delayed)")
-    parser.add_argument('--noise-clip', type=float, default=0.5,
-                         help='noise clip parameter of the Target Policy Smoothing Regularization')
+    parser.add_argument("--buffer-size", type=int, default=int(1e6),
+        help="the replay memory buffer size")
+    parser.add_argument("--gamma", type=float, default=0.99,
+        help="the discount factor gamma")
+    parser.add_argument("--tau", type=float, default=0.005,
+        help="target smoothing coefficient (default: 0.005)")
+    parser.add_argument("--max-grad-norm", type=float, default=0.5,
+        help="the maximum norm for the gradient clipping")
+    parser.add_argument("--batch-size", type=int, default=256,
+        help="the batch size of sample from the reply memory")
+    parser.add_argument("--exploration-noise", type=float, default=0.1,
+        help="the scale of exploration noise")
+    parser.add_argument("--learning-starts", type=int, default=25e3,
+        help="timestep to start learning")
+    parser.add_argument("--policy-frequency", type=int, default=2,
+        help="the frequency of training policy (delayed)")
+    parser.add_argument("--noise-clip", type=float, default=0.5,
+        help="noise clip parameter of the Target Policy Smoothing Regularization")
     args = parser.parse_args()
-    if not args.seed:
-        args.seed = int(time.time())
-
-# TRY NOT TO MODIFY: setup the environment
-experiment_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
-writer = SummaryWriter(f"runs/{experiment_name}")
-writer.add_text('hyperparameters', "|param|value|\n|-|-|\n%s" % (
-        '\n'.join([f"|{key}|{value}|" for key, value in vars(args).items()])))
-if args.track:
-    import wandb
-    wandb.init(project=args.wandb_project_name, entity=args.wandb_entity, sync_tensorboard=True, config=vars(args), name=experiment_name, monitor_gym=True, save_code=True)
-    writer = SummaryWriter(f"/tmp/{experiment_name}")
+    # fmt: on
+    return args
 
 
-# TRY NOT TO MODIFY: seeding
-device = torch.device('cuda' if torch.cuda.is_available() and args.cuda else 'cpu')
-env = gym.make(args.gym_id)
-random.seed(args.seed)
-np.random.seed(args.seed)
-torch.manual_seed(args.seed)
-torch.backends.cudnn.deterministic = args.torch_deterministic
-env.seed(args.seed)
-env.action_space.seed(args.seed)
-env.observation_space.seed(args.seed)
-# respect the default timelimit
-assert isinstance(env.action_space, Box), "only continuous action space is supported"
-assert isinstance(env, TimeLimit) or int(args.episode_length), "the gym env does not have a built in TimeLimit, please specify by using --episode-length"
-if isinstance(env, TimeLimit):
-    if int(args.episode_length):
-        env._max_episode_steps = int(args.episode_length)
-    args.episode_length = env._max_episode_steps
-else:
-    env = TimeLimit(env, int(args.episode_length))
-if args.capture_video:
-    env = Monitor(env, f'videos/{experiment_name}')
+def make_env(gym_id, seed, idx, capture_video, run_name):
+    def thunk():
+        env = gym.make(gym_id)
+        env = gym.wrappers.RecordEpisodeStatistics(env)
+        if capture_video:
+            if idx == 0:
+                env = gym.wrappers.RecordVideo(env, f"videos/{run_name}")
+        env.seed(seed)
+        env.action_space.seed(seed)
+        env.observation_space.seed(seed)
+        return env
 
-# modified from https://github.com/seungeunrho/minimalRL/blob/master/dqn.py#
-class ReplayBuffer():
-    def __init__(self, buffer_limit):
-        self.buffer = collections.deque(maxlen=buffer_limit)
-    
-    def put(self, transition):
-        self.buffer.append(transition)
-    
-    def sample(self, n):
-        mini_batch = random.sample(self.buffer, n)
-        s_lst, a_lst, r_lst, s_prime_lst, done_mask_lst = [], [], [], [], []
-        
-        for transition in mini_batch:
-            s, a, r, s_prime, done_mask = transition
-            s_lst.append(s)
-            a_lst.append(a)
-            r_lst.append(r)
-            s_prime_lst.append(s_prime)
-            done_mask_lst.append(done_mask)
+    return thunk
 
-        return np.array(s_lst), np.array(a_lst), \
-               np.array(r_lst), np.array(s_prime_lst), \
-               np.array(done_mask_lst)
 
 # ALGO LOGIC: initialize agent here:
 class QNetwork(nn.Module):
     def __init__(self, env):
         super(QNetwork, self).__init__()
         self.fc1 = nn.Linear(
-            np.array(env.observation_space.shape).prod()+np.prod(env.action_space.shape), 256)
+            np.array(env.single_observation_space.shape).prod()+np.prod(env.single_action_space.shape), 256)
         self.fc2 = nn.Linear(256, 256)
         self.fc3 = nn.Linear(256, 1)
 
-    def forward(self, x, a, device):
-        x = torch.Tensor(x).to(device)
+    def forward(self, x, a):
         x = torch.cat([x, a], 1)
         x = F.relu(self.fc1(x))
         x = F.relu(self.fc2(x))
@@ -148,95 +98,132 @@ class QNetwork(nn.Module):
 class Actor(nn.Module):
     def __init__(self, env):
         super(Actor, self).__init__()
-        self.fc1 = nn.Linear(np.array(env.observation_space.shape).prod(), 256)
+        self.fc1 = nn.Linear(np.array(env.single_observation_space.shape).prod(), 256)
         self.fc2 = nn.Linear(256, 256)
-        self.fc_mu = nn.Linear(256, np.prod(env.action_space.shape))
+        self.fc_mu = nn.Linear(256, np.prod(env.single_action_space.shape))
 
-    def forward(self, x, device):
-        x = torch.Tensor(x).to(device)
+    def forward(self, x):
         x = F.relu(self.fc1(x))
         x = F.relu(self.fc2(x))
         return torch.tanh(self.fc_mu(x))
 
-def linear_schedule(start_sigma: float, end_sigma: float, duration: int, t: int):
-    slope =  (end_sigma - start_sigma) / duration
-    return max(slope * t + start_sigma, end_sigma)
 
-max_action = float(env.action_space.high[0])
-rb = ReplayBuffer(args.buffer_size)
-actor = Actor(env).to(device)
-qf1 = QNetwork(env).to(device)
-qf1_target = QNetwork(env).to(device)
-target_actor = Actor(env).to(device)
-target_actor.load_state_dict(actor.state_dict())
-qf1_target.load_state_dict(qf1.state_dict())
-q_optimizer = optim.Adam(list(qf1.parameters()), lr=args.learning_rate)
-actor_optimizer = optim.Adam(list(actor.parameters()), lr=args.learning_rate)
-loss_fn = nn.MSELoss()
-# TRY NOT TO MODIFY: start the game
-obs = env.reset()
-episode_reward = 0
+if __name__ == "__main__":
+    args = parse_args()
+    run_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    if args.track:
+        import wandb
 
-for global_step in range(args.total_timesteps):
-    # ALGO LOGIC: put action logic here
-    if global_step < args.learning_starts:
-        action = env.action_space.sample()
-    else:
-        action = actor.forward(obs.reshape((1,)+obs.shape), device)
-        action = (
-            action.tolist()[0]
-            + np.random.normal(0, max_action * args.exploration_noise, size=env.action_space.shape[0])
-        ).clip(env.action_space.low, env.action_space.high)
+        wandb.init(
+            project=args.wandb_project_name,
+            entity=args.wandb_entity,
+            sync_tensorboard=True,
+            config=vars(args),
+            name=run_name,
+            monitor_gym=True,
+            save_code=True,
+        )
+    writer = SummaryWriter(f"runs/{run_name}")
+    writer.add_text(
+        "hyperparameters",
+        "|param|value|\n|-|-|\n%s" % ("\n".join([f"|{key}|{value}|" for key, value in vars(args).items()])),
+    )
 
-    # TRY NOT TO MODIFY: execute the game and log data.
-    next_obs, reward, done, info = env.step(action)
-    episode_reward += reward
-    
-    # ALGO LOGIC: training.
-    rb.put((obs, action, reward, next_obs, done))
-    if global_step > args.learning_starts:
-        s_obs, s_actions, s_rewards, s_next_obses, s_dones = rb.sample(args.batch_size)
-        with torch.no_grad():
-            next_state_actions = (
-                target_actor.forward(s_next_obses, device)
-            ).clamp(env.action_space.low[0], env.action_space.high[0])
-            qf1_next_target = qf1_target.forward(s_next_obses, next_state_actions, device)
-            next_q_value = torch.Tensor(s_rewards).to(device) + (1 - torch.Tensor(s_dones).to(device)) * args.gamma * (qf1_next_target).view(-1)
+    # TRY NOT TO MODIFY: seeding
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.backends.cudnn.deterministic = args.torch_deterministic
 
-        qf1_a_values = qf1.forward(s_obs, torch.Tensor(s_actions).to(device), device).view(-1)
-        qf1_loss = loss_fn(qf1_a_values, next_q_value)
+    device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
 
-        # optimize the midel
-        q_optimizer.zero_grad()
-        qf1_loss.backward()
-        nn.utils.clip_grad_norm_(list(qf1.parameters()), args.max_grad_norm)
-        q_optimizer.step()
+    # env setup
+    envs = gym.vector.SyncVectorEnv(
+        [make_env(args.gym_id, 0, 0, args.capture_video, run_name)]
+    )
+    assert isinstance(envs.single_action_space, gym.spaces.Box), "only continuous action space is supported"
 
-        if global_step % args.policy_frequency == 0:
-            actor_loss = -qf1.forward(s_obs, actor.forward(s_obs, device), device).mean()
-            actor_optimizer.zero_grad()
-            actor_loss.backward()
-            nn.utils.clip_grad_norm_(list(actor.parameters()), args.max_grad_norm)
-            actor_optimizer.step()
+    max_action = float(envs.single_action_space.high[0])
+    actor = Actor(envs).to(device)
+    qf1 = QNetwork(envs).to(device)
+    qf1_target = QNetwork(envs).to(device)
+    target_actor = Actor(envs).to(device)
+    target_actor.load_state_dict(actor.state_dict())
+    qf1_target.load_state_dict(qf1.state_dict())
+    q_optimizer = optim.Adam(list(qf1.parameters()), lr=args.learning_rate)
+    actor_optimizer = optim.Adam(list(actor.parameters()), lr=args.learning_rate)
 
-            # update the target network
-            for param, target_param in zip(actor.parameters(), target_actor.parameters()):
-                target_param.data.copy_(args.tau * param.data + (1 - args.tau) * target_param.data)
-            for param, target_param in zip(qf1.parameters(), qf1_target.parameters()):
-                target_param.data.copy_(args.tau * param.data + (1 - args.tau) * target_param.data)
+    rb = ReplayBuffer(args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device, optimize_memory_usage=True)
+    loss_fn = nn.MSELoss()
 
-        if global_step % 100 == 0:
-            writer.add_scalar("losses/qf1_loss", qf1_loss.item(), global_step)
-            writer.add_scalar("losses/actor_loss", actor_loss.item(), global_step)
+    # TRY NOT TO MODIFY: start the game
+    obs = envs.reset()
+    for global_step in range(args.total_timesteps):
+        # ALGO LOGIC: put action logic here
+        if global_step < args.learning_starts:
+            actions = envs.action_space.sample()
+        else:
+            actions = actor.forward(torch.Tensor(obs).to(device))
+            actions = np.array([(
+                actions.tolist()[0]
+                + np.random.normal(0, max_action * args.exploration_noise, size=envs.action_space.shape[0])
+            ).clip(envs.single_action_space.low, envs.single_action_space.high)])
 
-    # TRY NOT TO MODIFY: CRUCIAL step easy to overlook 
-    obs = next_obs
+        # TRY NOT TO MODIFY: execute the game and log data.
+        next_obs, rewards, dones, infos = envs.step(actions)
 
-    if done:
         # TRY NOT TO MODIFY: record rewards for plotting purposes
-        print(f"global_step={global_step}, episode_reward={episode_reward}")
-        writer.add_scalar("charts/episodic_return", episode_reward, global_step)
-        obs, episode_reward = env.reset(), 0
+        for info in infos:
+            if "episode" in info.keys():
+                print(f"global_step={global_step}, episode_reward={info['episode']['r']}")
+                writer.add_scalar("charts/episodic_return", info["episode"]["r"], global_step)
+                break
 
-env.close()
-writer.close()
+        # TRY NOT TO MODIFY: save data to reply buffer; handle `terminal_observation`
+        real_next_obs = next_obs.copy()
+        for idx, d in enumerate(dones):
+            if d:
+                real_next_obs[idx] = infos[idx]["terminal_observation"]
+        rb.add(obs, real_next_obs, actions, rewards, dones, infos)
+
+        # TRY NOT TO MODIFY: CRUCIAL step easy to overlook
+        obs = next_obs
+
+        # ALGO LOGIC: training.
+        if global_step > args.learning_starts:
+            data = rb.sample(args.batch_size)
+            with torch.no_grad():
+                next_state_actions = (
+                    target_actor.forward(data.next_observations)
+                ).clamp(envs.single_action_space.low[0], envs.single_action_space.high[0])
+                qf1_next_target = qf1_target.forward(data.next_observations, next_state_actions)
+                next_q_value = data.rewards.flatten() + (1 - data.dones.flatten()) * args.gamma * (qf1_next_target).view(-1)
+
+            qf1_a_values = qf1.forward(data.observations, data.actions).view(-1)
+            qf1_loss = loss_fn(qf1_a_values, next_q_value)
+
+            # optimize the midel
+            q_optimizer.zero_grad()
+            qf1_loss.backward()
+            nn.utils.clip_grad_norm_(list(qf1.parameters()), args.max_grad_norm)
+            q_optimizer.step()
+
+            if global_step % args.policy_frequency == 0:
+                actor_loss = -qf1.forward(data.observations, actor.forward(data.observations)).mean()
+                actor_optimizer.zero_grad()
+                actor_loss.backward()
+                nn.utils.clip_grad_norm_(list(actor.parameters()), args.max_grad_norm)
+                actor_optimizer.step()
+
+                # update the target network
+                for param, target_param in zip(actor.parameters(), target_actor.parameters()):
+                    target_param.data.copy_(args.tau * param.data + (1 - args.tau) * target_param.data)
+                for param, target_param in zip(qf1.parameters(), qf1_target.parameters()):
+                    target_param.data.copy_(args.tau * param.data + (1 - args.tau) * target_param.data)
+
+            if global_step % 100 == 0:
+                writer.add_scalar("losses/qf1_loss", qf1_loss.item(), global_step)
+                writer.add_scalar("losses/actor_loss", actor_loss.item(), global_step)
+
+    envs.close()
+    writer.close()

--- a/cleanrl/ddpg_continuous_action.py
+++ b/cleanrl/ddpg_continuous_action.py
@@ -19,7 +19,7 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
         help="the name of this experiment")
-    parser.add_argument("--gym-id", type=str, default="Pendulum-v1",
+    parser.add_argument("--gym-id", type=str, default="HopperBulletEnv-v0",
         help="the id of the gym environment")
     parser.add_argument("--learning-rate", type=float, default=3e-4,
         help="the learning rate of the optimizer")

--- a/cleanrl/ddpg_continuous_action.py
+++ b/cleanrl/ddpg_continuous_action.py
@@ -202,7 +202,7 @@ if __name__ == "__main__":
             qf1_a_values = qf1.forward(data.observations, data.actions).view(-1)
             qf1_loss = loss_fn(qf1_a_values, next_q_value)
 
-            # optimize the midel
+            # optimize the model
             q_optimizer.zero_grad()
             qf1_loss.backward()
             nn.utils.clip_grad_norm_(list(qf1.parameters()), args.max_grad_norm)

--- a/cleanrl/dqn.py
+++ b/cleanrl/dqn.py
@@ -187,7 +187,7 @@ if __name__ == "__main__":
             if global_step % 100 == 0:
                 writer.add_scalar("losses/td_loss", loss, global_step)
 
-            # optimize the midel
+            # optimize the model
             optimizer.zero_grad()
             loss.backward()
             nn.utils.clip_grad_norm_(list(q_network.parameters()), args.max_grad_norm)

--- a/cleanrl/dqn.py
+++ b/cleanrl/dqn.py
@@ -1,222 +1,201 @@
-# Reference: https://www.cs.toronto.edu/~vmnih/docs/dqn.pdf
+import argparse
+import os
+import random
+import time
+from distutils.util import strtobool
 
+import gym
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.optim as optim
-import torch.nn.functional as F
 from torch.utils.tensorboard import SummaryWriter
+from stable_baselines3.common.buffers import ReplayBuffer
 
-import argparse
-from distutils.util import strtobool
-import collections
-import numpy as np
-import gym
-from gym.wrappers import TimeLimit, Monitor
-from gym.spaces import Discrete, Box, MultiBinary, MultiDiscrete, Space
-import time
-import random
-import os
+def parse_args():
+    # fmt: off
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
+        help="the name of this experiment")
+    parser.add_argument("--gym-id", type=str, default="CartPole-v1",
+        help="the id of the gym environment")
+    parser.add_argument("--learning-rate", type=float, default=2.5e-4,
+        help="the learning rate of the optimizer")
+    parser.add_argument("--seed", type=int, default=1,
+        help="seed of the experiment")
+    parser.add_argument("--total-timesteps", type=int, default=25000,
+        help="total timesteps of the experiments")
+    parser.add_argument("--torch-deterministic", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
+        help="if toggled, `torch.backends.cudnn.deterministic=False`")
+    parser.add_argument("--cuda", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
+        help="if toggled, cuda will be enabled by default")
+    parser.add_argument("--track", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="if toggled, this experiment will be tracked with Weights and Biases")
+    parser.add_argument("--wandb-project-name", type=str, default="cleanRL",
+        help="the wandb's project name")
+    parser.add_argument("--wandb-entity", type=str, default=None,
+        help="the entity (team) of wandb's project")
+    parser.add_argument("--capture-video", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="weather to capture videos of the agent performances (check out `videos` folder)")
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='DQN agent')
-    # Common arguments
-    parser.add_argument('--exp-name', type=str, default=os.path.basename(__file__).rstrip(".py"),
-                        help='the name of this experiment')
-    parser.add_argument('--gym-id', type=str, default="CartPole-v0",
-                        help='the id of the gym environment')
-    parser.add_argument('--learning-rate', type=float, default=7e-4,
-                        help='the learning rate of the optimizer')
-    parser.add_argument('--seed', type=int, default=1,
-                        help='seed of the experiment')
-    parser.add_argument('--total-timesteps', type=int, default=20000,
-                        help='total timesteps of the experiments')
-    parser.add_argument('--torch-deterministic', type=lambda x:bool(strtobool(x)), default=True, nargs='?', const=True,
-                        help='if toggled, `torch.backends.cudnn.deterministic=False`')
-    parser.add_argument('--cuda', type=lambda x:bool(strtobool(x)), default=True, nargs='?', const=True,
-                        help='if toggled, cuda will not be enabled by default')
-    parser.add_argument('--track', type=lambda x:bool(strtobool(x)), default=False, nargs='?', const=True,
-                        help='run the script in production mode and use wandb to log outputs')
-    parser.add_argument('--capture-video', type=lambda x:bool(strtobool(x)), default=False, nargs='?', const=True,
-                        help='weather to capture videos of the agent performances (check out `videos` folder)')
-    parser.add_argument('--wandb-project-name', type=str, default="cleanRL",
-                        help="the wandb's project name")
-    parser.add_argument('--wandb-entity', type=str, default=None,
-                        help="the entity (team) of wandb's project")
-    
     # Algorithm specific arguments
-    parser.add_argument('--buffer-size', type=int, default=10000,
-                         help='the replay memory buffer size')
-    parser.add_argument('--gamma', type=float, default=0.99,
-                        help='the discount factor gamma')
-    parser.add_argument('--target-network-frequency', type=int, default=500,
-                        help="the timesteps it takes to update the target network")
-    parser.add_argument('--max-grad-norm', type=float, default=0.5,
-                        help='the maximum norm for the gradient clipping')
-    parser.add_argument('--batch-size', type=int, default=32,
-                        help="the batch size of sample from the reply memory")
-    parser.add_argument('--start-e', type=float, default=1,
-                        help="the starting epsilon for exploration")
-    parser.add_argument('--end-e', type=float, default=0.05,
-                        help="the ending epsilon for exploration")
-    parser.add_argument('--exploration-fraction', type=float, default=0.8,
-                        help="the fraction of `total-timesteps` it takes from start-e to go end-e")
-    parser.add_argument('--learning-starts', type=int, default=10000,
-                        help="timestep to start learning")
-    parser.add_argument('--train-frequency', type=int, default=1,
-                        help="the frequency of training")
+    parser.add_argument("--buffer-size", type=int, default=10000,
+        help="the replay memory buffer size")
+    parser.add_argument("--gamma", type=float, default=0.99,
+        help="the discount factor gamma")
+    parser.add_argument("--target-network-frequency", type=int, default=500,
+        help="the timesteps it takes to update the target network")
+    parser.add_argument("--max-grad-norm", type=float, default=0.5,
+        help="the maximum norm for the gradient clipping")
+    parser.add_argument("--batch-size", type=int, default=32,
+        help="the batch size of sample from the reply memory")
+    parser.add_argument("--start-e", type=float, default=1,
+        help="the starting epsilon for exploration")
+    parser.add_argument("--end-e", type=float, default=0.05,
+        help="the ending epsilon for exploration")
+    parser.add_argument("--exploration-fraction", type=float, default=0.8,
+        help="the fraction of `total-timesteps` it takes from start-e to go end-e")
+    parser.add_argument("--learning-starts", type=int, default=10000,
+        help="timestep to start learning")
+    parser.add_argument("--train-frequency", type=int, default=1,
+        help="the frequency of training")
     args = parser.parse_args()
-    if not args.seed:
-        args.seed = int(time.time())
-
-def one_hot(a, size):
-    b = np.zeros((size))
-    b[a] = 1
-    return b
-
-class ProcessObsInputEnv(gym.ObservationWrapper):
-    """
-    This wrapper handles inputs from `Discrete` and `Box` observation space.
-    If the `env.observation_space` is of `Discrete` type, 
-    it returns the one-hot encoding of the state
-    """
-    def __init__(self, env):
-        super().__init__(env)
-        self.n = None
-        if isinstance(self.env.observation_space, Discrete):
-            self.n = self.env.observation_space.n
-            self.observation_space = Box(0, 1, (self.n,))
-
-    def observation(self, obs):
-        if self.n:
-            return one_hot(np.array(obs), self.n)
-        return obs
-
-# TRY NOT TO MODIFY: setup the environment
-experiment_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
-writer = SummaryWriter(f"runs/{experiment_name}")
-writer.add_text('hyperparameters', "|param|value|\n|-|-|\n%s" % (
-        '\n'.join([f"|{key}|{value}|" for key, value in vars(args).items()])))
-if args.track:
-    import wandb
-    wandb.init(project=args.wandb_project_name, entity=args.wandb_entity, sync_tensorboard=True, config=vars(args), name=experiment_name, monitor_gym=True, save_code=True)
-    writer = SummaryWriter(f"/tmp/{experiment_name}")
+    # fmt: on
+    return args
 
 
-# TRY NOT TO MODIFY: seeding
-device = torch.device('cuda' if torch.cuda.is_available() and args.cuda else 'cpu')
-env = ProcessObsInputEnv(gym.make(args.gym_id))
-random.seed(args.seed)
-np.random.seed(args.seed)
-torch.manual_seed(args.seed)
-torch.backends.cudnn.deterministic = args.torch_deterministic
-env.seed(args.seed)
-env.action_space.seed(args.seed)
-env.observation_space.seed(args.seed)
-# respect the default timelimit
-assert isinstance(env.action_space, Discrete), "only discrete action space is supported"
-if args.capture_video:
-    env = Monitor(env, f'videos/{experiment_name}')
+def make_env(gym_id, seed, idx, capture_video, run_name):
+    def thunk():
+        env = gym.make(gym_id)
+        env = gym.wrappers.RecordEpisodeStatistics(env)
+        if capture_video:
+            if idx == 0:
+                env = gym.wrappers.RecordVideo(env, f"videos/{run_name}")
+        env.seed(seed)
+        env.action_space.seed(seed)
+        env.observation_space.seed(seed)
+        return env
 
-# modified from https://github.com/seungeunrho/minimalRL/blob/master/dqn.py#
-class ReplayBuffer():
-    def __init__(self, buffer_limit):
-        self.buffer = collections.deque(maxlen=buffer_limit)
-    
-    def put(self, transition):
-        self.buffer.append(transition)
-    
-    def sample(self, n):
-        mini_batch = random.sample(self.buffer, n)
-        s_lst, a_lst, r_lst, s_prime_lst, done_mask_lst = [], [], [], [], []
-        
-        for transition in mini_batch:
-            s, a, r, s_prime, done_mask = transition
-            s_lst.append(s)
-            a_lst.append(a)
-            r_lst.append(r)
-            s_prime_lst.append(s_prime)
-            done_mask_lst.append(done_mask)
+    return thunk
 
-        return np.array(s_lst), np.array(a_lst), \
-               np.array(r_lst), np.array(s_prime_lst), \
-               np.array(done_mask_lst)
 
 # ALGO LOGIC: initialize agent here:
 class QNetwork(nn.Module):
     def __init__(self, env):
         super(QNetwork, self).__init__()
-        self.fc1 = nn.Linear(np.array(env.observation_space.shape).prod(), 120)
-        self.fc2 = nn.Linear(120, 84)
-        self.fc3 = nn.Linear(84, env.action_space.n)
+        self.network = nn.Sequential(
+            nn.Linear(np.array(env.single_observation_space.shape).prod(), 64),
+            nn.Tanh(),
+            nn.Linear(64, 64),
+            nn.Tanh(),
+            nn.Linear(64, env.single_action_space.n),
+        )
 
-    def forward(self, x, device):
-        x = torch.Tensor(x).to(device)
-        x = F.relu(self.fc1(x))
-        x = F.relu(self.fc2(x))
-        x = self.fc3(x)
-        return x
+    def forward(self, x):
+        return self.network(x)
+
 
 def linear_schedule(start_e: float, end_e: float, duration: int, t: int):
     slope =  (end_e - start_e) / duration
     return max(slope * t + start_e, end_e)
 
-rb = ReplayBuffer(args.buffer_size)
-q_network = QNetwork(env).to(device)
-target_network = QNetwork(env).to(device)
-target_network.load_state_dict(q_network.state_dict())
-optimizer = optim.Adam(q_network.parameters(), lr=args.learning_rate)
-loss_fn = nn.MSELoss()
-print(device.__repr__())
-print(q_network)
 
-# TRY NOT TO MODIFY: start the game
-obs = env.reset()
-episode_reward = 0
-for global_step in range(args.total_timesteps):
-    # ALGO LOGIC: put action logic here
-    epsilon = linear_schedule(args.start_e, args.end_e, args.exploration_fraction*args.total_timesteps, global_step)
-    if random.random() < epsilon:
-        action = env.action_space.sample()
-    else:
-        logits = q_network.forward(obs.reshape((1,)+obs.shape), device)
-        action = torch.argmax(logits, dim=1).tolist()[0]
+if __name__ == "__main__":
+    args = parse_args()
+    run_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    if args.track:
+        import wandb
 
-    # TRY NOT TO MODIFY: execute the game and log data.
-    next_obs, reward, done, _ = env.step(action)
-    episode_reward += reward
+        wandb.init(
+            project=args.wandb_project_name,
+            entity=args.wandb_entity,
+            sync_tensorboard=True,
+            config=vars(args),
+            name=run_name,
+            monitor_gym=True,
+            save_code=True,
+        )
+    writer = SummaryWriter(f"runs/{run_name}")
+    writer.add_text(
+        "hyperparameters",
+        "|param|value|\n|-|-|\n%s" % ("\n".join([f"|{key}|{value}|" for key, value in vars(args).items()])),
+    )
 
-    # ALGO LOGIC: training.
-    rb.put((obs, action, reward, next_obs, done))
-    if global_step > args.learning_starts and global_step % args.train_frequency == 0:
-        s_obs, s_actions, s_rewards, s_next_obses, s_dones = rb.sample(args.batch_size)
-        with torch.no_grad():
-            target_max = torch.max(target_network.forward(s_next_obses, device), dim=1)[0]
-            td_target = torch.Tensor(s_rewards).to(device) + args.gamma * target_max * (1 - torch.Tensor(s_dones).to(device))
-        old_val = q_network.forward(s_obs, device).gather(1, torch.LongTensor(s_actions).view(-1,1).to(device)).squeeze()
-        loss = loss_fn(td_target, old_val)
+    # TRY NOT TO MODIFY: seeding
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.backends.cudnn.deterministic = args.torch_deterministic
 
-        if global_step % 100 == 0:
-            writer.add_scalar("losses/td_loss", loss, global_step)
+    device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
 
-        # optimize the midel
-        optimizer.zero_grad()
-        loss.backward()
-        nn.utils.clip_grad_norm_(list(q_network.parameters()), args.max_grad_norm)
-        optimizer.step()
+    # env setup
+    envs = gym.vector.SyncVectorEnv(
+        [make_env(args.gym_id, 0, 0, args.capture_video, run_name)]
+    )
+    assert isinstance(envs.single_action_space, gym.spaces.Discrete), "only discrete action space is supported"
 
-        # update the target network
-        if global_step % args.target_network_frequency == 0:
-            target_network.load_state_dict(q_network.state_dict())
+    q_network = QNetwork(envs).to(device)
+    optimizer = optim.Adam(q_network.parameters(), lr=args.learning_rate)
+    target_network = QNetwork(envs).to(device)
+    target_network.load_state_dict(q_network.state_dict())
 
-    # TRY NOT TO MODIFY: CRUCIAL step easy to overlook 
-    obs = next_obs
+    rb = ReplayBuffer(args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device, optimize_memory_usage=True)
+    loss_fn = nn.MSELoss()
 
-    if done:
+    # TRY NOT TO MODIFY: start the game
+    obs = envs.reset()
+    for global_step in range(args.total_timesteps):
+        # ALGO LOGIC: put action logic here
+        epsilon = linear_schedule(args.start_e, args.end_e, args.exploration_fraction*args.total_timesteps, global_step)
+        if random.random() < epsilon:
+            actions = envs.action_space.sample()
+        else:
+            logits = q_network.forward(torch.Tensor(obs).to(device))
+            actions = torch.argmax(logits, dim=1).cpu().numpy()
+
+        # TRY NOT TO MODIFY: execute the game and log data.
+        next_obs, rewards, dones, infos = envs.step(actions)
+
         # TRY NOT TO MODIFY: record rewards for plotting purposes
-        print(f"global_step={global_step}, episode_reward={episode_reward}")
-        writer.add_scalar("charts/episodic_return", episode_reward, global_step)
-        writer.add_scalar("charts/epsilon", epsilon, global_step)
-        obs, episode_reward = env.reset(), 0
+        for info in infos:
+            if "episode" in info.keys():
+                print(f"global_step={global_step}, episode_reward={info['episode']['r']}")
+                writer.add_scalar("charts/episodic_return", info["episode"]["r"], global_step)
+                writer.add_scalar("charts/epsilon", epsilon, global_step)
+                break
 
-env.close()
-writer.close()
+        # TRY NOT TO MODIFY: save data to reply buffer; handle `terminal_observation`
+        real_next_obs = next_obs.copy()
+        for idx, d in enumerate(dones):
+            if d:
+                real_next_obs[idx] = infos[idx]["terminal_observation"]
+        rb.add(obs, real_next_obs, actions, rewards, dones, infos)
+
+        # TRY NOT TO MODIFY: CRUCIAL step easy to overlook
+        obs = next_obs
+
+        # ALGO LOGIC: training.
+        if global_step > args.learning_starts and global_step % args.train_frequency == 0:
+            data = rb.sample(args.batch_size)
+            with torch.no_grad():
+                target_max, _ = target_network.forward(data.next_observations).max(dim=1)
+                td_target = data.rewards.flatten() + args.gamma * target_max * (1 - data.dones.flatten())
+            old_val = q_network.forward(data.observations).gather(1, data.actions).squeeze()
+            loss = loss_fn(td_target, old_val)
+
+            if global_step % 100 == 0:
+                writer.add_scalar("losses/td_loss", loss, global_step)
+
+            # optimize the midel
+            optimizer.zero_grad()
+            loss.backward()
+            nn.utils.clip_grad_norm_(list(q_network.parameters()), args.max_grad_norm)
+            optimizer.step()
+
+            # update the target network
+            if global_step % args.target_network_frequency == 0:
+                target_network.load_state_dict(q_network.state_dict())
+
+    envs.close()
+    writer.close()

--- a/cleanrl/dqn_atari.py
+++ b/cleanrl/dqn_atari.py
@@ -208,7 +208,7 @@ if __name__ == "__main__":
             if global_step % 100 == 0:
                 writer.add_scalar("losses/td_loss", loss, global_step)
 
-            # optimize the midel
+            # optimize the model
             optimizer.zero_grad()
             loss.backward()
             nn.utils.clip_grad_norm_(list(q_network.parameters()), args.max_grad_norm)

--- a/cleanrl/dqn_atari.py
+++ b/cleanrl/dqn_atari.py
@@ -26,7 +26,7 @@ def parse_args():
         help="the name of this experiment")
     parser.add_argument("--gym-id", type=str, default="BreakoutNoFrameskip-v4",
         help="the id of the gym environment")
-    parser.add_argument("--learning-rate", type=float, default=2.5e-4,
+    parser.add_argument("--learning-rate", type=float, default=1e-4,
         help="the learning rate of the optimizer")
     parser.add_argument("--seed", type=int, default=1,
         help="seed of the experiment")

--- a/cleanrl/dqn_atari.py
+++ b/cleanrl/dqn_atari.py
@@ -1,447 +1,106 @@
-# https://github.com/facebookresearch/torchbeast/blob/master/torchbeast/core/environment.py
+import argparse
+import os
+import random
+import time
+from distutils.util import strtobool
 
-import numpy as np
-from collections import deque
 import gym
-from gym import spaces
-import cv2
-cv2.ocl.setUseOpenCL(False)
-
-
-class NoopResetEnv(gym.Wrapper):
-    def __init__(self, env, noop_max=30):
-        """Sample initial states by taking random number of no-ops on reset.
-        No-op is assumed to be action 0.
-        """
-        gym.Wrapper.__init__(self, env)
-        self.noop_max = noop_max
-        self.override_num_noops = None
-        self.noop_action = 0
-        assert env.unwrapped.get_action_meanings()[0] == 'NOOP'
-
-    def reset(self, **kwargs):
-        """ Do no-op action for a number of steps in [1, noop_max]."""
-        self.env.reset(**kwargs)
-        if self.override_num_noops is not None:
-            noops = self.override_num_noops
-        else:
-            noops = self.unwrapped.np_random.randint(1, self.noop_max + 1) #pylint: disable=E1101
-        assert noops > 0
-        obs = None
-        for _ in range(noops):
-            obs, _, done, _ = self.env.step(self.noop_action)
-            if done:
-                obs = self.env.reset(**kwargs)
-        return obs
-
-    def step(self, ac):
-        return self.env.step(ac)
-
-class FireResetEnv(gym.Wrapper):
-    def __init__(self, env):
-        """Take action on reset for environments that are fixed until firing."""
-        gym.Wrapper.__init__(self, env)
-        assert env.unwrapped.get_action_meanings()[1] == 'FIRE'
-        assert len(env.unwrapped.get_action_meanings()) >= 3
-
-    def reset(self, **kwargs):
-        self.env.reset(**kwargs)
-        obs, _, done, _ = self.env.step(1)
-        if done:
-            self.env.reset(**kwargs)
-        obs, _, done, _ = self.env.step(2)
-        if done:
-            self.env.reset(**kwargs)
-        return obs
-
-    def step(self, ac):
-        return self.env.step(ac)
-
-class EpisodicLifeEnv(gym.Wrapper):
-    def __init__(self, env):
-        """Make end-of-life == end-of-episode, but only reset on true game over.
-        Done by DeepMind for the DQN and co. since it helps value estimation.
-        """
-        gym.Wrapper.__init__(self, env)
-        self.lives = 0
-        self.was_real_done  = True
-
-    def step(self, action):
-        obs, reward, done, info = self.env.step(action)
-        self.was_real_done = done
-        # check current lives, make loss of life terminal,
-        # then update lives to handle bonus lives
-        lives = self.env.unwrapped.ale.lives()
-        if lives < self.lives and lives > 0:
-            # for Qbert sometimes we stay in lives == 0 condition for a few frames
-            # so it's important to keep lives > 0, so that we only reset once
-            # the environment advertises done.
-            done = True
-        self.lives = lives
-        return obs, reward, done, info
-
-    def reset(self, **kwargs):
-        """Reset only when lives are exhausted.
-        This way all states are still reachable even though lives are episodic,
-        and the learner need not know about any of this behind-the-scenes.
-        """
-        if self.was_real_done:
-            obs = self.env.reset(**kwargs)
-        else:
-            # no-op step to advance from terminal/lost life state
-            obs, _, _, _ = self.env.step(0)
-        self.lives = self.env.unwrapped.ale.lives()
-        return obs
-
-class MaxAndSkipEnv(gym.Wrapper):
-    def __init__(self, env, skip=4):
-        """Return only every `skip`-th frame"""
-        gym.Wrapper.__init__(self, env)
-        # most recent raw observations (for max pooling across time steps)
-        self._obs_buffer = np.zeros((2,)+env.observation_space.shape, dtype=np.uint8)
-        self._skip       = skip
-
-    def step(self, action):
-        """Repeat action, sum reward, and max over last observations."""
-        total_reward = 0.0
-        done = None
-        for i in range(self._skip):
-            obs, reward, done, info = self.env.step(action)
-            if i == self._skip - 2: self._obs_buffer[0] = obs
-            if i == self._skip - 1: self._obs_buffer[1] = obs
-            total_reward += reward
-            if done:
-                break
-        # Note that the observation on the done=True frame
-        # doesn't matter
-        max_frame = self._obs_buffer.max(axis=0)
-
-        return max_frame, total_reward, done, info
-
-    def reset(self, **kwargs):
-        return self.env.reset(**kwargs)
-
-class ClipRewardEnv(gym.RewardWrapper):
-    def __init__(self, env):
-        gym.RewardWrapper.__init__(self, env)
-
-    def reward(self, reward):
-        """Bin reward to {+1, 0, -1} by its sign."""
-        return np.sign(reward)
-
-
-class WarpFrame(gym.ObservationWrapper):
-    def __init__(self, env, width=84, height=84, grayscale=True, dict_space_key=None):
-        """
-        Warp frames to 84x84 as done in the Nature paper and later work.
-        If the environment uses dictionary observations, `dict_space_key` can be specified which indicates which
-        observation should be warped.
-        """
-        super().__init__(env)
-        self._width = width
-        self._height = height
-        self._grayscale = grayscale
-        self._key = dict_space_key
-        if self._grayscale:
-            num_colors = 1
-        else:
-            num_colors = 3
-
-        new_space = gym.spaces.Box(
-            low=0,
-            high=255,
-            shape=(self._height, self._width, num_colors),
-            dtype=np.uint8,
-        )
-        if self._key is None:
-            original_space = self.observation_space
-            self.observation_space = new_space
-        else:
-            original_space = self.observation_space.spaces[self._key]
-            self.observation_space.spaces[self._key] = new_space
-        assert original_space.dtype == np.uint8 and len(original_space.shape) == 3
-
-    def observation(self, obs):
-        if self._key is None:
-            frame = obs
-        else:
-            frame = obs[self._key]
-
-        if self._grayscale:
-            frame = cv2.cvtColor(frame, cv2.COLOR_RGB2GRAY)
-        frame = cv2.resize(
-            frame, (self._width, self._height), interpolation=cv2.INTER_AREA
-        )
-        if self._grayscale:
-            frame = np.expand_dims(frame, -1)
-
-        if self._key is None:
-            obs = frame
-        else:
-            obs = obs.copy()
-            obs[self._key] = frame
-        return obs
-
-
-class FrameStack(gym.Wrapper):
-    def __init__(self, env, k):
-        """Stack k last frames.
-        Returns lazy array, which is much more memory efficient.
-        See Also
-        --------
-        baselines.common.atari_wrappers.LazyFrames
-        """
-        gym.Wrapper.__init__(self, env)
-        self.k = k
-        self.frames = deque([], maxlen=k)
-        shp = env.observation_space.shape
-        self.observation_space = spaces.Box(low=0, high=255, shape=((shp[0] * k,)+shp[1:]), dtype=env.observation_space.dtype)
-
-    def reset(self):
-        ob = self.env.reset()
-        for _ in range(self.k):
-            self.frames.append(ob)
-        return self._get_ob()
-
-    def step(self, action):
-        ob, reward, done, info = self.env.step(action)
-        self.frames.append(ob)
-        return self._get_ob(), reward, done, info
-
-    def _get_ob(self):
-        assert len(self.frames) == self.k
-        return LazyFrames(list(self.frames))
-
-class ScaledFloatFrame(gym.ObservationWrapper):
-    def __init__(self, env):
-        gym.ObservationWrapper.__init__(self, env)
-        self.observation_space = gym.spaces.Box(low=0, high=1, shape=env.observation_space.shape, dtype=np.float32)
-
-    def observation(self, observation):
-        # careful! This undoes the memory optimization, use
-        # with smaller replay buffers only.
-        return np.array(observation).astype(np.float32) / 255.0
-
-class LazyFrames(object):
-    def __init__(self, frames):
-        """This object ensures that common frames between the observations are only stored once.
-        It exists purely to optimize memory usage which can be huge for DQN's 1M frames replay
-        buffers.
-        This object should only be converted to numpy array before being passed to the model.
-        You'd not believe how complex the previous solution was."""
-        self._frames = frames
-        self._out = None
-
-    def _force(self):
-        if self._out is None:
-            self._out = np.concatenate(self._frames, axis=0)
-            self._frames = None
-        return self._out
-
-    def __array__(self, dtype=None):
-        out = self._force()
-        if dtype is not None:
-            out = out.astype(dtype)
-        return out
-
-    def __len__(self):
-        return len(self._force())
-
-    def __getitem__(self, i):
-        return self._force()[i]
-
-    def count(self):
-        frames = self._force()
-        return frames.shape[frames.ndim - 1]
-
-    def frame(self, i):
-        return self._force()[..., i]
-
-def wrap_atari(env, max_episode_steps=None):
-    assert 'NoFrameskip' in env.spec.id
-    env = NoopResetEnv(env, noop_max=30)
-    env = MaxAndSkipEnv(env, skip=4)
-
-    assert max_episode_steps is None
-
-    return env
-
-class ImageToPyTorch(gym.ObservationWrapper):
-    """
-    Image shape to channels x weight x height
-    """
-
-    def __init__(self, env):
-        super(ImageToPyTorch, self).__init__(env)
-        old_shape = self.observation_space.shape
-        self.observation_space = gym.spaces.Box(
-            low=0,
-            high=255,
-            shape=(old_shape[-1], old_shape[0], old_shape[1]),
-            dtype=np.uint8,
-        )
-
-    def observation(self, observation):
-        return np.transpose(observation, axes=(2, 0, 1))
-
-def wrap_deepmind(env, episode_life=True, clip_rewards=True, frame_stack=False, scale=False):
-    """Configure environment for DeepMind-style Atari.
-    """
-    if episode_life:
-        env = EpisodicLifeEnv(env)
-    if 'FIRE' in env.unwrapped.get_action_meanings():
-        env = FireResetEnv(env)
-    env = WarpFrame(env)
-    if scale:
-        env = ScaledFloatFrame(env)
-    if clip_rewards:
-        env = ClipRewardEnv(env)
-    env = ImageToPyTorch(env)
-    if frame_stack:
-        env = FrameStack(env, 4)
-    return env
-
-# Reference: https://www.cs.toronto.edu/~vmnih/docs/dqn.pdf
-
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.optim as optim
-import torch.nn.functional as F
 from torch.utils.tensorboard import SummaryWriter
-
-import argparse
-from distutils.util import strtobool
-import collections
-import numpy as np
-import gym
-from gym.wrappers import TimeLimit, Monitor
-from gym.spaces import Discrete, Box, MultiBinary, MultiDiscrete, Space
-import time
-import random
-import os
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='DQN agent')
-    # Common arguments
-    parser.add_argument('--exp-name', type=str, default=os.path.basename(__file__).rstrip(".py"),
-                        help='the name of this experiment')
-    parser.add_argument('--gym-id', type=str, default="BreakoutNoFrameskip-v4",
-                        help='the id of the gym environment')
-    parser.add_argument('--learning-rate', type=float, default=1e-4,
-                        help='the learning rate of the optimizer')
-    parser.add_argument('--seed', type=int, default=2,
-                        help='seed of the experiment')
-    parser.add_argument('--total-timesteps', type=int, default=10000000,
-                        help='total timesteps of the experiments')
-    parser.add_argument('--torch-deterministic', type=lambda x:bool(strtobool(x)), default=True, nargs='?', const=True,
-                        help='if toggled, `torch.backends.cudnn.deterministic=False`')
-    parser.add_argument('--cuda', type=lambda x:bool(strtobool(x)), default=True, nargs='?', const=True,
-                        help='if toggled, cuda will not be enabled by default')
-    parser.add_argument('--track', type=lambda x:bool(strtobool(x)), default=False, nargs='?', const=True,
-                        help='run the script in production mode and use wandb to log outputs')
-    parser.add_argument('--capture-video', type=lambda x:bool(strtobool(x)), default=False, nargs='?', const=True,
-                        help='weather to capture videos of the agent performances (check out `videos` folder)')
-    parser.add_argument('--wandb-project-name', type=str, default="cleanRL",
-                        help="the wandb's project name")
-    parser.add_argument('--wandb-entity', type=str, default=None,
-                        help="the entity (team) of wandb's project")
-    
-    # Algorithm specific arguments
-    parser.add_argument('--buffer-size', type=int, default=1000000,
-                         help='the replay memory buffer size')
-    parser.add_argument('--gamma', type=float, default=0.99,
-                        help='the discount factor gamma')
-    parser.add_argument('--target-network-frequency', type=int, default=1000,
-                        help="the timesteps it takes to update the target network")
-    parser.add_argument('--max-grad-norm', type=float, default=0.5,
-                        help='the maximum norm for the gradient clipping')
-    parser.add_argument('--batch-size', type=int, default=32,
-                        help="the batch size of sample from the reply memory")
-    parser.add_argument('--start-e', type=float, default=1.,
-                        help="the starting epsilon for exploration")
-    parser.add_argument('--end-e', type=float, default=0.02,
-                        help="the ending epsilon for exploration")
-    parser.add_argument('--exploration-fraction', type=float, default=0.10,
-                        help="the fraction of `total-timesteps` it takes from start-e to go end-e")
-    parser.add_argument('--learning-starts', type=int, default=80000,
-                        help="timestep to start learning")
-    parser.add_argument('--train-frequency', type=int, default=4,
-                        help="the frequency of training")
-    args = parser.parse_args()
-    if not args.seed:
-        args.seed = int(time.time())
-
-# TRY NOT TO MODIFY: setup the environment
-experiment_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
-writer = SummaryWriter(f"runs/{experiment_name}")
-writer.add_text('hyperparameters', "|param|value|\n|-|-|\n%s" % (
-        '\n'.join([f"|{key}|{value}|" for key, value in vars(args).items()])))
-if args.track:
-    import wandb
-    wandb.init(project=args.wandb_project_name, entity=args.wandb_entity, sync_tensorboard=True, config=vars(args), name=experiment_name, monitor_gym=True, save_code=True)
-    writer = SummaryWriter(f"/tmp/{experiment_name}")
-
-# TRY NOT TO MODIFY: seeding
-device = torch.device('cuda' if torch.cuda.is_available() and args.cuda else 'cpu')
-env = gym.make(args.gym_id)
-env = wrap_atari(env)
-env = gym.wrappers.RecordEpisodeStatistics(env) # records episode reward in `info['episode']['r']`
-if args.capture_video:
-    env = Monitor(env, f'videos/{experiment_name}')
-env = wrap_deepmind(
-    env,
-    clip_rewards=True,
-    frame_stack=True,
-    scale=False,
+from stable_baselines3.common.atari_wrappers import (
+    ClipRewardEnv,
+    EpisodicLifeEnv,
+    FireResetEnv,
+    MaxAndSkipEnv,
+    NoopResetEnv,
 )
-random.seed(args.seed)
-np.random.seed(args.seed)
-torch.manual_seed(args.seed)
-torch.backends.cudnn.deterministic = args.torch_deterministic
-env.seed(args.seed)
-env.action_space.seed(args.seed)
-env.observation_space.seed(args.seed)
-# respect the default timelimit
-assert isinstance(env.action_space, Discrete), "only discrete action space is supported"
+from stable_baselines3.common.buffers import ReplayBuffer
 
-# modified from https://github.com/seungeunrho/minimalRL/blob/master/dqn.py#
-class ReplayBuffer():
-    def __init__(self, buffer_limit):
-        self.buffer = collections.deque(maxlen=buffer_limit)
-    
-    def put(self, transition):
-        self.buffer.append(transition)
-    
-    def sample(self, n):
-        mini_batch = random.sample(self.buffer, n)
-        s_lst, a_lst, r_lst, s_prime_lst, done_mask_lst = [], [], [], [], []
-        
-        for transition in mini_batch:
-            s, a, r, s_prime, done_mask = transition
-            s_lst.append(s)
-            a_lst.append(a)
-            r_lst.append(r)
-            s_prime_lst.append(s_prime)
-            done_mask_lst.append(done_mask)
+def parse_args():
+    # fmt: off
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
+        help="the name of this experiment")
+    parser.add_argument("--gym-id", type=str, default="BreakoutNoFrameskip-v4",
+        help="the id of the gym environment")
+    parser.add_argument("--learning-rate", type=float, default=2.5e-4,
+        help="the learning rate of the optimizer")
+    parser.add_argument("--seed", type=int, default=1,
+        help="seed of the experiment")
+    parser.add_argument("--total-timesteps", type=int, default=10000000,
+        help="total timesteps of the experiments")
+    parser.add_argument("--torch-deterministic", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
+        help="if toggled, `torch.backends.cudnn.deterministic=False`")
+    parser.add_argument("--cuda", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
+        help="if toggled, cuda will be enabled by default")
+    parser.add_argument("--track", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="if toggled, this experiment will be tracked with Weights and Biases")
+    parser.add_argument("--wandb-project-name", type=str, default="cleanRL",
+        help="the wandb's project name")
+    parser.add_argument("--wandb-entity", type=str, default=None,
+        help="the entity (team) of wandb's project")
+    parser.add_argument("--capture-video", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="weather to capture videos of the agent performances (check out `videos` folder)")
 
-        return np.array(s_lst), np.array(a_lst), \
-               np.array(r_lst), np.array(s_prime_lst), \
-               np.array(done_mask_lst)
+    # Algorithm specific arguments
+    parser.add_argument("--buffer-size", type=int, default=1000000,
+        help="the replay memory buffer size")
+    parser.add_argument("--gamma", type=float, default=0.99,
+        help="the discount factor gamma")
+    parser.add_argument("--target-network-frequency", type=int, default=1000,
+        help="the timesteps it takes to update the target network")
+    parser.add_argument("--max-grad-norm", type=float, default=0.5,
+        help="the maximum norm for the gradient clipping")
+    parser.add_argument("--batch-size", type=int, default=32,
+        help="the batch size of sample from the reply memory")
+    parser.add_argument("--start-e", type=float, default=1,
+        help="the starting epsilon for exploration")
+    parser.add_argument("--end-e", type=float, default=0.02,
+        help="the ending epsilon for exploration")
+    parser.add_argument("--exploration-fraction", type=float, default=0.10,
+        help="the fraction of `total-timesteps` it takes from start-e to go end-e")
+    parser.add_argument("--learning-starts", type=int, default=80000,
+        help="timestep to start learning")
+    parser.add_argument("--train-frequency", type=int, default=4,
+        help="the frequency of training")
+    args = parser.parse_args()
+    # fmt: on
+    return args
+
+
+def make_env(gym_id, seed, idx, capture_video, run_name):
+    def thunk():
+        env = gym.make(gym_id)
+        env = gym.wrappers.RecordEpisodeStatistics(env)
+        if capture_video:
+            if idx == 0:
+                env = gym.wrappers.RecordVideo(env, f"videos/{run_name}")
+        env = NoopResetEnv(env, noop_max=30)
+        env = MaxAndSkipEnv(env, skip=4)
+        env = EpisodicLifeEnv(env)
+        if "FIRE" in env.unwrapped.get_action_meanings():
+            env = FireResetEnv(env)
+        env = ClipRewardEnv(env)
+        env = gym.wrappers.ResizeObservation(env, (84, 84))
+        env = gym.wrappers.GrayScaleObservation(env)
+        env = gym.wrappers.FrameStack(env, 4)
+        env.seed(seed)
+        env.action_space.seed(seed)
+        env.observation_space.seed(seed)
+        return env
+
+    return thunk
+
 
 # ALGO LOGIC: initialize agent here:
-class Scale(nn.Module):
-    def __init__(self, scale):
-        super().__init__()
-        self.scale = scale
-
-    def forward(self, x):
-        return x * self.scale
 class QNetwork(nn.Module):
-    def __init__(self, env, frames=4):
+    def __init__(self, env):
         super(QNetwork, self).__init__()
         self.network = nn.Sequential(
-            Scale(1/255),
-            nn.Conv2d(frames, 32, 8, stride=4),
+            nn.Conv2d(4, 32, 8, stride=4),
             nn.ReLU(),
             nn.Conv2d(32, 64, 4, stride=2),
             nn.ReLU(),
@@ -450,79 +109,114 @@ class QNetwork(nn.Module):
             nn.Flatten(),
             nn.Linear(3136, 512),
             nn.ReLU(),
-            nn.Linear(512, env.action_space.n)
+            nn.Linear(512, env.single_action_space.n),
         )
 
-    def forward(self, x, device):
-        x = torch.Tensor(x).to(device)
-        return self.network(x)
+    def forward(self, x):
+        return self.network(x / 255.0)
+
 
 def linear_schedule(start_e: float, end_e: float, duration: int, t: int):
     slope =  (end_e - start_e) / duration
     return max(slope * t + start_e, end_e)
 
-rb = ReplayBuffer(args.buffer_size)
-q_network = QNetwork(env).to(device)
-target_network = QNetwork(env).to(device)
-target_network.load_state_dict(q_network.state_dict())
-optimizer = optim.Adam(q_network.parameters(), lr=args.learning_rate)
-loss_fn = nn.MSELoss()
-print(device.__repr__())
-print(q_network)
 
-# TRY NOT TO MODIFY: start the game
-obs = env.reset()
-episode_reward = 0
-for global_step in range(args.total_timesteps):
-    # ALGO LOGIC: put action logic here
-    epsilon = linear_schedule(args.start_e, args.end_e, args.exploration_fraction*args.total_timesteps, global_step)
-    obs = np.array(obs)
-    if random.random() < epsilon:
-        action = env.action_space.sample()
-    else:
-        logits = q_network.forward(obs.reshape((1,)+obs.shape), device)
-        action = torch.argmax(logits, dim=1).tolist()[0]
+if __name__ == "__main__":
+    args = parse_args()
+    run_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    if args.track:
+        import wandb
 
-    # TRY NOT TO MODIFY: execute the game and log data.
-    next_obs, reward, done, info = env.step(action)
-    episode_reward += reward
-    
-    # TRY NOT TO MODIFY: record rewards for plotting purposes
-    if 'episode' in info.keys():
-        print(f"global_step={global_step}, episode_reward={info['episode']['r']}")
-        writer.add_scalar("charts/episodic_return", info['episode']['r'], global_step)
-        writer.add_scalar("charts/epsilon", epsilon, global_step)
+        wandb.init(
+            project=args.wandb_project_name,
+            entity=args.wandb_entity,
+            sync_tensorboard=True,
+            config=vars(args),
+            name=run_name,
+            monitor_gym=True,
+            save_code=True,
+        )
+    writer = SummaryWriter(f"runs/{run_name}")
+    writer.add_text(
+        "hyperparameters",
+        "|param|value|\n|-|-|\n%s" % ("\n".join([f"|{key}|{value}|" for key, value in vars(args).items()])),
+    )
 
-    # ALGO LOGIC: training.
-    rb.put((obs, action, reward, next_obs, done))
-    if global_step > args.learning_starts and global_step % args.train_frequency == 0:
-        s_obs, s_actions, s_rewards, s_next_obses, s_dones = rb.sample(args.batch_size)
-        with torch.no_grad():
-            target_max = torch.max(target_network.forward(s_next_obses, device), dim=1)[0]
-            td_target = torch.Tensor(s_rewards).to(device) + args.gamma * target_max * (1 - torch.Tensor(s_dones).to(device))
-        old_val = q_network.forward(s_obs, device).gather(1, torch.LongTensor(s_actions).view(-1,1).to(device)).squeeze()
-        loss = loss_fn(td_target, old_val)
-        
-        if global_step % 100 == 0:
-            writer.add_scalar("losses/td_loss", loss, global_step)
+    # TRY NOT TO MODIFY: seeding
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.backends.cudnn.deterministic = args.torch_deterministic
 
-        # optimize the midel
-        optimizer.zero_grad()
-        loss.backward()
-        nn.utils.clip_grad_norm_(list(q_network.parameters()), args.max_grad_norm)
-        optimizer.step()
+    device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
 
-        # update the target network
-        if global_step % args.target_network_frequency == 0:
-            target_network.load_state_dict(q_network.state_dict())
+    # env setup
+    envs = gym.vector.SyncVectorEnv(
+        [make_env(args.gym_id, 0, 0, args.capture_video, run_name)]
+    )
+    assert isinstance(envs.single_action_space, gym.spaces.Discrete), "only discrete action space is supported"
 
-    # TRY NOT TO MODIFY: CRUCIAL step easy to overlook
-    obs = next_obs
-    if done:
-        # important to note that because `EpisodicLifeEnv` wrapper is applied,
-        # the real episode reward is actually the sum of episode reward of 5 lives
-        # which we record through `info['episode']['r']` provided by gym.wrappers.RecordEpisodeStatistics
-        obs, episode_reward = env.reset(), 0
+    q_network = QNetwork(envs).to(device)
+    optimizer = optim.Adam(q_network.parameters(), lr=args.learning_rate)
+    target_network = QNetwork(envs).to(device)
+    target_network.load_state_dict(q_network.state_dict())
 
-env.close()
-writer.close()
+    rb = ReplayBuffer(args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device, optimize_memory_usage=True)
+    loss_fn = nn.MSELoss()
+
+    # TRY NOT TO MODIFY: start the game
+    obs = envs.reset()
+    for global_step in range(args.total_timesteps):
+        # ALGO LOGIC: put action logic here
+        epsilon = linear_schedule(args.start_e, args.end_e, args.exploration_fraction*args.total_timesteps, global_step)
+        if random.random() < epsilon:
+            actions = envs.action_space.sample()
+        else:
+            logits = q_network.forward(torch.Tensor(obs).to(device))
+            actions = torch.argmax(logits, dim=1).cpu().numpy()
+
+        # TRY NOT TO MODIFY: execute the game and log data.
+        next_obs, rewards, dones, infos = envs.step(actions)
+
+        # TRY NOT TO MODIFY: record rewards for plotting purposes
+        for info in infos:
+            if "episode" in info.keys():
+                print(f"global_step={global_step}, episode_reward={info['episode']['r']}")
+                writer.add_scalar("charts/episodic_return", info["episode"]["r"], global_step)
+                writer.add_scalar("charts/epsilon", epsilon, global_step)
+                break
+
+        # TRY NOT TO MODIFY: save data to reply buffer; handle `terminal_observation`
+        real_next_obs = next_obs.copy()
+        for idx, d in enumerate(dones):
+            if d:
+                real_next_obs[idx] = infos[idx]["terminal_observation"]
+        rb.add(obs, real_next_obs, actions, rewards, dones, infos)
+
+        # TRY NOT TO MODIFY: CRUCIAL step easy to overlook
+        obs = next_obs
+
+        # ALGO LOGIC: training.
+        if global_step > args.learning_starts and global_step % args.train_frequency == 0:
+            data = rb.sample(args.batch_size)
+            with torch.no_grad():
+                target_max, _ = target_network.forward(data.next_observations).max(dim=1)
+                td_target = data.rewards.flatten() + args.gamma * target_max * (1 - data.dones.flatten())
+            old_val = q_network.forward(data.observations).gather(1, data.actions).squeeze()
+            loss = loss_fn(td_target, old_val)
+
+            if global_step % 100 == 0:
+                writer.add_scalar("losses/td_loss", loss, global_step)
+
+            # optimize the midel
+            optimizer.zero_grad()
+            loss.backward()
+            nn.utils.clip_grad_norm_(list(q_network.parameters()), args.max_grad_norm)
+            optimizer.step()
+
+            # update the target network
+            if global_step % args.target_network_frequency == 0:
+                target_network.load_state_dict(q_network.state_dict())
+
+    envs.close()
+    writer.close()

--- a/cleanrl/offline/offline_dqn_atari_visual.py
+++ b/cleanrl/offline/offline_dqn_atari_visual.py
@@ -554,7 +554,7 @@ for global_step in range(args.total_timesteps):
         writer.add_scalar("losses/td_loss", loss, global_step)
         writer.add_scalar("losses/average_q_values", old_val.mean().item(), global_step)
 
-        # optimize the midel
+        # optimize the model
         optimizer.zero_grad()
         loss.backward()
         nn.utils.clip_grad_norm_(list(q_network.parameters()), args.max_grad_norm)

--- a/cleanrl/offline/offline_dqn_cql_atari_visual.py
+++ b/cleanrl/offline/offline_dqn_cql_atari_visual.py
@@ -564,7 +564,7 @@ for global_step in range(args.total_timesteps):
         writer.add_scalar("losses/min_q_loss", min_q_loss, global_step)
         writer.add_scalar("losses/average_q_values", dataset_expec.item(), global_step)
 
-        # optimize the midel
+        # optimize the model
         optimizer.zero_grad()
         (loss+min_q_loss).backward()
         nn.utils.clip_grad_norm_(list(q_network.parameters()), args.max_grad_norm)

--- a/cleanrl/sac_continuous_action.py
+++ b/cleanrl/sac_continuous_action.py
@@ -1,163 +1,138 @@
-# https://github.com/pranz24/pytorch-soft-actor-critic
+import argparse
+import os
+import random
+import time
+from distutils.util import strtobool
 
+import gym
+import numpy as np
+import pybullet_envs  # noqa
 import torch
 import torch.nn as nn
 import torch.optim as optim
 import torch.nn.functional as F
-from torch.distributions.categorical import Categorical
-from torch.distributions.normal import Normal
 from torch.utils.tensorboard import SummaryWriter
+from stable_baselines3.common.buffers import ReplayBuffer
 
-import argparse
-from distutils.util import strtobool
-import collections
-import numpy as np
-import gym
-from gym.wrappers import TimeLimit, Monitor
-import pybullet_envs
-from gym.spaces import Discrete, Box, MultiBinary, MultiDiscrete, Space
-import time
-import random
-import os
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='SAC with 2 Q functions, Online updates')
-    # Common arguments
-    parser.add_argument('--exp-name', type=str, default=os.path.basename(__file__).rstrip(".py"),
-                        help='the name of this experiment')
-    parser.add_argument('--gym-id', type=str, default="HopperBulletEnv-v0",
-                        help='the id of the gym environment')
-    parser.add_argument('--learning-rate', type=float, default=7e-4,
-                        help='the learning rate of the optimizer')
-    parser.add_argument('--seed', type=int, default=2,
-                        help='seed of the experiment')
-    parser.add_argument('--episode-length', type=int, default=0,
-                        help='the maximum length of each episode')
-    parser.add_argument('--total-timesteps', type=int, default=4000000,
-                        help='total timesteps of the experiments')
-    parser.add_argument('--torch-deterministic', type=lambda x:bool(strtobool(x)), default=True, nargs='?', const=True,
-                        help='if toggled, `torch.backends.cudnn.deterministic=False`')
-    parser.add_argument('--cuda', type=lambda x:bool(strtobool(x)), default=True, nargs='?', const=True,
-                        help='if toggled, cuda will not be enabled by default')
-    parser.add_argument('--track', type=lambda x:bool(strtobool(x)), default=False, nargs='?', const=True,
-                        help='run the script in production mode and use wandb to log outputs')
-    parser.add_argument('--capture-video', type=lambda x:bool(strtobool(x)), default=False, nargs='?', const=True,
-                        help='weather to capture videos of the agent performances (check out `videos` folder)')
-    parser.add_argument('--wandb-project-name', type=str, default="cleanRL",
-                        help="the wandb's project name")
-    parser.add_argument('--wandb-entity', type=str, default=None,
-                        help="the entity (team) of wandb's project")
-    parser.add_argument('--autotune', type=lambda x:bool(strtobool(x)), default=True, nargs='?', const=True,
-                        help='automatic tuning of the entropy coefficient.')
+def parse_args():
+    # fmt: off
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
+        help="the name of this experiment")
+    parser.add_argument("--gym-id", type=str, default="HopperBulletEnv-v0",
+        help="the id of the gym environment")
+    parser.add_argument("--seed", type=int, default=1,
+        help="seed of the experiment")
+    parser.add_argument("--total-timesteps", type=int, default=1000000,
+        help="total timesteps of the experiments")
+    parser.add_argument("--torch-deterministic", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
+        help="if toggled, `torch.backends.cudnn.deterministic=False`")
+    parser.add_argument("--cuda", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
+        help="if toggled, cuda will be enabled by default")
+    parser.add_argument("--track", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="if toggled, this experiment will be tracked with Weights and Biases")
+    parser.add_argument("--wandb-project-name", type=str, default="cleanRL",
+        help="the wandb's project name")
+    parser.add_argument("--wandb-entity", type=str, default=None,
+        help="the entity (team) of wandb's project")
+    parser.add_argument("--capture-video", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
-    parser.add_argument('--buffer-size', type=int, default=1000000,
-                         help='the replay memory buffer size')
-    parser.add_argument('--gamma', type=float, default=0.99,
-                        help='the discount factor gamma')
-    parser.add_argument('--target-network-frequency', type=int, default=1, # Denis Yarats' implementation delays this by 2.
-                        help="the timesteps it takes to update the target network")
-    parser.add_argument('--max-grad-norm', type=float, default=0.5,
-                        help='the maximum norm for the gradient clipping')
-    parser.add_argument('--batch-size', type=int, default=256, # Worked better in my experiments, still have to do ablation on this. Please remind me
-                        help="the batch size of sample from the reply memory")
-    parser.add_argument('--tau', type=float, default=0.005,
-                        help="target smoothing coefficient (default: 0.005)")
-    parser.add_argument('--alpha', type=float, default=0.2,
-                        help="Entropy regularization coefficient.")
-    parser.add_argument('--learning-starts', type=int, default=5e3,
-                        help="timestep to start learning")
-
-
-    # Additional hyper parameters for tweaks
-    ## Separating the learning rate of the policy and value commonly seen: (Original implementation, Denis Yarats)
-    parser.add_argument('--policy-lr', type=float, default=3e-4,
-                        help='the learning rate of the policy network optimizer')
-    parser.add_argument('--q-lr', type=float, default=1e-3,
-                        help='the learning rate of the Q network network optimizer')
-    parser.add_argument('--policy-frequency', type=int, default=1,
-                        help='delays the update of the actor, as per the TD3 paper.')
-    # NN Parameterization
-    parser.add_argument('--weights-init', default='xavier', const='xavier', nargs='?', choices=['xavier', "orthogonal", 'uniform'],
-                        help='weight initialization scheme for the neural networks.')
-    parser.add_argument('--bias-init', default='zeros', const='xavier', nargs='?', choices=['zeros', 'uniform'],
-                        help='weight initialization scheme for the neural networks.')
-
+    parser.add_argument("--buffer-size", type=int, default=int(1e6),
+        help="the replay memory buffer size")
+    parser.add_argument("--gamma", type=float, default=0.99,
+        help="the discount factor gamma")
+    parser.add_argument("--tau", type=float, default=0.005,
+        help="target smoothing coefficient (default: 0.005)")
+    parser.add_argument("--max-grad-norm", type=float, default=0.5,
+        help="the maximum norm for the gradient clipping")
+    parser.add_argument("--batch-size", type=int, default=256,
+        help="the batch size of sample from the reply memory")
+    parser.add_argument("--exploration-noise", type=float, default=0.1,
+        help="the scale of exploration noise")
+    parser.add_argument("--learning-starts", type=int, default=5e3,
+        help="timestep to start learning")
+    parser.add_argument("--policy-lr", type=float, default=3e-4,
+        help="the learning rate of the policy network optimizer")
+    parser.add_argument("--q-lr", type=float, default=1e-3,
+        help="the learning rate of the Q network network optimizer")
+    parser.add_argument("--policy-frequency", type=int, default=2,
+        help="the frequency of training policy (delayed)")
+    parser.add_argument("--target-network-frequency", type=int, default=1, # Denis Yarats' implementation delays this by 2.
+        help="the frequency of updates for the target nerworks")
+    parser.add_argument("--noise-clip", type=float, default=0.5,
+        help="noise clip parameter of the Target Policy Smoothing Regularization")
+    parser.add_argument("--alpha", type=float, default=0.2,
+            help="Entropy regularization coefficient.")
+    parser.add_argument("--autotune", type=lambda x:bool(strtobool(x)), default=True, nargs="?", const=True,
+        help="automatic tuning of the entropy coefficient")
     args = parser.parse_args()
-    if not args.seed:
-        args.seed = int(time.time())
-
-# TRY NOT TO MODIFY: setup the environment
-experiment_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
-writer = SummaryWriter(f"runs/{experiment_name}")
-writer.add_text('hyperparameters', "|param|value|\n|-|-|\n%s" % (
-        '\n'.join([f"|{key}|{value}|" for key, value in vars(args).items()])))
-if args.track:
-    import wandb
-    wandb.init(project=args.wandb_project_name, entity=args.wandb_entity, sync_tensorboard=True, config=vars(args), name=experiment_name, monitor_gym=True, save_code=True)
-    writer = SummaryWriter(f"/tmp/{experiment_name}")
+    # fmt: on
+    return args
 
 
-# TRY NOT TO MODIFY: seeding
-device = torch.device('cuda' if torch.cuda.is_available() and args.cuda else 'cpu')
-env = gym.make(args.gym_id)
-random.seed(args.seed)
-np.random.seed(args.seed)
-torch.manual_seed(args.seed)
-torch.backends.cudnn.deterministic = args.torch_deterministic
-env.seed(args.seed)
-env.action_space.seed(args.seed)
-env.observation_space.seed(args.seed)
-input_shape = env.observation_space.shape[0]
-output_shape = env.action_space.shape[0]
-# respect the default timelimit
-assert isinstance(env.action_space, Box), "only continuous action space is supported"
-if args.capture_video:
-    env = Monitor(env, f'videos/{experiment_name}')
+def make_env(gym_id, seed, idx, capture_video, run_name):
+    def thunk():
+        env = gym.make(gym_id)
+        env = gym.wrappers.RecordEpisodeStatistics(env)
+        if capture_video:
+            if idx == 0:
+                env = gym.wrappers.RecordVideo(env, f"videos/{run_name}")
+        env.seed(seed)
+        env.action_space.seed(seed)
+        env.observation_space.seed(seed)
+        return env
+
+    return thunk
+
 
 # ALGO LOGIC: initialize agent here:
+class SoftQNetwork(nn.Module):
+    def __init__(self, env):
+        super(SoftQNetwork, self).__init__()
+        self.fc1 = nn.Linear(
+            np.array(env.single_observation_space.shape).prod()+np.prod(env.single_action_space.shape), 256)
+        self.fc2 = nn.Linear(256, 256)
+        self.fc3 = nn.Linear(256, 1)
+
+    def forward(self, x, a):
+        x = torch.cat([x, a], 1)
+        x = F.relu(self.fc1(x))
+        x = F.relu(self.fc2(x))
+        x = self.fc3(x)
+        return x
+
 LOG_STD_MAX = 2
 LOG_STD_MIN = -5
 
-def layer_init(layer, weight_gain=1, bias_const=0):
-    if isinstance(layer, nn.Linear):
-        if args.weights_init == "xavier":
-            torch.nn.init.xavier_uniform_(layer.weight, gain=weight_gain)
-        elif args.weights_init == "orthogonal":
-            torch.nn.init.orthogonal_(layer.weight, gain=weight_gain)
-        if args.bias_init == "zeros":
-            torch.nn.init.constant_(layer.bias, bias_const)
-
-class Policy(nn.Module):
-    def __init__(self, input_shape, output_shape, env):
-        super(Policy, self).__init__()
-        self.fc1 = nn.Linear(input_shape, 256) # Better result with slightly wider networks.
-        self.fc2 = nn.Linear(256, 128)
-        self.mean = nn.Linear(128, output_shape)
-        self.logstd = nn.Linear(128, output_shape)
+class Actor(nn.Module):
+    def __init__(self, env):
+        super(Actor, self).__init__()
+        self.fc1 = nn.Linear(np.array(env.single_observation_space.shape).prod(), 256)
+        self.fc2 = nn.Linear(256, 256)
+        self.fc_mean = nn.Linear(256, np.prod(env.single_action_space.shape))
+        self.fc_logstd = nn.Linear(256, np.prod(env.single_action_space.shape))
         # action rescaling
         self.action_scale = torch.FloatTensor(
             (env.action_space.high - env.action_space.low) / 2.)
         self.action_bias = torch.FloatTensor(
             (env.action_space.high + env.action_space.low) / 2.)
-        self.apply(layer_init)
 
-    def forward(self, x, device):
-        x = torch.Tensor(x).to(device)
-
+    def forward(self, x):
         x = F.relu(self.fc1(x))
         x = F.relu(self.fc2(x))
-        mean = self.mean(x)
-        log_std = self.logstd(x)
+        mean = self.fc_mean(x)
+        log_std = self.fc_logstd(x)
         log_std = torch.tanh(log_std)
         log_std = LOG_STD_MIN + 0.5 * (LOG_STD_MAX - LOG_STD_MIN) * (log_std + 1) # From SpinUp / Denis Yarats
 
         return mean, log_std
 
-    def get_action(self, x, device):
-        mean, log_std = self.forward(x, device)
+    def get_action(self, x):
+        mean, log_std = self(x)
         std = log_std.exp()
-        normal = Normal(mean, std)
+        normal = torch.distributions.Normal(mean, std)
         x_t = normal.rsample()  # for reparameterization trick (mean + std * N(0,1))
         y_t = torch.tanh(x_t)
         action = y_t * self.action_scale + self.action_bias
@@ -171,158 +146,162 @@ class Policy(nn.Module):
     def to(self, device):
         self.action_scale = self.action_scale.to(device)
         self.action_bias = self.action_bias.to(device)
-        return super(Policy, self).to(device)
+        return super(Actor, self).to(device)
 
-class SoftQNetwork(nn.Module):
-    def __init__(self, input_shape, output_shape, layer_init):
-        super(SoftQNetwork, self).__init__()
-        self.fc1 = nn.Linear(input_shape+output_shape, 256)
-        self.fc2 = nn.Linear(256, 128)
-        self.fc3 = nn.Linear(128, 1)
-        self.apply(layer_init)
+if __name__ == "__main__":
+    args = parse_args()
+    run_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    if args.track:
+        import wandb
 
-    def forward(self, x, a, device):
-        x = torch.Tensor(x).to(device)
-        x = torch.cat([x, a], 1)
-        x = F.relu(self.fc1(x))
-        x = F.relu(self.fc2(x))
-        x = self.fc3(x)
-        return x
+        wandb.init(
+            project=args.wandb_project_name,
+            entity=args.wandb_entity,
+            sync_tensorboard=True,
+            config=vars(args),
+            name=run_name,
+            monitor_gym=True,
+            save_code=True,
+        )
+    writer = SummaryWriter(f"runs/{run_name}")
+    writer.add_text(
+        "hyperparameters",
+        "|param|value|\n|-|-|\n%s" % ("\n".join([f"|{key}|{value}|" for key, value in vars(args).items()])),
+    )
 
-# modified from https://github.com/seungeunrho/minimalRL/blob/master/dqn.py#
-class ReplayBuffer():
-    def __init__(self, buffer_limit):
-        self.buffer = collections.deque(maxlen=buffer_limit)
+    # TRY NOT TO MODIFY: seeding
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.backends.cudnn.deterministic = args.torch_deterministic
 
-    def put(self, transition):
-        self.buffer.append(transition)
+    device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
 
-    def sample(self, n):
-        mini_batch = random.sample(self.buffer, n)
-        s_lst, a_lst, r_lst, s_prime_lst, done_mask_lst = [], [], [], [], []
+    # env setup
+    envs = gym.vector.SyncVectorEnv(
+        [make_env(args.gym_id, 0, 0, args.capture_video, run_name)]
+    )
+    assert isinstance(envs.single_action_space, gym.spaces.Box), "only continuous action space is supported"
 
-        for transition in mini_batch:
-            s, a, r, s_prime, done_mask = transition
-            s_lst.append(s)
-            a_lst.append(a)
-            r_lst.append(r)
-            s_prime_lst.append(s_prime)
-            done_mask_lst.append(done_mask)
+    max_action = float(envs.single_action_space.high[0])
 
-        return np.array(s_lst), np.array(a_lst), \
-               np.array(r_lst), np.array(s_prime_lst), \
-               np.array(done_mask_lst)
+    actor = Actor(envs).to(device)
+    qf1 = SoftQNetwork(envs).to(device)
+    qf2 = SoftQNetwork(envs).to(device)
+    qf1_target = SoftQNetwork(envs).to(device)
+    qf2_target = SoftQNetwork(envs).to(device)
+    qf1_target.load_state_dict(qf1.state_dict())
+    qf2_target.load_state_dict(qf2.state_dict())
+    q_optimizer = optim.Adam(list(qf1.parameters()) + list(qf2.parameters()), lr=args.q_lr)
+    actor_optimizer = optim.Adam(list(actor.parameters()), lr=args.policy_lr)
 
-rb = ReplayBuffer(args.buffer_size)
-pg = Policy(input_shape, output_shape, env).to(device)
-qf1 = SoftQNetwork(input_shape, output_shape, layer_init).to(device)
-qf2 = SoftQNetwork(input_shape, output_shape, layer_init).to(device)
-qf1_target = SoftQNetwork(input_shape, output_shape, layer_init).to(device)
-qf2_target = SoftQNetwork(input_shape, output_shape, layer_init).to(device)
-qf1_target.load_state_dict(qf1.state_dict())
-qf2_target.load_state_dict(qf2.state_dict())
-values_optimizer = optim.Adam(list(qf1.parameters()) + list(qf2.parameters()), lr=args.q_lr)
-policy_optimizer = optim.Adam(list(pg.parameters()), lr=args.policy_lr)
-loss_fn = nn.MSELoss()
-
-# Automatic entropy tuning
-if args.autotune:
-    target_entropy = - torch.prod(torch.Tensor(env.action_space.shape).to(device)).item()
-    log_alpha = torch.zeros(1, requires_grad=True, device=device)
-    alpha = log_alpha.exp().item()
-    a_optimizer = optim.Adam([log_alpha], lr=args.q_lr)
-else:
-    alpha = args.alpha
-
-# TRY NOT TO MODIFY: start the game
-global_episode = 0
-obs, done = env.reset(), False
-episode_reward, episode_length= 0.,0
-
-for global_step in range(1, args.total_timesteps+1):
-    # ALGO LOGIC: put action logic here
-    if global_step < args.learning_starts:
-        action = env.action_space.sample()
+    # Automatic entropy tuning
+    if args.autotune:
+        target_entropy = - torch.prod(torch.Tensor(
+            envs.single_action_space.shape).to(device)).item()
+        log_alpha = torch.zeros(1, requires_grad=True, device=device)
+        alpha = log_alpha.exp().item()
+        a_optimizer = optim.Adam([log_alpha], lr=args.q_lr)
     else:
-        action, _, _ = pg.get_action([obs], device)
-        action = action.tolist()[0]
+        alpha = args.alpha
 
-    # TRY NOT TO MODIFY: execute the game and log data.
-    next_obs, reward, done, _ = env.step(action)
-    rb.put((obs, action, reward, next_obs, done))
-    episode_reward += reward
-    episode_length += 1
-    obs = np.array(next_obs)
+    rb = ReplayBuffer(args.buffer_size, envs.single_observation_space, 
+        envs.single_action_space, device=device, optimize_memory_usage=True)
 
-    # ALGO LOGIC: training.
-    if len(rb.buffer) > args.learning_starts: # starts update as soon as there is enough data.
-        s_obs, s_actions, s_rewards, s_next_obses, s_dones = rb.sample(args.batch_size)
-        with torch.no_grad():
-            next_state_actions, next_state_log_pi, _ = pg.get_action(s_next_obses, device)
-            qf1_next_target = qf1_target.forward(s_next_obses, next_state_actions, device)
-            qf2_next_target = qf2_target.forward(s_next_obses, next_state_actions, device)
-            min_qf_next_target = torch.min(qf1_next_target, qf2_next_target) - alpha * next_state_log_pi
-            next_q_value = torch.Tensor(s_rewards).to(device) + (1 - torch.Tensor(s_dones).to(device)) * args.gamma * (min_qf_next_target).view(-1)
+    # TRY NOT TO MODIFY: start the game
+    obs = envs.reset()
+    for global_step in range(args.total_timesteps):
+        # ALGO LOGIC: put action logic here
+        if global_step < args.learning_starts:
+            actions = envs.action_space.sample()
+        else:
+            actions, _, _ = actor.get_action(torch.Tensor(obs).to(device))
+            actions = actions.detach().cpu().numpy()
+        
+        # TRY NOT TO MODIFY: execute the game and log data.
+        next_obs, rewards, dones, infos = envs.step(actions)
 
-        qf1_a_values = qf1.forward(s_obs, torch.Tensor(s_actions).to(device), device).view(-1)
-        qf2_a_values = qf2.forward(s_obs, torch.Tensor(s_actions).to(device), device).view(-1)
-        qf1_loss = loss_fn(qf1_a_values, next_q_value)
-        qf2_loss = loss_fn(qf2_a_values, next_q_value)
-        qf_loss = (qf1_loss + qf2_loss) / 2
+        # TRY NOT TO MODIFY: record rewards for plotting purposes
+        for info in infos:
+            if "episode" in info.keys():
+                print(f"global_step={global_step}, episode_reward={info['episode']['r']}")
+                writer.add_scalar("charts/episodic_return", info["episode"]["r"], global_step)
+                break
 
-        values_optimizer.zero_grad()
-        qf_loss.backward()
-        values_optimizer.step()
+        # TRY NOT TO MODIFY: save data to reply buffer; handle `terminal_observation`
+        real_next_obs = next_obs.copy()
+        for idx, d in enumerate(dones):
+            if d:
+                real_next_obs[idx] = infos[idx]["terminal_observation"]
+        rb.add(obs, real_next_obs, actions, rewards, dones, infos)
 
-        if global_step % args.policy_frequency == 0: # TD 3 Delayed update support
-            for _ in range(args.policy_frequency): # compensate for the delay by doing 'actor_update_interval' instead of 1
-                pi, log_pi, _ = pg.get_action(s_obs, device)
-                qf1_pi = qf1.forward(s_obs, pi, device)
-                qf2_pi = qf2.forward(s_obs, pi, device)
-                min_qf_pi = torch.min(qf1_pi, qf2_pi).view(-1)
-                policy_loss = ((alpha * log_pi) - min_qf_pi).mean()
+        # TRY NOT TO MODIFY: CRUCIAL step easy to overlook
+        obs = next_obs
+        
+        # ALGO LOGIC: training.
+        if global_step > args.learning_starts:
+            data = rb.sample(args.batch_size)
+            with torch.no_grad():
+                next_state_actions, next_state_log_pi, _ = \
+                    actor.get_action(data.next_observations)
+                qf1_next_target = qf1_target(data.next_observations, next_state_actions)
+                qf2_next_target = qf2_target(data.next_observations, next_state_actions)
+                min_qf_next_target = torch.min(qf1_next_target, qf2_next_target) - \
+                    alpha * next_state_log_pi
+                next_q_value = data.rewards.flatten() + (1 - data.dones.flatten()) * args.gamma * (min_qf_next_target).view(-1)
+            
+            # NOTE: other potential refactors
+            # 1. using qf1() instead, which calls forward() by default
+            # 2. use F.mse_loss() instead of loss_fn = nn.MSELoss()
+            qf1_a_values = qf1(data.observations, data.actions).view(-1)
+            qf2_a_values = qf2(data.observations, data.actions).view(-1)
+            qf1_loss = F.mse_loss(qf1_a_values, next_q_value)
+            qf2_loss = F.mse_loss(qf2_a_values, next_q_value)
+            qf_loss = (qf1_loss + qf2_loss) / 2
 
-                policy_optimizer.zero_grad()
-                policy_loss.backward()
-                policy_optimizer.step()
+            q_optimizer.zero_grad()
+            qf_loss.backward()
+            nn.utils.clip_grad_norm_(list(qf1.parameters())+list(qf2.parameters()), args.max_grad_norm)
+            q_optimizer.step()
 
+            if global_step % args.policy_frequency == 0: # TD 3 Delayed update support
+                for _ in range(args.policy_frequency): # compensate for the delay by doing 'actor_update_interval' instead of 1
+                    pi, log_pi, _ = actor.get_action(data.observations)
+                    qf1_pi = qf1(data.observations, pi)
+                    qf2_pi = qf2(data.observations, pi)
+                    min_qf_pi = torch.min(qf1_pi, qf2_pi).view(-1)
+                    actor_loss = ((alpha * log_pi) - min_qf_pi).mean()
+
+                    actor_optimizer.zero_grad()
+                    actor_loss.backward()
+                    nn.utils.clip_grad_norm_(list(actor.parameters()), args.max_grad_norm)
+                    actor_optimizer.step()
+
+                    if args.autotune:
+                        with torch.no_grad():
+                            _, log_pi, _ = actor.get_action(data.observations)
+                        alpha_loss = ( -log_alpha * (log_pi + target_entropy)).mean()
+
+                        a_optimizer.zero_grad()
+                        alpha_loss.backward()
+                        a_optimizer.step()
+                        alpha = log_alpha.exp().item()
+            
+            # update the target networks
+            if global_step % args.target_network_frequency == 0:
+                for param, target_param in zip(qf1.parameters(), qf1_target.parameters()):
+                    target_param.data.copy_(args.tau * param.data + (1 - args.tau) * target_param.data)
+                for param, target_param in zip(qf2.parameters(), qf2_target.parameters()):
+                    target_param.data.copy_(args.tau * param.data + (1 - args.tau) * target_param.data)
+            
+            if global_step % 100 == 0:
+                writer.add_scalar("losses/qf1_loss", qf1_loss.item(), global_step)
+                writer.add_scalar("losses/qf2_loss", qf2_loss.item(), global_step)
+                writer.add_scalar("losses/qf_loss", qf_loss.item(), global_step)
+                writer.add_scalar("losses/actor_loss", actor_loss.item(), global_step)
+                writer.add_scalar("losses/alpha", alpha, global_step)
                 if args.autotune:
-                    with torch.no_grad():
-                        _, log_pi, _ = pg.get_action(s_obs, device)
-                    alpha_loss = ( -log_alpha * (log_pi + target_entropy)).mean()
+                    writer.add_scalar("losses/alpha_loss", alpha_loss.item(), global_step)
 
-                    a_optimizer.zero_grad()
-                    alpha_loss.backward()
-                    a_optimizer.step()
-                    alpha = log_alpha.exp().item()
-
-        # update the target network
-        if global_step % args.target_network_frequency == 0:
-            for param, target_param in zip(qf1.parameters(), qf1_target.parameters()):
-                target_param.data.copy_(args.tau * param.data + (1 - args.tau) * target_param.data)
-            for param, target_param in zip(qf2.parameters(), qf2_target.parameters()):
-                target_param.data.copy_(args.tau * param.data + (1 - args.tau) * target_param.data)
-
-    if len(rb.buffer) > args.learning_starts and global_step % 100 == 0:
-        writer.add_scalar("losses/soft_q_value_1_loss", qf1_loss.item(), global_step)
-        writer.add_scalar("losses/soft_q_value_2_loss", qf2_loss.item(), global_step)
-        writer.add_scalar("losses/qf_loss", qf_loss.item(), global_step)
-        writer.add_scalar("losses/policy_loss", policy_loss.item(), global_step)
-        writer.add_scalar("losses/alpha", alpha, global_step)
-        if args.autotune:
-            writer.add_scalar("losses/alpha_loss", alpha_loss.item(), global_step)
-    
-    if done:
-        global_episode += 1 # Outside the loop already means the epsiode is done
-        writer.add_scalar("charts/episodic_return", episode_reward, global_step)
-        writer.add_scalar("charts/episode_length", episode_length, global_step)
-        # Terminal verbosity
-        if global_episode % 10 == 0:
-            print(f"global_step={global_step}, episode_reward={episode_reward}")
-
-        # Reseting what need to be
-        obs, done = env.reset(), False
-        episode_reward, episode_length = 0., 0
-
-writer.close()
-env.close()
+    envs.close()
+    writer.close()

--- a/cleanrl/td3_continuous_action.py
+++ b/cleanrl/td3_continuous_action.py
@@ -198,42 +198,6 @@ if __name__ == "__main__":
         if global_step > args.learning_starts:
             data = rb.sample(args.batch_size)
             with torch.no_grad():
-                next_state_actions = (
-                    target_actor.forward(data.next_observations)
-                ).clamp(envs.single_action_space.low[0], envs.single_action_space.high[0])
-                qf1_next_target = qf1_target.forward(data.next_observations, next_state_actions)
-                next_q_value = data.rewards.flatten() + (1 - data.dones.flatten()) * args.gamma * (qf1_next_target).view(-1)
-
-            qf1_a_values = qf1.forward(data.observations, data.actions).view(-1)
-            qf1_loss = loss_fn(qf1_a_values, next_q_value)
-
-            # optimize the midel
-            q_optimizer.zero_grad()
-            qf1_loss.backward()
-            nn.utils.clip_grad_norm_(list(qf1.parameters()), args.max_grad_norm)
-            q_optimizer.step()
-
-            if global_step % args.policy_frequency == 0:
-                actor_loss = -qf1.forward(data.observations, actor.forward(data.observations)).mean()
-                actor_optimizer.zero_grad()
-                actor_loss.backward()
-                nn.utils.clip_grad_norm_(list(actor.parameters()), args.max_grad_norm)
-                actor_optimizer.step()
-
-                # update the target network
-                for param, target_param in zip(actor.parameters(), target_actor.parameters()):
-                    target_param.data.copy_(args.tau * param.data + (1 - args.tau) * target_param.data)
-                for param, target_param in zip(qf1.parameters(), qf1_target.parameters()):
-                    target_param.data.copy_(args.tau * param.data + (1 - args.tau) * target_param.data)
-
-            if global_step % 100 == 0:
-                writer.add_scalar("losses/qf1_loss", qf1_loss.item(), global_step)
-                writer.add_scalar("losses/actor_loss", actor_loss.item(), global_step)
-
-
-
-
-            with torch.no_grad():
                 clipped_noise = (
                     torch.randn_like(torch.Tensor(actions[0])) * args.policy_noise
                 ).clamp(-args.noise_clip, args.noise_clip)
@@ -251,7 +215,7 @@ if __name__ == "__main__":
             qf1_loss = loss_fn(qf1_a_values, next_q_value)
             qf2_loss = loss_fn(qf2_a_values, next_q_value)
 
-            # optimize the midel
+            # optimize the model
             q_optimizer.zero_grad()
             qf1_loss.backward()
             qf2_loss.backward()

--- a/cleanrl/td3_continuous_action.py
+++ b/cleanrl/td3_continuous_action.py
@@ -6,7 +6,7 @@ from distutils.util import strtobool
 
 import gym
 import numpy as np
-# import pybullet_envs  # noqa
+import pybullet_envs  # noqa
 import torch
 import torch.nn as nn
 import torch.optim as optim

--- a/cleanrl/td3_continuous_action.py
+++ b/cleanrl/td3_continuous_action.py
@@ -1,139 +1,96 @@
-# Reference: https://arxiv.org/pdf/1509.02971.pdf
-# https://github.com/seungeunrho/minimalRL/blob/master/ddpg.py
-# https://github.com/openai/spinningup/blob/master/spinup/algos/pytorch/ddpg/ddpg.py
+import argparse
+import os
+import random
+import time
+from distutils.util import strtobool
 
+import gym
+import numpy as np
+# import pybullet_envs  # noqa
 import torch
 import torch.nn as nn
 import torch.optim as optim
 import torch.nn.functional as F
 from torch.utils.tensorboard import SummaryWriter
+from stable_baselines3.common.buffers import ReplayBuffer
 
-import argparse
-from distutils.util import strtobool
-import collections
-import numpy as np
-import gym
-import pybullet_envs
-from gym.wrappers import TimeLimit, Monitor
-from gym.spaces import Discrete, Box, MultiBinary, MultiDiscrete, Space
-import time
-import random
-import os
+def parse_args():
+    # fmt: off
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
+        help="the name of this experiment")
+    parser.add_argument("--gym-id", type=str, default="HopperBulletEnv-v0",
+        help="the id of the gym environment")
+    parser.add_argument("--learning-rate", type=float, default=3e-4,
+        help="the learning rate of the optimizer")
+    parser.add_argument("--seed", type=int, default=1,
+        help="seed of the experiment")
+    parser.add_argument("--total-timesteps", type=int, default=1000000,
+        help="total timesteps of the experiments")
+    parser.add_argument("--torch-deterministic", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
+        help="if toggled, `torch.backends.cudnn.deterministic=False`")
+    parser.add_argument("--cuda", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
+        help="if toggled, cuda will be enabled by default")
+    parser.add_argument("--track", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="if toggled, this experiment will be tracked with Weights and Biases")
+    parser.add_argument("--wandb-project-name", type=str, default="cleanRL",
+        help="the wandb's project name")
+    parser.add_argument("--wandb-entity", type=str, default=None,
+        help="the entity (team) of wandb's project")
+    parser.add_argument("--capture-video", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="weather to capture videos of the agent performances (check out `videos` folder)")
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='TD3 agent')
-    # Common arguments
-    parser.add_argument('--exp-name', type=str, default=os.path.basename(__file__).rstrip(".py"),
-                        help='the name of this experiment')
-    parser.add_argument('--gym-id', type=str, default="HopperBulletEnv-v0",
-                        help='the id of the gym environment')
-    parser.add_argument('--learning-rate', type=float, default=3e-4,
-                        help='the learning rate of the optimizer')
-    parser.add_argument('--seed', type=int, default=1,
-                        help='seed of the experiment')
-    parser.add_argument('--episode-length', type=int, default=0,
-                        help='the maximum length of each episode')
-    parser.add_argument('--total-timesteps', type=int, default=1000000,
-                        help='total timesteps of the experiments')
-    parser.add_argument('--torch-deterministic', type=lambda x:bool(strtobool(x)), default=True, nargs='?', const=True,
-                        help='if toggled, `torch.backends.cudnn.deterministic=False`')
-    parser.add_argument('--cuda', type=lambda x:bool(strtobool(x)), default=True, nargs='?', const=True,
-                        help='if toggled, cuda will not be enabled by default')
-    parser.add_argument('--track', type=lambda x:bool(strtobool(x)), default=False, nargs='?', const=True,
-                        help='run the script in production mode and use wandb to log outputs')
-    parser.add_argument('--capture-video', type=lambda x:bool(strtobool(x)), default=False, nargs='?', const=True,
-                        help='weather to capture videos of the agent performances (check out `videos` folder)')
-    parser.add_argument('--wandb-project-name', type=str, default="cleanRL",
-                        help="the wandb's project name")
-    parser.add_argument('--wandb-entity', type=str, default=None,
-                        help="the entity (team) of wandb's project")
-    
     # Algorithm specific arguments
-    parser.add_argument('--buffer-size', type=int, default=int(1e6),
-                         help='the replay memory buffer size')
-    parser.add_argument('--gamma', type=float, default=0.99,
-                        help='the discount factor gamma')
-    parser.add_argument('--tau', type=float, default=0.005,
-                        help="target smoothing coefficient (default: 0.005)")
-    parser.add_argument('--max-grad-norm', type=float, default=0.5,
-                        help='the maximum norm for the gradient clipping')
-    parser.add_argument('--batch-size', type=int, default=256,
-                        help="the batch size of sample from the reply memory")
-    parser.add_argument('--policy-noise', type=float, default=0.2,
-                        help='the scale of policy noise')
-    parser.add_argument('--exploration-noise', type=float, default=0.1,
-                        help='the scale of exploration noise')
-    parser.add_argument('--learning-starts', type=int, default=25e3,
-                        help="timestep to start learning")
-    parser.add_argument('--policy-frequency', type=int, default=2,
-                        help="the frequency of training policy (delayed)")
-    parser.add_argument('--noise-clip', type=float, default=0.5,
-                         help='noise clip parameter of the Target Policy Smoothing Regularization')
+    parser.add_argument("--buffer-size", type=int, default=int(1e6),
+        help="the replay memory buffer size")
+    parser.add_argument("--gamma", type=float, default=0.99,
+        help="the discount factor gamma")
+    parser.add_argument("--tau", type=float, default=0.005,
+        help="target smoothing coefficient (default: 0.005)")
+    parser.add_argument("--max-grad-norm", type=float, default=0.5,
+        help="the maximum norm for the gradient clipping")
+    parser.add_argument("--batch-size", type=int, default=256,
+        help="the batch size of sample from the reply memory")
+    parser.add_argument("--policy-noise", type=float, default=0.2,
+        help="the scale of policy noise")
+    parser.add_argument("--exploration-noise", type=float, default=0.1,
+        help="the scale of exploration noise")
+    parser.add_argument("--learning-starts", type=int, default=25e3,
+        help="timestep to start learning")
+    parser.add_argument("--policy-frequency", type=int, default=2,
+        help="the frequency of training policy (delayed)")
+    parser.add_argument("--noise-clip", type=float, default=0.5,
+        help="noise clip parameter of the Target Policy Smoothing Regularization")
     args = parser.parse_args()
-    if not args.seed:
-        args.seed = int(time.time())
-
-# TRY NOT TO MODIFY: setup the environment
-experiment_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
-writer = SummaryWriter(f"runs/{experiment_name}")
-writer.add_text('hyperparameters', "|param|value|\n|-|-|\n%s" % (
-        '\n'.join([f"|{key}|{value}|" for key, value in vars(args).items()])))
-if args.track:
-    import wandb
-    wandb.init(project=args.wandb_project_name, entity=args.wandb_entity, sync_tensorboard=True, config=vars(args), name=experiment_name, monitor_gym=True, save_code=True)
-    writer = SummaryWriter(f"/tmp/{experiment_name}")
+    # fmt: on
+    return args
 
 
-# TRY NOT TO MODIFY: seeding
-device = torch.device('cuda' if torch.cuda.is_available() and args.cuda else 'cpu')
-env = gym.make(args.gym_id)
-random.seed(args.seed)
-np.random.seed(args.seed)
-torch.manual_seed(args.seed)
-torch.backends.cudnn.deterministic = args.torch_deterministic
-env.seed(args.seed)
-env.action_space.seed(args.seed)
-env.observation_space.seed(args.seed)
-# respect the default timelimit
-assert isinstance(env.action_space, Box), "only continuous action space is supported"
-if args.capture_video:
-    env = Monitor(env, f'videos/{experiment_name}')
+def make_env(gym_id, seed, idx, capture_video, run_name):
+    def thunk():
+        env = gym.make(gym_id)
+        env = gym.wrappers.RecordEpisodeStatistics(env)
+        if capture_video:
+            if idx == 0:
+                env = gym.wrappers.RecordVideo(env, f"videos/{run_name}")
+        env.seed(seed)
+        env.action_space.seed(seed)
+        env.observation_space.seed(seed)
+        return env
 
-# modified from https://github.com/seungeunrho/minimalRL/blob/master/dqn.py#
-class ReplayBuffer():
-    def __init__(self, buffer_limit):
-        self.buffer = collections.deque(maxlen=buffer_limit)
-    
-    def put(self, transition):
-        self.buffer.append(transition)
-    
-    def sample(self, n):
-        mini_batch = random.sample(self.buffer, n)
-        s_lst, a_lst, r_lst, s_prime_lst, done_mask_lst = [], [], [], [], []
-        
-        for transition in mini_batch:
-            s, a, r, s_prime, done_mask = transition
-            s_lst.append(s)
-            a_lst.append(a)
-            r_lst.append(r)
-            s_prime_lst.append(s_prime)
-            done_mask_lst.append(done_mask)
+    return thunk
 
-        return np.array(s_lst), np.array(a_lst), \
-               np.array(r_lst), np.array(s_prime_lst), \
-               np.array(done_mask_lst)
 
 # ALGO LOGIC: initialize agent here:
 class QNetwork(nn.Module):
     def __init__(self, env):
         super(QNetwork, self).__init__()
         self.fc1 = nn.Linear(
-            np.array(env.observation_space.shape).prod()+np.prod(env.action_space.shape), 256)
+            np.array(env.single_observation_space.shape).prod()+np.prod(env.single_action_space.shape), 256)
         self.fc2 = nn.Linear(256, 256)
         self.fc3 = nn.Linear(256, 1)
 
-    def forward(self, x, a, device):
-        x = torch.Tensor(x).to(device)
+    def forward(self, x, a):
         x = torch.cat([x, a], 1)
         x = F.relu(self.fc1(x))
         x = F.relu(self.fc2(x))
@@ -143,109 +100,182 @@ class QNetwork(nn.Module):
 class Actor(nn.Module):
     def __init__(self, env):
         super(Actor, self).__init__()
-        self.fc1 = nn.Linear(np.array(env.observation_space.shape).prod(), 256)
+        self.fc1 = nn.Linear(np.array(env.single_observation_space.shape).prod(), 256)
         self.fc2 = nn.Linear(256, 256)
-        self.fc_mu = nn.Linear(256, np.prod(env.action_space.shape))
+        self.fc_mu = nn.Linear(256, np.prod(env.single_action_space.shape))
 
-    def forward(self, x, device):
-        x = torch.Tensor(x).to(device)
+    def forward(self, x):
         x = F.relu(self.fc1(x))
         x = F.relu(self.fc2(x))
         return torch.tanh(self.fc_mu(x))
 
-def linear_schedule(start_sigma: float, end_sigma: float, duration: int, t: int):
-    slope =  (end_sigma - start_sigma) / duration
-    return max(slope * t + start_sigma, end_sigma)
 
-max_action = float(env.action_space.high[0])
-rb = ReplayBuffer(args.buffer_size)
-actor = Actor(env).to(device)
-qf1 = QNetwork(env).to(device)
-qf2 = QNetwork(env).to(device)
-qf1_target = QNetwork(env).to(device)
-qf2_target = QNetwork(env).to(device)
-target_actor = Actor(env).to(device)
-target_actor.load_state_dict(actor.state_dict())
-qf1_target.load_state_dict(qf1.state_dict())
-qf2_target.load_state_dict(qf2.state_dict())
-q_optimizer = optim.Adam(list(qf1.parameters()) + list(qf2.parameters()), lr=args.learning_rate)
-actor_optimizer = optim.Adam(list(actor.parameters()), lr=args.learning_rate)
-loss_fn = nn.MSELoss()
-# TRY NOT TO MODIFY: start the game
-obs = env.reset()
-episode_reward = 0
+if __name__ == "__main__":
+    args = parse_args()
+    run_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    if args.track:
+        import wandb
 
-for global_step in range(args.total_timesteps):
-    # ALGO LOGIC: put action logic here
-    if global_step < args.learning_starts:
-        action = env.action_space.sample()
-    else:
-        action = actor.forward(obs.reshape((1,)+obs.shape), device)
-        action = (
-            action.tolist()[0]
-            + np.random.normal(0, max_action * args.exploration_noise, size=env.action_space.shape[0])
-        ).clip(env.action_space.low, env.action_space.high)
+        wandb.init(
+            project=args.wandb_project_name,
+            entity=args.wandb_entity,
+            sync_tensorboard=True,
+            config=vars(args),
+            name=run_name,
+            monitor_gym=True,
+            save_code=True,
+        )
+    writer = SummaryWriter(f"runs/{run_name}")
+    writer.add_text(
+        "hyperparameters",
+        "|param|value|\n|-|-|\n%s" % ("\n".join([f"|{key}|{value}|" for key, value in vars(args).items()])),
+    )
 
-    # TRY NOT TO MODIFY: execute the game and log data.
-    next_obs, reward, done, info = env.step(action)
-    episode_reward += reward
-    
-    # ALGO LOGIC: training.
-    rb.put((obs, action, reward, next_obs, done))
-    if global_step > args.learning_starts:
-        s_obs, s_actions, s_rewards, s_next_obses, s_dones = rb.sample(args.batch_size)
-        with torch.no_grad():
-            clipped_noise = (
-				torch.randn_like(torch.Tensor(action)) * args.policy_noise
-			).clamp(-args.noise_clip, args.noise_clip)
+    # TRY NOT TO MODIFY: seeding
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.backends.cudnn.deterministic = args.torch_deterministic
 
-            next_state_actions = (
-                target_actor.forward(s_next_obses, device) + clipped_noise.to(device)
-            ).clamp(env.action_space.low[0], env.action_space.high[0])
-            qf1_next_target = qf1_target.forward(s_next_obses, next_state_actions, device)
-            qf2_next_target = qf2_target.forward(s_next_obses, next_state_actions, device)
-            min_qf_next_target = torch.min(qf1_next_target, qf2_next_target)
-            next_q_value = torch.Tensor(s_rewards).to(device) + (1 - torch.Tensor(s_dones).to(device)) * args.gamma * (min_qf_next_target).view(-1)
+    device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
 
-        qf1_a_values = qf1.forward(s_obs, torch.Tensor(s_actions).to(device), device).view(-1)
-        qf2_a_values = qf2.forward(s_obs, torch.Tensor(s_actions).to(device), device).view(-1)
-        qf1_loss = loss_fn(qf1_a_values, next_q_value)
-        qf2_loss = loss_fn(qf2_a_values, next_q_value)
+    # env setup
+    envs = gym.vector.SyncVectorEnv(
+        [make_env(args.gym_id, 0, 0, args.capture_video, run_name)]
+    )
+    assert isinstance(envs.single_action_space, gym.spaces.Box), "only continuous action space is supported"
 
-        # optimize the midel
-        q_optimizer.zero_grad()
-        qf1_loss.backward()
-        qf2_loss.backward()
-        nn.utils.clip_grad_norm_(list(qf1.parameters())+list(qf2.parameters()), args.max_grad_norm)
-        q_optimizer.step()
+    max_action = float(envs.single_action_space.high[0])
+    actor = Actor(envs).to(device)
+    qf1 = QNetwork(envs).to(device)
+    qf2 = QNetwork(envs).to(device)
+    qf1_target = QNetwork(envs).to(device)
+    qf2_target = QNetwork(envs).to(device)
+    target_actor = Actor(envs).to(device)
+    target_actor.load_state_dict(actor.state_dict())
+    qf1_target.load_state_dict(qf1.state_dict())
+    qf2_target.load_state_dict(qf2.state_dict())
+    q_optimizer = optim.Adam(list(qf1.parameters()) + list(qf2.parameters()), lr=args.learning_rate)
+    actor_optimizer = optim.Adam(list(actor.parameters()), lr=args.learning_rate)
 
-        if global_step % args.policy_frequency == 0:
-            actor_loss = -qf1.forward(s_obs, actor.forward(s_obs, device), device).mean()
-            actor_optimizer.zero_grad()
-            actor_loss.backward()
-            nn.utils.clip_grad_norm_(list(actor.parameters()), args.max_grad_norm)
-            actor_optimizer.step()
+    rb = ReplayBuffer(args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device, optimize_memory_usage=True)
+    loss_fn = nn.MSELoss()
 
-            # update the target network
-            for param, target_param in zip(actor.parameters(), target_actor.parameters()):
-                target_param.data.copy_(args.tau * param.data + (1 - args.tau) * target_param.data)
-            for param, target_param in zip(qf1.parameters(), qf1_target.parameters()):
-                target_param.data.copy_(args.tau * param.data + (1 - args.tau) * target_param.data)
-            for param, target_param in zip(qf2.parameters(), qf2_target.parameters()):
-                target_param.data.copy_(args.tau * param.data + (1 - args.tau) * target_param.data)
+    # TRY NOT TO MODIFY: start the game
+    obs = envs.reset()
+    for global_step in range(args.total_timesteps):
+        # ALGO LOGIC: put action logic here
+        if global_step < args.learning_starts:
+            actions = envs.action_space.sample()
+        else:
+            actions = actor.forward(torch.Tensor(obs).to(device))
+            actions = np.array([(
+                actions.tolist()[0]
+                + np.random.normal(0, max_action * args.exploration_noise, size=envs.action_space.shape[0])
+            ).clip(envs.single_action_space.low, envs.single_action_space.high)])
 
-        if global_step % 100 == 0:
-            writer.add_scalar("losses/qf1_loss", qf1_loss.item(), global_step)
-            writer.add_scalar("losses/actor_loss", actor_loss.item(), global_step)
+        # TRY NOT TO MODIFY: execute the game and log data.
+        next_obs, rewards, dones, infos = envs.step(actions)
 
-    # TRY NOT TO MODIFY: CRUCIAL step easy to overlook 
-    obs = next_obs
-
-    if done:
         # TRY NOT TO MODIFY: record rewards for plotting purposes
-        print(f"global_step={global_step}, episode_reward={episode_reward}")
-        writer.add_scalar("charts/episodic_return", episode_reward, global_step)
-        obs, episode_reward = env.reset(), 0
+        for info in infos:
+            if "episode" in info.keys():
+                print(f"global_step={global_step}, episode_reward={info['episode']['r']}")
+                writer.add_scalar("charts/episodic_return", info["episode"]["r"], global_step)
+                break
 
-env.close()
-writer.close()
+        # TRY NOT TO MODIFY: save data to reply buffer; handle `terminal_observation`
+        real_next_obs = next_obs.copy()
+        for idx, d in enumerate(dones):
+            if d:
+                real_next_obs[idx] = infos[idx]["terminal_observation"]
+        rb.add(obs, real_next_obs, actions, rewards, dones, infos)
+
+        # TRY NOT TO MODIFY: CRUCIAL step easy to overlook
+        obs = next_obs
+
+        # ALGO LOGIC: training.
+        if global_step > args.learning_starts:
+            data = rb.sample(args.batch_size)
+            with torch.no_grad():
+                next_state_actions = (
+                    target_actor.forward(data.next_observations)
+                ).clamp(envs.single_action_space.low[0], envs.single_action_space.high[0])
+                qf1_next_target = qf1_target.forward(data.next_observations, next_state_actions)
+                next_q_value = data.rewards.flatten() + (1 - data.dones.flatten()) * args.gamma * (qf1_next_target).view(-1)
+
+            qf1_a_values = qf1.forward(data.observations, data.actions).view(-1)
+            qf1_loss = loss_fn(qf1_a_values, next_q_value)
+
+            # optimize the midel
+            q_optimizer.zero_grad()
+            qf1_loss.backward()
+            nn.utils.clip_grad_norm_(list(qf1.parameters()), args.max_grad_norm)
+            q_optimizer.step()
+
+            if global_step % args.policy_frequency == 0:
+                actor_loss = -qf1.forward(data.observations, actor.forward(data.observations)).mean()
+                actor_optimizer.zero_grad()
+                actor_loss.backward()
+                nn.utils.clip_grad_norm_(list(actor.parameters()), args.max_grad_norm)
+                actor_optimizer.step()
+
+                # update the target network
+                for param, target_param in zip(actor.parameters(), target_actor.parameters()):
+                    target_param.data.copy_(args.tau * param.data + (1 - args.tau) * target_param.data)
+                for param, target_param in zip(qf1.parameters(), qf1_target.parameters()):
+                    target_param.data.copy_(args.tau * param.data + (1 - args.tau) * target_param.data)
+
+            if global_step % 100 == 0:
+                writer.add_scalar("losses/qf1_loss", qf1_loss.item(), global_step)
+                writer.add_scalar("losses/actor_loss", actor_loss.item(), global_step)
+
+
+
+
+            with torch.no_grad():
+                clipped_noise = (
+                    torch.randn_like(torch.Tensor(actions[0])) * args.policy_noise
+                ).clamp(-args.noise_clip, args.noise_clip)
+
+                next_state_actions = (
+                    target_actor.forward(data.next_observations) + clipped_noise.to(device)
+                ).clamp(envs.single_action_space.low[0], envs.single_action_space.high[0])
+                qf1_next_target = qf1_target.forward(data.next_observations, next_state_actions)
+                qf2_next_target = qf2_target.forward(data.next_observations, next_state_actions)
+                min_qf_next_target = torch.min(qf1_next_target, qf2_next_target)
+                next_q_value = data.rewards.flatten() + (1 - data.dones.flatten()) * args.gamma * (min_qf_next_target).view(-1)
+
+            qf1_a_values = qf1.forward(data.observations, data.actions).view(-1)
+            qf2_a_values = qf2.forward(data.observations, data.actions).view(-1)
+            qf1_loss = loss_fn(qf1_a_values, next_q_value)
+            qf2_loss = loss_fn(qf2_a_values, next_q_value)
+
+            # optimize the midel
+            q_optimizer.zero_grad()
+            qf1_loss.backward()
+            qf2_loss.backward()
+            nn.utils.clip_grad_norm_(list(qf1.parameters())+list(qf2.parameters()), args.max_grad_norm)
+            q_optimizer.step()
+
+            if global_step % args.policy_frequency == 0:
+                actor_loss = -qf1.forward(data.observations, actor.forward(data.observations)).mean()
+                actor_optimizer.zero_grad()
+                actor_loss.backward()
+                nn.utils.clip_grad_norm_(list(actor.parameters()), args.max_grad_norm)
+                actor_optimizer.step()
+
+                # update the target network
+                for param, target_param in zip(actor.parameters(), target_actor.parameters()):
+                    target_param.data.copy_(args.tau * param.data + (1 - args.tau) * target_param.data)
+                for param, target_param in zip(qf1.parameters(), qf1_target.parameters()):
+                    target_param.data.copy_(args.tau * param.data + (1 - args.tau) * target_param.data)
+                for param, target_param in zip(qf2.parameters(), qf2_target.parameters()):
+                    target_param.data.copy_(args.tau * param.data + (1 - args.tau) * target_param.data)
+
+            if global_step % 100 == 0:
+                writer.add_scalar("losses/qf1_loss", qf1_loss.item(), global_step)
+                writer.add_scalar("losses/actor_loss", actor_loss.item(), global_step)
+
+    envs.close()
+    writer.close()

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,10 +1,10 @@
 [[package]]
 name = "absl-py"
-version = "0.15.0"
+version = "1.0.0"
 description = "Abseil Python Common Libraries, see https://github.com/abseil/abseil-py."
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [package.dependencies]
 six = "*"
@@ -53,22 +53,8 @@ optional = true
 python-versions = "*"
 
 [[package]]
-name = "argcomplete"
-version = "1.12.3"
-description = "Bash tab completion for argparse"
-category = "main"
-optional = true
-python-versions = "*"
-
-[package.dependencies]
-importlib-metadata = {version = ">=0.23,<5", markers = "python_version == \"3.7\""}
-
-[package.extras]
-test = ["coverage", "flake8", "pexpect", "wheel"]
-
-[[package]]
 name = "arrow"
-version = "1.2.1"
+version = "1.2.2"
 description = "Better dates & times for Python"
 category = "main"
 optional = true
@@ -102,17 +88,17 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "attrs"
-version = "21.2.0"
+version = "21.4.0"
 description = "Classes Without Boilerplate"
 category = "main"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
 docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
 name = "autopep8"
@@ -163,14 +149,14 @@ tests = ["ale-py", "multi-agent-ale-py"]
 
 [[package]]
 name = "awscli"
-version = "1.21.12"
+version = "1.22.45"
 description = "Universal Command Line Environment for AWS."
 category = "main"
 optional = true
 python-versions = ">= 3.6"
 
 [package.dependencies]
-botocore = "1.22.12"
+botocore = "1.23.45"
 colorama = ">=0.2.5,<0.4.4"
 docutils = ">=0.10,<0.16"
 PyYAML = ">=3.10,<5.5"
@@ -225,7 +211,7 @@ chardet = ">=3.0.2"
 
 [[package]]
 name = "black"
-version = "21.10b0"
+version = "21.12b0"
 description = "The uncompromising code formatter."
 category = "main"
 optional = true
@@ -236,9 +222,8 @@ click = ">=7.1.2"
 mypy-extensions = ">=0.4.3"
 pathspec = ">=0.9.0,<1"
 platformdirs = ">=2"
-regex = ">=2020.1.8"
 tomli = ">=0.2.6,<2.0.0"
-typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\""}
+typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implementation_name == \"cpython\""}
 typing-extensions = ">=3.10.0.0"
 
 [package.extras]
@@ -263,14 +248,14 @@ webencodings = "*"
 
 [[package]]
 name = "boto3"
-version = "1.19.12"
+version = "1.20.45"
 description = "The AWS SDK for Python"
 category = "main"
 optional = true
 python-versions = ">= 3.6"
 
 [package.dependencies]
-botocore = ">=1.22.12,<1.23.0"
+botocore = ">=1.23.45,<1.24.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.5.0,<0.6.0"
 
@@ -279,7 +264,7 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.22.12"
+version = "1.23.45"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = true
@@ -295,11 +280,11 @@ crt = ["awscrt (==0.12.5)"]
 
 [[package]]
 name = "cachetools"
-version = "4.2.4"
+version = "5.0.0"
 description = "Extensible memoizing collections and decorators"
 category = "main"
 optional = false
-python-versions = "~=3.5"
+python-versions = "~=3.7"
 
 [[package]]
 name = "certifi"
@@ -330,7 +315,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "charset-normalizer"
-version = "2.0.7"
+version = "2.0.10"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
 optional = false
@@ -369,7 +354,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "configparser"
-version = "5.1.0"
+version = "5.2.0"
 description = "Updated configparser from Python 3.8 for Python 2.6+."
 category = "main"
 optional = false
@@ -377,7 +362,7 @@ python-versions = ">=3.6"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-black (>=0.3.7)", "pytest-mypy"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "types-backports", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [[package]]
 name = "cookiecutter"
@@ -399,7 +384,7 @@ six = ">=1.10"
 
 [[package]]
 name = "cryptography"
-version = "35.0.0"
+version = "36.0.1"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "main"
 optional = true
@@ -410,7 +395,7 @@ cffi = ">=1.12"
 
 [package.extras]
 docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx-rtd-theme"]
-docstest = ["doc8", "pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
+docstest = ["pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
 pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
 sdist = ["setuptools_rust (>=0.11.4)"]
 ssh = ["bcrypt (>=3.1.5)"]
@@ -426,7 +411,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "cython"
-version = "0.29.24"
+version = "0.29.26"
 description = "The Cython compiler for writing C extensions for the Python language."
 category = "main"
 optional = true
@@ -442,7 +427,7 @@ python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
 
 [[package]]
 name = "decorator"
-version = "5.1.0"
+version = "5.1.1"
 description = "Decorators for Humans"
 category = "main"
 optional = true
@@ -505,11 +490,11 @@ six = "*"
 
 [[package]]
 name = "filelock"
-version = "3.3.2"
+version = "3.4.2"
 description = "A platform independent file lock."
 category = "main"
 optional = true
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.extras]
 docs = ["furo (>=2021.8.17b43)", "sphinx (>=4.1)", "sphinx-autodoc-typehints (>=1.12)"]
@@ -528,6 +513,27 @@ importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 mccabe = ">=0.6.0,<0.7.0"
 pycodestyle = ">=2.7.0,<2.8.0"
 pyflakes = ">=2.3.0,<2.4.0"
+
+[[package]]
+name = "fonttools"
+version = "4.29.0"
+description = "Tools to manipulate font files"
+category = "main"
+optional = true
+python-versions = ">=3.7"
+
+[package.extras]
+all = ["fs (>=2.2.0,<3)", "lxml (>=4.0,<5)", "zopfli (>=0.1.4)", "lz4 (>=1.7.4.2)", "matplotlib", "sympy", "skia-pathops (>=0.5.0)", "brotlicffi (>=0.8.0)", "scipy", "brotli (>=1.0.1)", "munkres", "unicodedata2 (>=14.0.0)", "xattr"]
+graphite = ["lz4 (>=1.7.4.2)"]
+interpolatable = ["scipy", "munkres"]
+lxml = ["lxml (>=4.0,<5)"]
+pathops = ["skia-pathops (>=0.5.0)"]
+plot = ["matplotlib"]
+symfont = ["sympy"]
+type1 = ["xattr"]
+ufo = ["fs (>=2.2.0,<3)"]
+unicode = ["unicodedata2 (>=14.0.0)"]
+woff = ["zopfli (>=0.1.4)", "brotlicffi (>=0.8.0)", "brotli (>=1.0.1)"]
 
 [[package]]
 name = "free-mujoco-py"
@@ -572,7 +578,7 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.24"
+version = "3.1.26"
 description = "GitPython is a python library used to interact with Git repositories"
 category = "main"
 optional = false
@@ -580,7 +586,7 @@ python-versions = ">=3.7"
 
 [package.dependencies]
 gitdb = ">=4.0.1,<5"
-typing-extensions = {version = ">=3.7.4.3", markers = "python_version < \"3.10\""}
+typing-extensions = {version = ">=3.7.4.3", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "glcontext"
@@ -600,14 +606,14 @@ python-versions = "*"
 
 [[package]]
 name = "google-auth"
-version = "2.3.3"
+version = "2.5.0"
 description = "Google Authentication Library"
 category = "main"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"
 
 [package.dependencies]
-cachetools = ">=2.0.0,<5.0"
+cachetools = ">=2.0.0,<6.0"
 pyasn1-modules = ">=0.2.1"
 rsa = {version = ">=3.1.4,<5", markers = "python_version >= \"3.6\""}
 six = ">=1.9.0"
@@ -634,17 +640,17 @@ tool = ["click (>=6.0.0)"]
 
 [[package]]
 name = "grpcio"
-version = "1.41.1"
+version = "1.43.0"
 description = "HTTP/2-based RPC framework"
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [package.dependencies]
 six = ">=1.5.2"
 
 [package.extras]
-protobuf = ["grpcio-tools (>=1.41.1)"]
+protobuf = ["grpcio-tools (>=1.43.0)"]
 
 [[package]]
 name = "gym"
@@ -652,24 +658,30 @@ version = "0.21.0"
 description = "Gym: A universal API for reinforcement learning environments."
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
+develop = false
 
 [package.dependencies]
 cloudpickle = ">=1.2.0"
-importlib_metadata = {version = ">=4.8.1", markers = "python_version < \"3.8\""}
+importlib-metadata = {version = ">=4.10.0", markers = "python_version < \"3.10\""}
 numpy = ">=1.18.0"
 
 [package.extras]
 accept-rom-license = ["autorom[accept-rom-license] (>=0.4.2,<0.5.0)"]
-all = ["mujoco_py (>=1.50,<2.0)", "lz4 (>=3.1.0)", "opencv-python (>=3)", "ale-py (>=0.7.1,<0.8.0)", "pyglet (>=1.4.0)", "scipy (>=1.4.1)", "box2d-py (==2.3.5)", "pyglet (>=1.4.0)", "ale-py (>=0.7.1,<0.8.0)", "lz4 (>=3.1.0)", "opencv-python (>=3)", "pyglet (>=1.4.0)", "box2d-py (==2.3.5)", "pyglet (>=1.4.0)", "scipy (>=1.4.1)", "mujoco_py (>=1.50,<2.0)"]
+all = ["box2d-py (==2.3.5)", "pyglet (>=1.4.0)", "ale-py (>=0.7.1,<0.8.0)", "lz4 (>=3.1.0)", "opencv-python (>=3.0)", "pygame (==2.1.0)", "scipy (>=1.4.1)", "mujoco-py (>=1.50,<2.0)"]
 atari = ["ale-py (>=0.7.1,<0.8.0)"]
 box2d = ["box2d-py (==2.3.5)", "pyglet (>=1.4.0)"]
 classic_control = ["pyglet (>=1.4.0)"]
-mujoco = ["mujoco_py (>=1.50,<2.0)"]
-nomujoco = ["lz4 (>=3.1.0)", "opencv-python (>=3)", "ale-py (>=0.7.1,<0.8.0)", "pyglet (>=1.4.0)", "scipy (>=1.4.1)", "box2d-py (==2.3.5)", "pyglet (>=1.4.0)"]
-other = ["lz4 (>=3.1.0)", "opencv-python (>=3)"]
-robotics = ["mujoco_py (>=1.50,<2.0)"]
-toy_text = ["scipy (>=1.4.1)"]
+mujoco = ["mujoco-py (>=1.50,<2.0)"]
+nomujoco = ["box2d-py (==2.3.5)", "pyglet (>=1.4.0)", "lz4 (>=3.1.0)", "opencv-python (>=3.0)", "pygame (==2.1.0)", "scipy (>=1.4.1)"]
+other = ["lz4 (>=3.1.0)", "opencv-python (>=3.0)"]
+toy_text = ["pygame (==2.1.0)", "scipy (>=1.4.1)"]
+
+[package.source]
+type = "git"
+url = "https://github.com/openai/gym"
+reference = "b9e8b6c"
+resolved_reference = "b9e8b6c587239e8f73e9f91a0261a70e46d9660a"
 
 [[package]]
 name = "gym3"
@@ -700,7 +712,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "imageio"
-version = "2.10.3"
+version = "2.14.1"
 description = "Library for reading and writing a wide range of image, video, scientific, and volumetric data formats."
 category = "main"
 optional = true
@@ -716,11 +728,12 @@ dev = ["invoke", "pytest", "pytest-cov", "black", "flake8"]
 docs = ["sphinx", "numpydoc", "pydata-sphinx-theme"]
 ffmpeg = ["imageio-ffmpeg", "psutil"]
 fits = ["astropy"]
-full = ["astropy", "black", "flake8", "gdal", "imageio-ffmpeg", "invoke", "itk", "numpydoc", "psutil", "pydata-sphinx-theme", "pytest", "pytest-cov", "sphinx", "wheel"]
+full = ["astropy", "black", "flake8", "gdal", "imageio-ffmpeg", "invoke", "itk", "numpydoc", "psutil", "pydata-sphinx-theme", "pytest", "pytest-cov", "sphinx", "tifffile", "wheel"]
 gdal = ["gdal"]
 itk = ["itk"]
 linting = ["black", "flake8"]
 test = ["invoke", "pytest", "pytest-cov"]
+tifffile = ["tifffile"]
 
 [[package]]
 name = "imageio-ffmpeg"
@@ -732,7 +745,7 @@ python-versions = ">=3.4"
 
 [[package]]
 name = "imagesize"
-version = "1.2.0"
+version = "1.3.0"
 description = "Getting image size from png/jpeg/jpeg2000/gif file"
 category = "main"
 optional = true
@@ -740,11 +753,11 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.8.1"
+version = "4.10.1"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
@@ -753,7 +766,7 @@ zipp = ">=0.5"
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 perf = ["ipython"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "importlib-resources"
@@ -799,7 +812,7 @@ sortedcontainers = ">=2.0,<3.0"
 
 [[package]]
 name = "ipykernel"
-version = "6.5.0"
+version = "6.7.0"
 description = "IPython Kernel for Jupyter"
 category = "main"
 optional = true
@@ -807,21 +820,20 @@ python-versions = ">=3.7"
 
 [package.dependencies]
 appnope = {version = "*", markers = "platform_system == \"Darwin\""}
-argcomplete = {version = ">=1.12.3", markers = "python_version < \"3.8.0\""}
 debugpy = ">=1.0.0,<2.0"
-importlib-metadata = {version = "<5", markers = "python_version < \"3.8.0\""}
-ipython = ">=7.23.1,<8.0"
+ipython = ">=7.23.1"
 jupyter-client = "<8.0"
 matplotlib-inline = ">=0.1.0,<0.2.0"
+nest-asyncio = "*"
 tornado = ">=4.2,<7.0"
 traitlets = ">=5.1.0,<6.0"
 
 [package.extras]
-test = ["pytest (!=5.3.4)", "pytest-cov", "flaky", "nose", "ipyparallel"]
+test = ["pytest (!=5.3.4)", "pytest-cov", "flaky", "ipyparallel"]
 
 [[package]]
 name = "ipython"
-version = "7.29.0"
+version = "7.31.1"
 description = "IPython: Productive Interactive Computing"
 category = "main"
 optional = true
@@ -861,7 +873,7 @@ python-versions = "*"
 
 [[package]]
 name = "isort"
-version = "5.10.0"
+version = "5.10.1"
 description = "A Python utility / library to sort Python imports."
 category = "main"
 optional = true
@@ -875,7 +887,7 @@ plugins = ["setuptools"]
 
 [[package]]
 name = "jedi"
-version = "0.18.0"
+version = "0.18.1"
 description = "An autocompletion tool for Python that can be used for text editors."
 category = "main"
 optional = true
@@ -886,7 +898,7 @@ parso = ">=0.8.0,<0.9.0"
 
 [package.extras]
 qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
-testing = ["Django (<3.1)", "colorama", "docopt", "pytest (<6.0.0)"]
+testing = ["Django (<3.1)", "colorama", "docopt", "pytest (<7.0.0)"]
 
 [[package]]
 name = "jeepney"
@@ -902,7 +914,7 @@ trio = ["trio", "async-generator"]
 
 [[package]]
 name = "jinja2"
-version = "3.0.2"
+version = "3.0.3"
 description = "A very fast and expressive template engine."
 category = "main"
 optional = true
@@ -936,7 +948,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "jsonschema"
-version = "4.2.1"
+version = "4.4.0"
 description = "An implementation of JSON Schema validation for Python"
 category = "main"
 optional = true
@@ -947,6 +959,7 @@ attrs = ">=17.4.0"
 importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 importlib-resources = {version = ">=1.4.0", markers = "python_version < \"3.9\""}
 pyrsistent = ">=0.14.0,<0.17.0 || >0.17.0,<0.17.1 || >0.17.1,<0.17.2 || >0.17.2"
+typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
 format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
@@ -997,11 +1010,11 @@ pygments = ">=2.4.1,<3"
 
 [[package]]
 name = "keyring"
-version = "23.2.1"
+version = "23.5.0"
 description = "Store and access your passwords safely."
 category = "main"
 optional = true
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 importlib-metadata = ">=3.6"
@@ -1010,8 +1023,8 @@ pywin32-ctypes = {version = "<0.1.0 || >0.1.0,<0.1.1 || >0.1.1", markers = "sys_
 SecretStorage = {version = ">=3.2", markers = "sys_platform == \"linux\""}
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-black (>=0.3.7)", "pytest-mypy"]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [[package]]
 name = "kiwisolver"
@@ -1023,22 +1036,22 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "lazy-object-proxy"
-version = "1.6.0"
+version = "1.7.1"
 description = "A fast and thorough lazy object proxy."
 category = "main"
 optional = true
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "markdown"
-version = "3.3.4"
+version = "3.3.6"
 description = "Python implementation of Markdown."
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+importlib-metadata = {version = ">=4.4", markers = "python_version < \"3.10\""}
 
 [package.extras]
 testing = ["coverage", "pyyaml"]
@@ -1053,7 +1066,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "matplotlib"
-version = "3.4.3"
+version = "3.5.1"
 description = "Python plotting package"
 category = "main"
 optional = true
@@ -1061,11 +1074,14 @@ python-versions = ">=3.7"
 
 [package.dependencies]
 cycler = ">=0.10"
+fonttools = ">=4.22.0"
 kiwisolver = ">=1.0.1"
-numpy = ">=1.16"
+numpy = ">=1.17"
+packaging = ">=20.0"
 pillow = ">=6.2.0"
 pyparsing = ">=2.2.1"
 python-dateutil = ">=2.7"
+setuptools_scm = ">=4"
 
 [[package]]
 name = "matplotlib-inline"
@@ -1178,11 +1194,11 @@ python-versions = "*"
 
 [[package]]
 name = "nbclient"
-version = "0.5.4"
+version = "0.5.10"
 description = "A client library for executing notebooks. Formerly nbconvert's ExecutePreprocessor."
 category = "main"
 optional = true
-python-versions = ">=3.6.1"
+python-versions = ">=3.7.0"
 
 [package.dependencies]
 jupyter-client = ">=6.1.5"
@@ -1191,13 +1207,12 @@ nest-asyncio = "*"
 traitlets = ">=4.2"
 
 [package.extras]
-dev = ["codecov", "coverage", "ipython", "ipykernel", "ipywidgets", "pytest (>=4.1)", "pytest-cov (>=2.6.1)", "check-manifest", "flake8", "mypy", "tox", "bumpversion", "xmltodict", "pip (>=18.1)", "wheel (>=0.31.0)", "setuptools (>=38.6.0)", "twine (>=1.11.0)", "black"]
 sphinx = ["Sphinx (>=1.7)", "sphinx-book-theme", "mock", "moto", "myst-parser"]
-test = ["codecov", "coverage", "ipython", "ipykernel", "ipywidgets", "pytest (>=4.1)", "pytest-cov (>=2.6.1)", "check-manifest", "flake8", "mypy", "tox", "bumpversion", "xmltodict", "pip (>=18.1)", "wheel (>=0.31.0)", "setuptools (>=38.6.0)", "twine (>=1.11.0)", "black"]
+test = ["ipython", "ipykernel", "ipywidgets (<8.0.0)", "pytest (>=4.1)", "pytest-cov (>=2.6.1)", "check-manifest", "flake8", "mypy", "xmltodict", "black", "pip (>=18.1)", "wheel (>=0.31.0)", "setuptools (>=38.6.0)", "twine (>=1.11.0)"]
 
 [[package]]
 name = "nbconvert"
-version = "6.2.0"
+version = "6.4.1"
 description = "Converting Jupyter Notebooks"
 category = "main"
 optional = true
@@ -1245,7 +1260,7 @@ test = ["check-manifest", "fastjsonschema", "testpath", "pytest", "pytest-cov"]
 
 [[package]]
 name = "nest-asyncio"
-version = "1.5.1"
+version = "1.5.4"
 description = "Patch asyncio to allow nested event loops"
 category = "main"
 optional = true
@@ -1253,7 +1268,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "numpy"
-version = "1.21.4"
+version = "1.21.5"
 description = "NumPy is the fundamental package for array computing with Python."
 category = "main"
 optional = false
@@ -1261,18 +1276,18 @@ python-versions = ">=3.7,<3.11"
 
 [[package]]
 name = "numpydoc"
-version = "1.1.0"
+version = "1.2"
 description = "Sphinx extension to support docstrings in Numpy format"
 category = "main"
 optional = true
-python-versions = ">=3.5"
+python-versions = ">=3.7"
 
 [package.dependencies]
-Jinja2 = ">=2.3"
-sphinx = ">=1.6.5"
+Jinja2 = ">=2.10"
+sphinx = ">=1.8"
 
 [package.extras]
-testing = ["matplotlib", "pytest", "pytest-cov"]
+testing = ["pytest", "pytest-cov", "matplotlib"]
 
 [[package]]
 name = "oauthlib"
@@ -1289,29 +1304,34 @@ signedtoken = ["cryptography (>=3.0.0,<4)", "pyjwt (>=2.0.0,<3)"]
 
 [[package]]
 name = "opencv-python"
-version = "4.5.4.58"
+version = "4.5.5.62"
 description = "Wrapper package for OpenCV python bindings."
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-numpy = ">=1.21.2"
+numpy = [
+    {version = ">=1.21.2", markers = "python_version >= \"3.6\" and platform_system == \"Darwin\" and platform_machine == \"arm64\""},
+    {version = ">=1.19.3", markers = "python_version >= \"3.6\" and platform_system == \"Linux\" and platform_machine == \"aarch64\" or python_version >= \"3.9\""},
+    {version = ">=1.14.5", markers = "python_version >= \"3.7\""},
+    {version = ">=1.17.3", markers = "python_version >= \"3.8\""},
+]
 
 [[package]]
 name = "packaging"
-version = "21.2"
+version = "21.3"
 description = "Core utilities for Python packages"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyparsing = ">=2.0.2,<3"
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pandas"
-version = "1.3.4"
+version = "1.3.5"
 description = "Powerful data structures for data analysis, time series, and statistics"
 category = "main"
 optional = true
@@ -1339,7 +1359,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "paramiko"
-version = "2.8.0"
+version = "2.9.2"
 description = "SSH2 protocol library"
 category = "main"
 optional = true
@@ -1358,7 +1378,7 @@ invoke = ["invoke (>=1.3)"]
 
 [[package]]
 name = "parso"
-version = "0.8.2"
+version = "0.8.3"
 description = "A Python Parser"
 category = "main"
 optional = true
@@ -1386,25 +1406,25 @@ python-versions = "*"
 
 [[package]]
 name = "pettingzoo"
-version = "1.13.1"
+version = "1.14.0"
 description = "Gym for multi-agent reinforcement learning"
 category = "main"
 optional = true
-python-versions = ">=3.7, <3.10"
+python-versions = ">=3.7, <3.11"
 
 [package.dependencies]
 gym = ">=0.21.0"
 numpy = ">=1.18.0"
 
 [package.extras]
-all = ["multi_agent_ale_py (==0.1.11)", "pygame (==2.0.0)", "chess (==1.7.0)", "rlcard (==1.0.4)", "pygame (==2.0.0)", "hanabi_learning_environment (==0.0.1)", "pygame (==2.0.0)", "pymunk (==6.2.0)", "magent (==0.1.14)", "pyglet (>=1.4.0)", "pygame (==2.0.0)", "box2d-py (==2.3.5)", "pyglet (>=1.4.0)", "scipy (>=1.4.1)", "pillow (>=8.0.1)"]
-atari = ["multi_agent_ale_py (==0.1.11)", "pygame (==2.0.0)"]
-butterfly = ["pygame (==2.0.0)", "pymunk (==6.2.0)"]
-classic = ["chess (==1.7.0)", "rlcard (==1.0.4)", "pygame (==2.0.0)", "hanabi_learning_environment (==0.0.1)"]
+all = ["multi_agent_ale_py (==0.1.11)", "pygame (==2.1.0)", "chess (==1.7.0)", "rlcard (==1.0.4)", "pygame (==2.1.0)", "hanabi_learning_environment (==0.0.1)", "pygame (==2.1.0)", "pymunk (==6.2.0)", "magent (==0.1.14)", "pyglet (>=1.4.0)", "pygame (==2.1.0)", "box2d-py (==2.3.5)", "pyglet (>=1.4.0)", "scipy (>=1.4.1)", "pillow (>=8.0.1)"]
+atari = ["multi_agent_ale_py (==0.1.11)", "pygame (==2.1.0)"]
+butterfly = ["pygame (==2.1.0)", "pymunk (==6.2.0)"]
+classic = ["chess (==1.7.0)", "rlcard (==1.0.4)", "pygame (==2.1.0)", "hanabi_learning_environment (==0.0.1)"]
 magent = ["magent (==0.1.14)"]
 mpe = ["pyglet (>=1.4.0)"]
 other = ["pillow (>=8.0.1)"]
-sisl = ["pygame (==2.0.0)", "box2d-py (==2.3.5)", "pyglet (>=1.4.0)", "scipy (>=1.4.1)"]
+sisl = ["pygame (==2.1.0)", "box2d-py (==2.3.5)", "pyglet (>=1.4.0)", "scipy (>=1.4.1)"]
 tests = ["pynput"]
 
 [[package]]
@@ -1428,19 +1448,19 @@ python-versions = "*"
 
 [[package]]
 name = "pillow"
-version = "8.4.0"
+version = "9.0.0"
 description = "Python Imaging Library (Fork)"
 category = "main"
 optional = true
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [[package]]
 name = "platformdirs"
-version = "2.4.0"
+version = "2.4.1"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "main"
 optional = true
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.extras]
 docs = ["Sphinx (>=4)", "furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)"]
@@ -1471,7 +1491,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "procgen"
-version = "0.10.4"
+version = "0.10.7"
 description = "Procedurally Generated Game-Like RL Environments"
 category = "main"
 optional = true
@@ -1484,7 +1504,7 @@ gym3 = ">=0.3.3,<1.0.0"
 numpy = ">=1.17.0,<2.0.0"
 
 [package.extras]
-test = ["pytest (==5.2.1)", "pytest-benchmark (==3.2.2)"]
+test = ["pytest (==6.2.5)", "pytest-benchmark (==3.4.1)"]
 
 [[package]]
 name = "promise"
@@ -1502,7 +1522,7 @@ test = ["pytest (>=2.7.3)", "pytest-cov", "coveralls", "futures", "pytest-benchm
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.22"
+version = "3.0.26"
 description = "Library for building powerful interactive command lines in Python"
 category = "main"
 optional = true
@@ -1513,7 +1533,7 @@ wcwidth = "*"
 
 [[package]]
 name = "protobuf"
-version = "3.19.1"
+version = "3.19.3"
 description = "Protocol Buffers"
 category = "main"
 optional = false
@@ -1521,7 +1541,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "psutil"
-version = "5.8.0"
+version = "5.9.0"
 description = "Cross-platform lib for process and system monitoring in Python."
 category = "main"
 optional = false
@@ -1567,7 +1587,7 @@ pyasn1 = ">=0.4.6,<0.5.0"
 
 [[package]]
 name = "pybullet"
-version = "3.2.0"
+version = "3.2.1"
 description = "Official Python Interface for the Bullet Physics SDK specialized for Robotics Simulation and Reinforcement Learning"
 category = "main"
 optional = true
@@ -1613,7 +1633,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pygame"
-version = "2.1.0"
+version = "2.1.2"
 description = "Python Game Development"
 category = "main"
 optional = true
@@ -1629,7 +1649,7 @@ python-versions = "*"
 
 [[package]]
 name = "pygments"
-version = "2.10.0"
+version = "2.11.2"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "main"
 optional = true
@@ -1663,7 +1683,7 @@ python-lsp-server = ">=1.0.1"
 
 [[package]]
 name = "pymdown-extensions"
-version = "9.0"
+version = "9.1"
 description = "Extension pack for Python Markdown."
 category = "main"
 optional = true
@@ -1688,15 +1708,14 @@ dev = ["pyglet", "pygame", "sphinx", "aafigure", "wheel", "matplotlib"]
 
 [[package]]
 name = "pynacl"
-version = "1.4.0"
+version = "1.5.0"
 description = "Python binding to the Networking and Cryptography (NaCl) library"
 category = "main"
 optional = true
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
 cffi = ">=1.4.1"
-six = "*"
 
 [package.extras]
 docs = ["sphinx (>=1.6.5)", "sphinx-rtd-theme"]
@@ -1704,150 +1723,159 @@ tests = ["pytest (>=3.2.1,!=3.3.0)", "hypothesis (>=3.27.0)"]
 
 [[package]]
 name = "pyobjc"
-version = "7.3"
+version = "8.2"
 description = "Python<->ObjC Interoperability Module"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = "7.3"
-pyobjc-framework-Accessibility = {version = "7.3", markers = "platform_release >= \"20.0\""}
-pyobjc-framework-Accounts = {version = "7.3", markers = "platform_release >= \"12.0\""}
-pyobjc-framework-AddressBook = "7.3"
-pyobjc-framework-AdServices = {version = "7.3", markers = "platform_release >= \"20.0\""}
-pyobjc-framework-AdSupport = {version = "7.3", markers = "platform_release >= \"18.0\""}
-pyobjc-framework-AppleScriptKit = "7.3"
-pyobjc-framework-AppleScriptObjC = {version = "7.3", markers = "platform_release >= \"10.0\""}
-pyobjc-framework-ApplicationServices = "7.3"
-pyobjc-framework-AppTrackingTransparency = {version = "7.3", markers = "platform_release >= \"20.0\""}
-pyobjc-framework-AuthenticationServices = {version = "7.3", markers = "platform_release >= \"19.0\""}
-pyobjc-framework-AutomaticAssessmentConfiguration = {version = "7.3", markers = "platform_release >= \"19.0\""}
-pyobjc-framework-Automator = "7.3"
-pyobjc-framework-AVFoundation = {version = "7.3", markers = "platform_release >= \"11.0\""}
-pyobjc-framework-AVKit = {version = "7.3", markers = "platform_release >= \"13.0\""}
-pyobjc-framework-BusinessChat = {version = "7.3", markers = "platform_release >= \"18.0\""}
-pyobjc-framework-CalendarStore = {version = "7.3", markers = "platform_release >= \"9.0\""}
-pyobjc-framework-CallKit = {version = "7.3", markers = "platform_release >= \"20.0\""}
-pyobjc-framework-CFNetwork = "7.3"
-pyobjc-framework-ClassKit = {version = "7.3", markers = "platform_release >= \"20.0\""}
-pyobjc-framework-CloudKit = {version = "7.3", markers = "platform_release >= \"14.0\""}
-pyobjc-framework-Cocoa = "7.3"
-pyobjc-framework-Collaboration = {version = "7.3", markers = "platform_release >= \"9.0\""}
-pyobjc-framework-ColorSync = {version = "7.3", markers = "platform_release >= \"17.0\""}
-pyobjc-framework-Contacts = {version = "7.3", markers = "platform_release >= \"15.0\""}
-pyobjc-framework-ContactsUI = {version = "7.3", markers = "platform_release >= \"15.0\""}
-pyobjc-framework-CoreAudio = "7.3"
-pyobjc-framework-CoreAudioKit = "7.3"
-pyobjc-framework-CoreBluetooth = {version = "7.3", markers = "platform_release >= \"14.0\""}
-pyobjc-framework-CoreData = "7.3"
-pyobjc-framework-CoreHaptics = {version = "7.3", markers = "platform_release >= \"19.0\""}
-pyobjc-framework-CoreLocation = {version = "7.3", markers = "platform_release >= \"10.0\""}
-pyobjc-framework-CoreMedia = {version = "7.3", markers = "platform_release >= \"11.0\""}
-pyobjc-framework-CoreMediaIO = {version = "7.3", markers = "platform_release >= \"11.0\""}
-pyobjc-framework-CoreMIDI = "7.3"
-pyobjc-framework-CoreML = {version = "7.3", markers = "platform_release >= \"17.0\""}
-pyobjc-framework-CoreMotion = {version = "7.3", markers = "platform_release >= \"19.0\""}
-pyobjc-framework-CoreServices = "7.3"
-pyobjc-framework-CoreSpotlight = {version = "7.3", markers = "platform_release >= \"17.0\""}
-pyobjc-framework-CoreText = "7.3"
-pyobjc-framework-CoreWLAN = {version = "7.3", markers = "platform_release >= \"10.0\""}
-pyobjc-framework-CryptoTokenKit = {version = "7.3", markers = "platform_release >= \"14.0\""}
-pyobjc-framework-DeviceCheck = {version = "7.3", markers = "platform_release >= \"19.0\""}
-pyobjc-framework-DictionaryServices = {version = "7.3", markers = "platform_release >= \"9.0\""}
-pyobjc-framework-DiscRecording = "7.3"
-pyobjc-framework-DiscRecordingUI = "7.3"
-pyobjc-framework-DiskArbitration = "7.3"
-pyobjc-framework-DVDPlayback = "7.3"
-pyobjc-framework-EventKit = {version = "7.3", markers = "platform_release >= \"12.0\""}
-pyobjc-framework-ExceptionHandling = "7.3"
-pyobjc-framework-ExecutionPolicy = {version = "7.3", markers = "platform_release >= \"19.0\""}
-pyobjc-framework-ExternalAccessory = {version = "7.3", markers = "platform_release >= \"17.0\""}
-pyobjc-framework-FileProvider = {version = "7.3", markers = "platform_release >= \"19.0\""}
-pyobjc-framework-FileProviderUI = {version = "7.3", markers = "platform_release >= \"19.0\""}
-pyobjc-framework-FinderSync = {version = "7.3", markers = "platform_release >= \"14.0\""}
-pyobjc-framework-FSEvents = {version = "7.3", markers = "platform_release >= \"9.0\""}
-pyobjc-framework-GameCenter = {version = "7.3", markers = "platform_release >= \"12.0\""}
-pyobjc-framework-GameController = {version = "7.3", markers = "platform_release >= \"13.0\""}
-pyobjc-framework-GameKit = {version = "7.3", markers = "platform_release >= \"12.0\""}
-pyobjc-framework-GameplayKit = {version = "7.3", markers = "platform_release >= \"15.0\""}
-pyobjc-framework-ImageCaptureCore = {version = "7.3", markers = "platform_release >= \"10.0\""}
-pyobjc-framework-IMServicePlugIn = {version = "7.3", markers = "platform_release >= \"11.0\""}
-pyobjc-framework-InputMethodKit = {version = "7.3", markers = "platform_release >= \"9.0\""}
-pyobjc-framework-InstallerPlugins = "7.3"
-pyobjc-framework-InstantMessage = {version = "7.3", markers = "platform_release >= \"9.0\""}
-pyobjc-framework-Intents = {version = "7.3", markers = "platform_release >= \"16.0\""}
-pyobjc-framework-InterfaceBuilderKit = {version = "7.3", markers = "platform_release >= \"9.0\" and platform_release < \"11.0\""}
-pyobjc-framework-IOSurface = {version = "7.3", markers = "platform_release >= \"10.0\""}
-pyobjc-framework-iTunesLibrary = {version = "7.3", markers = "platform_release >= \"10.0\""}
-pyobjc-framework-KernelManagement = {version = "7.3", markers = "platform_release >= \"20.0\""}
-pyobjc-framework-LatentSemanticMapping = "7.3"
-pyobjc-framework-LaunchServices = "7.3"
-pyobjc-framework-libdispatch = {version = "7.3", markers = "platform_release >= \"12.0\""}
-pyobjc-framework-LinkPresentation = {version = "7.3", markers = "platform_release >= \"19.0\""}
-pyobjc-framework-LocalAuthentication = {version = "7.3", markers = "platform_release >= \"14.0\""}
-pyobjc-framework-MapKit = {version = "7.3", markers = "platform_release >= \"13.0\""}
-pyobjc-framework-MediaAccessibility = {version = "7.3", markers = "platform_release >= \"13.0\""}
-pyobjc-framework-MediaLibrary = {version = "7.3", markers = "platform_release >= \"13.0\""}
-pyobjc-framework-MediaPlayer = {version = "7.3", markers = "platform_release >= \"16.0\""}
-pyobjc-framework-MediaToolbox = {version = "7.3", markers = "platform_release >= \"13.0\""}
-pyobjc-framework-Message = {version = "7.3", markers = "platform_release < \"13.0\""}
-pyobjc-framework-Metal = {version = "7.3", markers = "platform_release >= \"15.0\""}
-pyobjc-framework-MetalKit = {version = "7.3", markers = "platform_release >= \"15.0\""}
-pyobjc-framework-MetalPerformanceShaders = {version = "7.3", markers = "platform_release >= \"17.0\""}
-pyobjc-framework-MetalPerformanceShadersGraph = {version = "7.3", markers = "platform_release >= \"20.0\""}
-pyobjc-framework-MLCompute = {version = "7.3", markers = "platform_release >= \"20.0\""}
-pyobjc-framework-ModelIO = {version = "7.3", markers = "platform_release >= \"15.0\""}
-pyobjc-framework-MultipeerConnectivity = {version = "7.3", markers = "platform_release >= \"14.0\""}
-pyobjc-framework-NaturalLanguage = {version = "7.3", markers = "platform_release >= \"18.0\""}
-pyobjc-framework-NetFS = {version = "7.3", markers = "platform_release >= \"10.0\""}
-pyobjc-framework-Network = {version = "7.3", markers = "platform_release >= \"18.0\""}
-pyobjc-framework-NetworkExtension = {version = "7.3", markers = "platform_release >= \"15.0\""}
-pyobjc-framework-NotificationCenter = {version = "7.3", markers = "platform_release >= \"14.0\""}
-pyobjc-framework-OpenDirectory = {version = "7.3", markers = "platform_release >= \"10.0\""}
-pyobjc-framework-OSAKit = "7.3"
-pyobjc-framework-OSLog = {version = "7.3", markers = "platform_release >= \"19.0\""}
-pyobjc-framework-PassKit = {version = "7.3", markers = "platform_release >= \"20.0\""}
-pyobjc-framework-PencilKit = {version = "7.3", markers = "platform_release >= \"19.0\""}
-pyobjc-framework-Photos = {version = "7.3", markers = "platform_release >= \"15.0\""}
-pyobjc-framework-PhotosUI = {version = "7.3", markers = "platform_release >= \"15.0\""}
-pyobjc-framework-PreferencePanes = "7.3"
-pyobjc-framework-PubSub = {version = "7.3", markers = "platform_release >= \"9.0\" and platform_release < \"18.0\""}
-pyobjc-framework-PushKit = {version = "7.3", markers = "platform_release >= \"19.0\""}
-pyobjc-framework-Quartz = "7.3"
-pyobjc-framework-QuickLookThumbnailing = {version = "7.3", markers = "platform_release >= \"19.0\""}
-pyobjc-framework-ReplayKit = {version = "7.3", markers = "platform_release >= \"20.0\""}
-pyobjc-framework-SafariServices = {version = "7.3", markers = "platform_release >= \"15.0\""}
-pyobjc-framework-SceneKit = {version = "7.3", markers = "platform_release >= \"11.0\""}
-pyobjc-framework-ScreenSaver = "7.3"
-pyobjc-framework-ScreenTime = {version = "7.3", markers = "platform_release >= \"20.0\""}
-pyobjc-framework-ScriptingBridge = {version = "7.3", markers = "platform_release >= \"9.0\""}
-pyobjc-framework-SearchKit = "7.3"
-pyobjc-framework-Security = "7.3"
-pyobjc-framework-SecurityFoundation = "7.3"
-pyobjc-framework-SecurityInterface = "7.3"
-pyobjc-framework-ServerNotification = {version = "7.3", markers = "platform_release >= \"10.0\" and platform_release < \"13.0\""}
-pyobjc-framework-ServiceManagement = {version = "7.3", markers = "platform_release >= \"10.0\""}
-pyobjc-framework-Social = {version = "7.3", markers = "platform_release >= \"12.0\""}
-pyobjc-framework-SoundAnalysis = {version = "7.3", markers = "platform_release >= \"19.0\""}
-pyobjc-framework-Speech = {version = "7.3", markers = "platform_release >= \"19.0\""}
-pyobjc-framework-SpriteKit = {version = "7.3", markers = "platform_release >= \"13.0\""}
-pyobjc-framework-StoreKit = {version = "7.3", markers = "platform_release >= \"11.0\""}
-pyobjc-framework-SyncServices = "7.3"
-pyobjc-framework-SystemConfiguration = "7.3"
-pyobjc-framework-SystemExtensions = {version = "7.3", markers = "platform_release >= \"19.0\""}
-pyobjc-framework-UniformTypeIdentifiers = {version = "7.3", markers = "platform_release >= \"20.0\""}
-pyobjc-framework-UserNotifications = {version = "7.3", markers = "platform_release >= \"18.0\""}
-pyobjc-framework-UserNotificationsUI = {version = "7.3", markers = "platform_release >= \"20.0\""}
-pyobjc-framework-VideoSubscriberAccount = {version = "7.3", markers = "platform_release >= \"18.0\""}
-pyobjc-framework-VideoToolbox = {version = "7.3", markers = "platform_release >= \"12.0\""}
-pyobjc-framework-Virtualization = {version = "7.3", markers = "platform_release >= \"20.0\""}
-pyobjc-framework-Vision = {version = "7.3", markers = "platform_release >= \"17.0\""}
-pyobjc-framework-WebKit = "7.3"
+pyobjc-core = "8.2"
+pyobjc-framework-Accessibility = {version = "8.2", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-Accounts = {version = "8.2", markers = "platform_release >= \"12.0\""}
+pyobjc-framework-AddressBook = "8.2"
+pyobjc-framework-AdServices = {version = "8.2", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-AdSupport = {version = "8.2", markers = "platform_release >= \"18.0\""}
+pyobjc-framework-AppleScriptKit = "8.2"
+pyobjc-framework-AppleScriptObjC = {version = "8.2", markers = "platform_release >= \"10.0\""}
+pyobjc-framework-ApplicationServices = "8.2"
+pyobjc-framework-AppTrackingTransparency = {version = "8.2", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-AudioVideoBridging = {version = "8.2", markers = "platform_release >= \"12.0\""}
+pyobjc-framework-AuthenticationServices = {version = "8.2", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-AutomaticAssessmentConfiguration = {version = "8.2", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-Automator = "8.2"
+pyobjc-framework-AVFoundation = {version = "8.2", markers = "platform_release >= \"11.0\""}
+pyobjc-framework-AVKit = {version = "8.2", markers = "platform_release >= \"13.0\""}
+pyobjc-framework-BusinessChat = {version = "8.2", markers = "platform_release >= \"18.0\""}
+pyobjc-framework-CalendarStore = {version = "8.2", markers = "platform_release >= \"9.0\""}
+pyobjc-framework-CallKit = {version = "8.2", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-CFNetwork = "8.2"
+pyobjc-framework-ClassKit = {version = "8.2", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-CloudKit = {version = "8.2", markers = "platform_release >= \"14.0\""}
+pyobjc-framework-Cocoa = "8.2"
+pyobjc-framework-Collaboration = {version = "8.2", markers = "platform_release >= \"9.0\""}
+pyobjc-framework-ColorSync = {version = "8.2", markers = "platform_release >= \"17.0\""}
+pyobjc-framework-Contacts = {version = "8.2", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-ContactsUI = {version = "8.2", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-CoreAudio = "8.2"
+pyobjc-framework-CoreAudioKit = "8.2"
+pyobjc-framework-CoreBluetooth = {version = "8.2", markers = "platform_release >= \"14.0\""}
+pyobjc-framework-CoreData = "8.2"
+pyobjc-framework-CoreHaptics = {version = "8.2", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-CoreLocation = {version = "8.2", markers = "platform_release >= \"10.0\""}
+pyobjc-framework-CoreMedia = {version = "8.2", markers = "platform_release >= \"11.0\""}
+pyobjc-framework-CoreMediaIO = {version = "8.2", markers = "platform_release >= \"11.0\""}
+pyobjc-framework-CoreMIDI = "8.2"
+pyobjc-framework-CoreML = {version = "8.2", markers = "platform_release >= \"17.0\""}
+pyobjc-framework-CoreMotion = {version = "8.2", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-CoreServices = "8.2"
+pyobjc-framework-CoreSpotlight = {version = "8.2", markers = "platform_release >= \"17.0\""}
+pyobjc-framework-CoreText = "8.2"
+pyobjc-framework-CoreWLAN = {version = "8.2", markers = "platform_release >= \"10.0\""}
+pyobjc-framework-CryptoTokenKit = {version = "8.2", markers = "platform_release >= \"14.0\""}
+pyobjc-framework-DataDetection = {version = "8.2", markers = "platform_release >= \"21.0\""}
+pyobjc-framework-DeviceCheck = {version = "8.2", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-DictionaryServices = {version = "8.2", markers = "platform_release >= \"9.0\""}
+pyobjc-framework-DiscRecording = "8.2"
+pyobjc-framework-DiscRecordingUI = "8.2"
+pyobjc-framework-DiskArbitration = "8.2"
+pyobjc-framework-DVDPlayback = "8.2"
+pyobjc-framework-EventKit = {version = "8.2", markers = "platform_release >= \"12.0\""}
+pyobjc-framework-ExceptionHandling = "8.2"
+pyobjc-framework-ExecutionPolicy = {version = "8.2", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-ExternalAccessory = {version = "8.2", markers = "platform_release >= \"17.0\""}
+pyobjc-framework-FileProvider = {version = "8.2", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-FileProviderUI = {version = "8.2", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-FinderSync = {version = "8.2", markers = "platform_release >= \"14.0\""}
+pyobjc-framework-FSEvents = {version = "8.2", markers = "platform_release >= \"9.0\""}
+pyobjc-framework-GameCenter = {version = "8.2", markers = "platform_release >= \"12.0\""}
+pyobjc-framework-GameController = {version = "8.2", markers = "platform_release >= \"13.0\""}
+pyobjc-framework-GameKit = {version = "8.2", markers = "platform_release >= \"12.0\""}
+pyobjc-framework-GameplayKit = {version = "8.2", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-ImageCaptureCore = {version = "8.2", markers = "platform_release >= \"10.0\""}
+pyobjc-framework-IMServicePlugIn = {version = "8.2", markers = "platform_release >= \"11.0\""}
+pyobjc-framework-InputMethodKit = {version = "8.2", markers = "platform_release >= \"9.0\""}
+pyobjc-framework-InstallerPlugins = "8.2"
+pyobjc-framework-InstantMessage = {version = "8.2", markers = "platform_release >= \"9.0\""}
+pyobjc-framework-Intents = {version = "8.2", markers = "platform_release >= \"16.0\""}
+pyobjc-framework-IntentsUI = {version = "8.2", markers = "platform_release >= \"21.0\""}
+pyobjc-framework-IOSurface = {version = "8.2", markers = "platform_release >= \"10.0\""}
+pyobjc-framework-iTunesLibrary = {version = "8.2", markers = "platform_release >= \"10.0\""}
+pyobjc-framework-KernelManagement = {version = "8.2", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-LatentSemanticMapping = "8.2"
+pyobjc-framework-LaunchServices = "8.2"
+pyobjc-framework-libdispatch = {version = "8.2", markers = "platform_release >= \"12.0\""}
+pyobjc-framework-LinkPresentation = {version = "8.2", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-LocalAuthentication = {version = "8.2", markers = "platform_release >= \"14.0\""}
+pyobjc-framework-LocalAuthenticationEmbeddedUI = {version = "8.2", markers = "platform_release >= \"21.0\""}
+pyobjc-framework-MailKit = {version = "8.2", markers = "platform_release >= \"21.0\""}
+pyobjc-framework-MapKit = {version = "8.2", markers = "platform_release >= \"13.0\""}
+pyobjc-framework-MediaAccessibility = {version = "8.2", markers = "platform_release >= \"13.0\""}
+pyobjc-framework-MediaLibrary = {version = "8.2", markers = "platform_release >= \"13.0\""}
+pyobjc-framework-MediaPlayer = {version = "8.2", markers = "platform_release >= \"16.0\""}
+pyobjc-framework-MediaToolbox = {version = "8.2", markers = "platform_release >= \"13.0\""}
+pyobjc-framework-Message = {version = "8.2", markers = "platform_release < \"13.0\""}
+pyobjc-framework-Metal = {version = "8.2", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-MetalKit = {version = "8.2", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-MetalPerformanceShaders = {version = "8.2", markers = "platform_release >= \"17.0\""}
+pyobjc-framework-MetalPerformanceShadersGraph = {version = "8.2", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-MetricKit = {version = "8.2", markers = "platform_release >= \"21.0\""}
+pyobjc-framework-MLCompute = {version = "8.2", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-ModelIO = {version = "8.2", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-MultipeerConnectivity = {version = "8.2", markers = "platform_release >= \"14.0\""}
+pyobjc-framework-NaturalLanguage = {version = "8.2", markers = "platform_release >= \"18.0\""}
+pyobjc-framework-NetFS = {version = "8.2", markers = "platform_release >= \"10.0\""}
+pyobjc-framework-Network = {version = "8.2", markers = "platform_release >= \"18.0\""}
+pyobjc-framework-NetworkExtension = {version = "8.2", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-NotificationCenter = {version = "8.2", markers = "platform_release >= \"14.0\""}
+pyobjc-framework-OpenDirectory = {version = "8.2", markers = "platform_release >= \"10.0\""}
+pyobjc-framework-OSAKit = "8.2"
+pyobjc-framework-OSLog = {version = "8.2", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-PassKit = {version = "8.2", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-PencilKit = {version = "8.2", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-Photos = {version = "8.2", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-PhotosUI = {version = "8.2", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-PreferencePanes = "8.2"
+pyobjc-framework-PubSub = {version = "8.2", markers = "platform_release >= \"9.0\" and platform_release < \"18.0\""}
+pyobjc-framework-PushKit = {version = "8.2", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-Quartz = "8.2"
+pyobjc-framework-QuickLookThumbnailing = {version = "8.2", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-ReplayKit = {version = "8.2", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-SafariServices = {version = "8.2", markers = "platform_release >= \"15.0\""}
+pyobjc-framework-SceneKit = {version = "8.2", markers = "platform_release >= \"11.0\""}
+pyobjc-framework-ScreenSaver = "8.2"
+pyobjc-framework-ScreenTime = {version = "8.2", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-ScriptingBridge = {version = "8.2", markers = "platform_release >= \"9.0\""}
+pyobjc-framework-SearchKit = "8.2"
+pyobjc-framework-Security = "8.2"
+pyobjc-framework-SecurityFoundation = "8.2"
+pyobjc-framework-SecurityInterface = "8.2"
+pyobjc-framework-ServerNotification = {version = "8.2", markers = "platform_release >= \"10.0\" and platform_release < \"13.0\""}
+pyobjc-framework-ServiceManagement = {version = "8.2", markers = "platform_release >= \"10.0\""}
+pyobjc-framework-ShazamKit = {version = "8.2", markers = "platform_release >= \"21.0\""}
+pyobjc-framework-Social = {version = "8.2", markers = "platform_release >= \"12.0\""}
+pyobjc-framework-SoundAnalysis = {version = "8.2", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-Speech = {version = "8.2", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-SpriteKit = {version = "8.2", markers = "platform_release >= \"13.0\""}
+pyobjc-framework-StoreKit = {version = "8.2", markers = "platform_release >= \"11.0\""}
+pyobjc-framework-SyncServices = "8.2"
+pyobjc-framework-SystemConfiguration = "8.2"
+pyobjc-framework-SystemExtensions = {version = "8.2", markers = "platform_release >= \"19.0\""}
+pyobjc-framework-UniformTypeIdentifiers = {version = "8.2", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-UserNotifications = {version = "8.2", markers = "platform_release >= \"18.0\""}
+pyobjc-framework-UserNotificationsUI = {version = "8.2", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-VideoSubscriberAccount = {version = "8.2", markers = "platform_release >= \"18.0\""}
+pyobjc-framework-VideoToolbox = {version = "8.2", markers = "platform_release >= \"12.0\""}
+pyobjc-framework-Virtualization = {version = "8.2", markers = "platform_release >= \"20.0\""}
+pyobjc-framework-Vision = {version = "8.2", markers = "platform_release >= \"17.0\""}
+pyobjc-framework-WebKit = "8.2"
+
+[package.extras]
+allbindings = ["pyobjc-core (==8.2)", "pyobjc-framework-libdispatch (==8.2)", "pyobjc-framework-Accessibility (==8.2)", "pyobjc-framework-AdServices (==8.2)", "pyobjc-framework-AdSupport (==8.2)", "pyobjc-framework-AppTrackingTransparency (==8.2)", "pyobjc-framework-AudioVideoBridging (==8.2)", "pyobjc-framework-AuthenticationServices (==8.2)", "pyobjc-framework-AutomaticAssessmentConfiguration (==8.2)", "pyobjc-framework-AVKit (==8.2)", "pyobjc-framework-AVFoundation (==8.2)", "pyobjc-framework-Accounts (==8.2)", "pyobjc-framework-AddressBook (==8.2)", "pyobjc-framework-AppleScriptKit (==8.2)", "pyobjc-framework-AppleScriptObjC (==8.2)", "pyobjc-framework-ApplicationServices (==8.2)", "pyobjc-framework-Automator (==8.2)", "pyobjc-framework-BusinessChat (==8.2)", "pyobjc-framework-CFNetwork (==8.2)", "pyobjc-framework-CalendarStore (==8.2)", "pyobjc-framework-CallKit (==8.2)", "pyobjc-framework-ClassKit (==8.2)", "pyobjc-framework-CloudKit (==8.2)", "pyobjc-framework-Cocoa (==8.2)", "pyobjc-framework-Collaboration (==8.2)", "pyobjc-framework-ColorSync (==8.2)", "pyobjc-framework-Contacts (==8.2)", "pyobjc-framework-ContactsUI (==8.2)", "pyobjc-framework-CoreAudio (==8.2)", "pyobjc-framework-CoreAudioKit (==8.2)", "pyobjc-framework-CoreBluetooth (==8.2)", "pyobjc-framework-CoreData (==8.2)", "pyobjc-framework-CoreHaptics (==8.2)", "pyobjc-framework-CoreLocation (==8.2)", "pyobjc-framework-CoreMedia (==8.2)", "pyobjc-framework-CoreMediaIO (==8.2)", "pyobjc-framework-CoreMIDI (==8.2)", "pyobjc-framework-CoreML (==8.2)", "pyobjc-framework-CoreMotion (==8.2)", "pyobjc-framework-CoreServices (==8.2)", "pyobjc-framework-CoreSpotlight (==8.2)", "pyobjc-framework-CoreText (==8.2)", "pyobjc-framework-CoreWLAN (==8.2)", "pyobjc-framework-CryptoTokenKit (==8.2)", "pyobjc-framework-DataDetection (==8.2)", "pyobjc-framework-DeviceCheck (==8.2)", "pyobjc-framework-DictionaryServices (==8.2)", "pyobjc-framework-DiscRecording (==8.2)", "pyobjc-framework-DiscRecordingUI (==8.2)", "pyobjc-framework-DiskArbitration (==8.2)", "pyobjc-framework-DVDPlayback (==8.2)", "pyobjc-framework-EventKit (==8.2)", "pyobjc-framework-ExceptionHandling (==8.2)", "pyobjc-framework-ExecutionPolicy (==8.2)", "pyobjc-framework-ExternalAccessory (==8.2)", "pyobjc-framework-FileProvider (==8.2)", "pyobjc-framework-FileProviderUI (==8.2)", "pyobjc-framework-FSEvents (==8.2)", "pyobjc-framework-FinderSync (==8.2)", "pyobjc-framework-GameCenter (==8.2)", "pyobjc-framework-GameController (==8.2)", "pyobjc-framework-IMServicePlugIn (==8.2)", "pyobjc-framework-InputMethodKit (==8.2)", "pyobjc-framework-ImageCaptureCore (==8.2)", "pyobjc-framework-Intents (==8.2)", "pyobjc-framework-IntentsUI (==8.2)", "pyobjc-framework-InstallerPlugins (==8.2)", "pyobjc-framework-InstantMessage (==8.2)", "pyobjc-framework-IOSurface (==8.2)", "pyobjc-framework-KernelManagement (==8.2)", "pyobjc-framework-LatentSemanticMapping (==8.2)", "pyobjc-framework-LaunchServices (==8.2)", "pyobjc-framework-LinkPresentation (==8.2)", "pyobjc-framework-LocalAuthentication (==8.2)", "pyobjc-framework-LocalAuthenticationEmbeddedUI (==8.2)", "pyobjc-framework-MailKit (==8.2)", "pyobjc-framework-MapKit (==8.2)", "pyobjc-framework-MediaAccessibility (==8.2)", "pyobjc-framework-MediaLibrary (==8.2)", "pyobjc-framework-MediaPlayer (==8.2)", "pyobjc-framework-MediaToolbox (==8.2)", "pyobjc-framework-Message (==8.2)", "pyobjc-framework-Metal (==8.2)", "pyobjc-framework-MetalKit (==8.2)", "pyobjc-framework-MetalPerformanceShaders (==8.2)", "pyobjc-framework-MetalPerformanceShadersGraph (==8.2)", "pyobjc-framework-MetricKit (==8.2)", "pyobjc-framework-MLCompute (==8.2)", "pyobjc-framework-ModelIO (==8.2)", "pyobjc-framework-MultipeerConnectivity (==8.2)", "pyobjc-framework-NaturalLanguage (==8.2)", "pyobjc-framework-NetFS (==8.2)", "pyobjc-framework-Network (==8.2)", "pyobjc-framework-NetworkExtension (==8.2)", "pyobjc-framework-NotificationCenter (==8.2)", "pyobjc-framework-OpenDirectory (==8.2)", "pyobjc-framework-OSAKit (==8.2)", "pyobjc-framework-OSLog (==8.2)", "pyobjc-framework-PassKit (==8.2)", "pyobjc-framework-PencilKit (==8.2)", "pyobjc-framework-Photos (==8.2)", "pyobjc-framework-PhotosUI (==8.2)", "pyobjc-framework-PreferencePanes (==8.2)", "pyobjc-framework-PubSub (==8.2)", "pyobjc-framework-PushKit (==8.2)", "pyobjc-framework-Quartz (==8.2)", "pyobjc-framework-QuickLookThumbnailing (==8.2)", "pyobjc-framework-ReplayKit (==8.2)", "pyobjc-framework-SafariServices (==8.2)", "pyobjc-framework-ScreenSaver (==8.2)", "pyobjc-framework-ScreenTime (==8.2)", "pyobjc-framework-ScriptingBridge (==8.2)", "pyobjc-framework-Security (==8.2)", "pyobjc-framework-SecurityFoundation (==8.2)", "pyobjc-framework-SecurityInterface (==8.2)", "pyobjc-framework-SearchKit (==8.2)", "pyobjc-framework-ServerNotification (==8.2)", "pyobjc-framework-ServiceManagement (==8.2)", "pyobjc-framework-ShazamKit (==8.2)", "pyobjc-framework-Social (==8.2)", "pyobjc-framework-Speech (==8.2)", "pyobjc-framework-SpriteKit (==8.2)", "pyobjc-framework-StoreKit (==8.2)", "pyobjc-framework-SyncServices (==8.2)", "pyobjc-framework-SystemConfiguration (==8.2)", "pyobjc-framework-WebKit (==8.2)", "pyobjc-framework-GameKit (==8.2)", "pyobjc-framework-GameplayKit (==8.2)", "pyobjc-framework-SceneKit (==8.2)", "pyobjc-framework-SoundAnalysis (==8.2)", "pyobjc-framework-SystemExtensions (==8.2)", "pyobjc-framework-UniformTypeIdentifiers (==8.2)", "pyobjc-framework-UserNotifications (==8.2)", "pyobjc-framework-UserNotificationsUI (==8.2)", "pyobjc-framework-VideoSubscriberAccount (==8.2)", "pyobjc-framework-VideoToolbox (==8.2)", "pyobjc-framework-Virtualization (==8.2)", "pyobjc-framework-Vision (==8.2)", "pyobjc-framework-iTunesLibrary (==8.2)"]
 
 [[package]]
 name = "pyobjc-core"
-version = "7.3"
+version = "8.2"
 description = "Python<->ObjC Interoperability Module"
 category = "main"
 optional = true
@@ -1855,1628 +1883,1705 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "pyobjc-framework-accessibility"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework Accessibility on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
-pyobjc-framework-Quartz = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-Quartz = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-accounts"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework Accounts on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-addressbook"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework AddressBook on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-adservices"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework AdServices on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-adsupport"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework AdSupport on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-applescriptkit"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework AppleScriptKit on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-applescriptobjc"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework AppleScriptObjC on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-applicationservices"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework ApplicationServices on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
-pyobjc-framework-Quartz = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-Quartz = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-apptrackingtransparency"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework AppTrackingTransparency on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+
+[[package]]
+name = "pyobjc-framework-audiovideobridging"
+version = "8.2"
+description = "Wrappers for the framework AudioVideoBridging on macOS"
+category = "main"
+optional = true
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-authenticationservices"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework AuthenticationServices on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-automaticassessmentconfiguration"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework AutomaticAssessmentConfiguration on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-automator"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework Automator on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-avfoundation"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework AVFoundation on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
-pyobjc-framework-CoreMedia = ">=7.3"
-pyobjc-framework-Quartz = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-CoreAudio = ">=8.2"
+pyobjc-framework-CoreMedia = ">=8.2"
+pyobjc-framework-Quartz = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-avkit"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework AVKit on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
-pyobjc-framework-Quartz = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-Quartz = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-businesschat"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework BusinessChat on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-calendarstore"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework CalendarStore on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-callkit"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework CallKit on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-cfnetwork"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework CFNetwork on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-classkit"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework ClassKit on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-cloudkit"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework CloudKit on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Accounts = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
-pyobjc-framework-CoreData = ">=7.3"
-pyobjc-framework-CoreLocation = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Accounts = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-CoreData = ">=8.2"
+pyobjc-framework-CoreLocation = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-cocoa"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the Cocoa frameworks on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
+pyobjc-core = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-collaboration"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework Collaboration on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-colorsync"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework ColorSync on Mac OS X"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-contacts"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework Contacts on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-contactsui"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework ContactsUI on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
-pyobjc-framework-Contacts = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-Contacts = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-coreaudio"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework CoreAudio on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-coreaudiokit"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework CoreAudioKit on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
-pyobjc-framework-CoreAudio = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-CoreAudio = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-corebluetooth"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework CoreBluetooth on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-coredata"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework CoreData on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-corehaptics"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework CoreHaptics on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-corelocation"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework CoreLocation on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-coremedia"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework CoreMedia on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-coremediaio"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework CoreMediaIO on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-coremidi"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework CoreMIDI on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-coreml"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework CoreML on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-coremotion"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework CoreMotion on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-coreservices"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework CoreServices on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-FSEvents = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-FSEvents = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-corespotlight"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework CoreSpotlight on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-coretext"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework CoreText on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
-pyobjc-framework-Quartz = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-Quartz = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-corewlan"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework CoreWLAN on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-cryptotokenkit"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework CryptoTokenKit on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+
+[[package]]
+name = "pyobjc-framework-datadetection"
+version = "8.2"
+description = "Wrappers for the framework DataDetection on macOS"
+category = "main"
+optional = true
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-devicecheck"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework DeviceCheck on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-dictionaryservices"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework DictionaryServices on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-CoreServices = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-CoreServices = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-discrecording"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework DiscRecording on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-discrecordingui"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework DiscRecordingUI on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
-pyobjc-framework-DiscRecording = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-DiscRecording = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-diskarbitration"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework DiskArbitration on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-dvdplayback"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework DVDPlayback on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-eventkit"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework Accounts on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-exceptionhandling"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework ExceptionHandling on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-executionpolicy"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework ExecutionPolicy on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-externalaccessory"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework ExternalAccessory on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-fileprovider"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework FileProvider on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-fileproviderui"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework FileProviderUI on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-FileProvider = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-FileProvider = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-findersync"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework FinderSync on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-fsevents"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework FSEvents on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-gamecenter"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework GameCenter on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-gamecontroller"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework GameController on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-gamekit"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework GameKit on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
-pyobjc-framework-Quartz = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-Quartz = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-gameplaykit"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework GameplayKit on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
-pyobjc-framework-SpriteKit = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-SpriteKit = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-imagecapturecore"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework ImageCaptureCore on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-imserviceplugin"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework IMServicePlugIn on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-inputmethodkit"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework InputMethodKit on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-installerplugins"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework InstallerPlugins on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-instantmessage"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework InstantMessage on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
-pyobjc-framework-Quartz = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-Quartz = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-intents"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework Intents on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
-name = "pyobjc-framework-interfacebuilderkit"
-version = "7.3"
-description = "Wrappers for the framework InterfaceBuilderKit on macOS"
+name = "pyobjc-framework-intentsui"
+version = "8.2"
+description = "Wrappers for the framework Intents on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Intents = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-iosurface"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework IOSurface on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-ituneslibrary"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework iTunesLibrary on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-kernelmanagement"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework KernelManagement on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-latentsemanticmapping"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework LatentSemanticMapping on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-launchservices"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework LaunchServices on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-CoreServices = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-CoreServices = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-libdispatch"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for libdispatch on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
+pyobjc-core = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-linkpresentation"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework LinkPresentation on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
-pyobjc-framework-Quartz = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-Quartz = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-localauthentication"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework LocalAuthentication on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
-pyobjc-framework-Security = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-Security = ">=8.2"
+
+[[package]]
+name = "pyobjc-framework-localauthenticationembeddedui"
+version = "8.2"
+description = "Wrappers for the framework LocalAuthenticationEmbeddedUI on macOS"
+category = "main"
+optional = true
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-LocalAuthentication = ">=8.2"
+
+[[package]]
+name = "pyobjc-framework-mailkit"
+version = "8.2"
+description = "Wrappers for the framework MailKit on macOS"
+category = "main"
+optional = true
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-mapkit"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework MapKit on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
-pyobjc-framework-CoreLocation = ">=7.3"
-pyobjc-framework-Quartz = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-CoreLocation = ">=8.2"
+pyobjc-framework-Quartz = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-mediaaccessibility"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework MediaAccessibility on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-medialibrary"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework MediaLibrary on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
-pyobjc-framework-Quartz = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-Quartz = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-mediaplayer"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework MediaPlayer on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-AVFoundation = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-AVFoundation = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-mediatoolbox"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework MediaToolbox on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-message"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework Message on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-metal"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework Metal on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-metalkit"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework MetalKit on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
-pyobjc-framework-Metal = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-Metal = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-metalperformanceshaders"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework MetalPerformanceShaders on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Metal = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Metal = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-metalperformanceshadersgraph"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework MetalPerformanceShadersGraph on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-MetalPerformanceShaders = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-MetalPerformanceShaders = ">=8.2"
+
+[[package]]
+name = "pyobjc-framework-metrickit"
+version = "8.2"
+description = "Wrappers for the framework MetricKit on macOS"
+category = "main"
+optional = true
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-mlcompute"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework MLCompute on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-modelio"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework ModelIO on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
-pyobjc-framework-Quartz = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-Quartz = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-multipeerconnectivity"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework MultipeerConnectivity on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-naturallanguage"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework NaturalLanguage on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-netfs"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework NetFS on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-network"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework Network on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-networkextension"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework NetworkExtension on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-notificationcenter"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework NotificationCenter on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-opendirectory"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework OpenDirectory on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-osakit"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework OSAKit on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-oslog"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework OSLog on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
-pyobjc-framework-CoreMedia = ">=7.3"
-pyobjc-framework-Quartz = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-CoreMedia = ">=8.2"
+pyobjc-framework-Quartz = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-passkit"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework PassKit on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-pencilkit"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework PencilKit on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-photos"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework Photos on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-photosui"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework PhotosUI on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-preferencepanes"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework PreferencePanes on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-pubsub"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework PubSub on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-pushkit"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework PushKit on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-quartz"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the Quartz frameworks on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-quicklookthumbnailing"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework QuickLookThumbnailing on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
-pyobjc-framework-Quartz = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-Quartz = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-replaykit"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework ReplayKit on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-safariservices"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework SafariServices on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-scenekit"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework SceneKit on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
-pyobjc-framework-Quartz = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-Quartz = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-screensaver"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework ScreenSaver on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-screentime"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework ScreenTime on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-scriptingbridge"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework ScriptingBridge on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-searchkit"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework SearchKit on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-CoreServices = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-CoreServices = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-security"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework Security on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-securityfoundation"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework SecurityFoundation on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
-pyobjc-framework-Security = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-Security = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-securityinterface"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework SecurityInterface on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
-pyobjc-framework-Security = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-Security = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-servernotification"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework ServerNotification on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-servicemanagement"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework ServiceManagement on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+
+[[package]]
+name = "pyobjc-framework-shazamkit"
+version = "8.2"
+description = "Wrappers for the framework ShazamKit on macOS"
+category = "main"
+optional = true
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-social"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework Social on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-soundanalysis"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework SoundAnalysis on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-speech"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework Speech on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-spritekit"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework SpriteKit on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
-pyobjc-framework-Quartz = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-Quartz = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-storekit"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework StoreKit on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-syncservices"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework SyncServices on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
-pyobjc-framework-CoreData = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-CoreData = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-systemconfiguration"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework SystemConfiguration on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-systemextensions"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework SystemExtensions on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-uniformtypeidentifiers"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework UniformTypeIdentifiers on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-usernotifications"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework UserNotifications on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-usernotificationsui"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework UserNotificationsUI on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
-pyobjc-framework-UserNotifications = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-UserNotifications = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-videosubscriberaccount"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework VideoSubscriberAccount on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-videotoolbox"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework VideoToolbox on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
-pyobjc-framework-CoreMedia = ">=7.3"
-pyobjc-framework-Quartz = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-CoreMedia = ">=8.2"
+pyobjc-framework-Quartz = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-virtualization"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework Virtualization on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-vision"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework Vision on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
-pyobjc-framework-CoreML = ">=7.3"
-pyobjc-framework-Quartz = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
+pyobjc-framework-CoreML = ">=8.2"
+pyobjc-framework-Quartz = ">=8.2"
 
 [[package]]
 name = "pyobjc-framework-webkit"
-version = "7.3"
+version = "8.2"
 description = "Wrappers for the framework WebKit on macOS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyobjc-core = ">=7.3"
-pyobjc-framework-Cocoa = ">=7.3"
+pyobjc-core = ">=8.2"
+pyobjc-framework-Cocoa = ">=8.2"
 
 [[package]]
 name = "pyparsing"
-version = "2.4.7"
+version = "3.0.7"
 description = "Python parsing module"
 category = "main"
 optional = true
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+python-versions = ">=3.6"
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pyqt5"
@@ -3510,11 +3615,11 @@ PyQt5 = ">=5.12"
 
 [[package]]
 name = "pyrsistent"
-version = "0.18.0"
+version = "0.18.1"
 description = "Persistent/Functional/Immutable data structures"
 category = "main"
 optional = true
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [[package]]
 name = "pytest"
@@ -3551,7 +3656,7 @@ six = ">=1.5"
 
 [[package]]
 name = "python-lsp-black"
-version = "1.0.0"
+version = "1.0.1"
 description = "Black plugin for the Python LSP Server"
 category = "main"
 optional = true
@@ -3563,7 +3668,7 @@ python-lsp-server = "*"
 toml = "*"
 
 [package.extras]
-dev = ["isort (>=5.0)", "flake8", "pytest", "mypy"]
+dev = ["flake8", "isort (>=5.0)", "mypy", "pre-commit", "pytest", "types-pkg-resources", "types-setuptools", "types-toml"]
 
 [[package]]
 name = "python-lsp-jsonrpc"
@@ -3639,7 +3744,7 @@ python-versions = "*"
 
 [[package]]
 name = "pywin32"
-version = "302"
+version = "303"
 description = "Python for Window Extensions"
 category = "main"
 optional = true
@@ -3726,7 +3831,7 @@ test = ["pytest (>=6,<7)", "pytest-mock (>=3,<4)", "pytest-catchlog (>=1,<2)"]
 
 [[package]]
 name = "qtawesome"
-version = "1.1.0"
+version = "1.1.1"
 description = "FontAwesome icons in PyQt and PySide applications"
 category = "main"
 optional = true
@@ -3737,7 +3842,7 @@ qtpy = "*"
 
 [[package]]
 name = "qtconsole"
-version = "5.1.1"
+version = "5.2.2"
 description = "Jupyter Qt console"
 category = "main"
 optional = true
@@ -3759,23 +3864,21 @@ test = ["flaky", "pytest", "pytest-qt"]
 
 [[package]]
 name = "qtpy"
-version = "1.11.2"
-description = "Provides an abstraction layer on top of the various Qt bindings (PyQt5, PyQt4 and PySide) and additional custom QWidgets."
+version = "2.0.0"
+description = "Provides an abstraction layer on top of the various Qt bindings (PyQt5/6 and PySide2/6)."
 category = "main"
 optional = true
-python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"
+python-versions = ">=3.6"
 
-[[package]]
-name = "regex"
-version = "2021.11.2"
-description = "Alternative regular expression module, to replace re."
-category = "main"
-optional = true
-python-versions = "*"
+[package.dependencies]
+packaging = "*"
+
+[package.extras]
+test = ["pytest (>=6.0.0,<7.0)", "pytest-cov (>=2.11.0)"]
 
 [[package]]
 name = "requests"
-version = "2.26.0"
+version = "2.27.1"
 description = "Python HTTP for Humans."
 category = "main"
 optional = false
@@ -3808,14 +3911,14 @@ rsa = ["oauthlib[signedtoken] (>=3.0.0)"]
 
 [[package]]
 name = "rope"
-version = "0.21.0"
+version = "0.22.0"
 description = "a python refactoring library..."
 category = "main"
 optional = true
 python-versions = "*"
 
 [package.extras]
-dev = ["pytest", "pytest-timeout"]
+dev = ["build", "pytest", "pytest-timeout"]
 
 [[package]]
 name = "rsa"
@@ -3852,7 +3955,7 @@ crt = ["botocore[crt] (>=1.20.29,<2.0a.0)"]
 
 [[package]]
 name = "scipy"
-version = "1.7.2"
+version = "1.7.3"
 description = "SciPy: Scientific Library for Python"
 category = "main"
 optional = true
@@ -3889,7 +3992,7 @@ jeepney = ">=0.6"
 
 [[package]]
 name = "sentry-sdk"
-version = "1.4.3"
+version = "1.5.4"
 description = "Python client for Sentry (https://sentry.io)"
 category = "main"
 optional = false
@@ -3911,14 +4014,31 @@ flask = ["flask (>=0.11)", "blinker (>=1.1)"]
 httpx = ["httpx (>=0.16.0)"]
 pure_eval = ["pure-eval", "executing", "asttokens"]
 pyspark = ["pyspark (>=2.4.4)"]
+quart = ["quart (>=0.16.1)", "blinker (>=1.1)"]
 rq = ["rq (>=0.6)"]
 sanic = ["sanic (>=0.8)"]
 sqlalchemy = ["sqlalchemy (>=1.2)"]
 tornado = ["tornado (>=5)"]
 
 [[package]]
+name = "setuptools-scm"
+version = "6.4.2"
+description = "the blessed package to manage your versions by scm tags"
+category = "main"
+optional = true
+python-versions = ">=3.6"
+
+[package.dependencies]
+packaging = ">=20.0"
+tomli = ">=1.0.0"
+
+[package.extras]
+test = ["pytest (>=6.2)", "virtualenv (>20)"]
+toml = ["setuptools (>=42)"]
+
+[[package]]
 name = "shortuuid"
-version = "1.0.1"
+version = "1.0.8"
 description = "A generator library for concise, unambiguous and URL-safe UUIDs."
 category = "main"
 optional = false
@@ -3942,7 +4062,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "snowballstemmer"
-version = "2.1.0"
+version = "2.2.0"
 description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
 category = "main"
 optional = true
@@ -3958,7 +4078,7 @@ python-versions = "*"
 
 [[package]]
 name = "sphinx"
-version = "4.2.0"
+version = "4.4.0"
 description = "Python documentation generator"
 category = "main"
 optional = true
@@ -3970,6 +4090,7 @@ babel = ">=1.3"
 colorama = {version = ">=0.3.5", markers = "sys_platform == \"win32\""}
 docutils = ">=0.14,<0.18"
 imagesize = "*"
+importlib-metadata = {version = ">=4.4", markers = "python_version < \"3.10\""}
 Jinja2 = ">=2.3"
 packaging = "*"
 Pygments = ">=2.0"
@@ -3984,7 +4105,7 @@ sphinxcontrib-serializinghtml = ">=1.1.5"
 
 [package.extras]
 docs = ["sphinxcontrib-websupport"]
-lint = ["flake8 (>=3.5.0)", "isort", "mypy (>=0.900)", "docutils-stubs", "types-typed-ast", "types-pkg-resources", "types-requests"]
+lint = ["flake8 (>=3.5.0)", "isort", "mypy (>=0.931)", "docutils-stubs", "types-typed-ast", "types-requests"]
 test = ["pytest", "pytest-cov", "html5lib", "cython", "typed-ast"]
 
 [[package]]
@@ -4159,7 +4280,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, <4"
 
 [[package]]
 name = "tensorboard"
-version = "2.7.0"
+version = "2.8.0"
 description = "TensorBoard lets you watch Tensors Flow"
 category = "main"
 optional = false
@@ -4188,7 +4309,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "tensorboard-plugin-wit"
-version = "1.8.0"
+version = "1.8.1"
 description = "What-If Tool TensorBoard plugin."
 category = "main"
 optional = false
@@ -4259,8 +4380,8 @@ test = ["pytest", "pytest-cov", "flaky", "pytest-timeout"]
 
 [[package]]
 name = "tinycss2"
-version = "1.1.0"
-description = "tinycss2"
+version = "1.1.1"
+description = "A tiny CSS parser"
 category = "main"
 optional = true
 python-versions = ">=3.6"
@@ -4282,7 +4403,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "tomli"
-version = "1.2.2"
+version = "1.2.3"
 description = "A lil' TOML parser"
 category = "main"
 optional = true
@@ -4290,7 +4411,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "torch"
-version = "1.10.0"
+version = "1.10.2"
 description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
 category = "main"
 optional = false
@@ -4344,23 +4465,23 @@ python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
-version = "3.10.0.2"
-description = "Backported and Experimental Type Hints for Python 3.5+"
+version = "4.0.1"
+description = "Backported and Experimental Type Hints for Python 3.6+"
 category = "main"
 optional = false
-python-versions = "*"
-
-[[package]]
-name = "ujson"
-version = "4.2.0"
-description = "Ultra fast JSON encoder and decoder for Python"
-category = "main"
-optional = true
 python-versions = ">=3.6"
 
 [[package]]
+name = "ujson"
+version = "5.1.0"
+description = "Ultra fast JSON encoder and decoder for Python"
+category = "main"
+optional = true
+python-versions = ">=3.7"
+
+[[package]]
 name = "urllib3"
-version = "1.26.7"
+version = "1.26.8"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
@@ -4373,7 +4494,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "wandb"
-version = "0.12.6"
+version = "0.12.9"
 description = "A CLI and library for interacting with the Weights and Biases API."
 category = "main"
 optional = false
@@ -4400,10 +4521,11 @@ yaspin = ">=1.0.0"
 [package.extras]
 aws = ["boto3"]
 gcp = ["google-cloud-storage"]
+grpc = ["grpcio (>=1.27.2)", "setproctitle"]
 kubeflow = ["kubernetes", "minio", "google-cloud-storage", "sh"]
 launch = ["jupyter-repo2docker", "nbconvert", "chardet", "iso8601", "typing-extensions", "yaspin"]
-media = ["numpy", "moviepy", "pillow", "bokeh", "soundfile", "plotly"]
-service = ["grpcio (>=1.27.2)", "setproctitle"]
+media = ["numpy", "moviepy", "pillow", "bokeh", "soundfile", "plotly", "rdkit-pypi"]
+service = ["setproctitle"]
 sweeps = ["numpy (>=1.15,<1.21)", "scipy (>=1.5.4)", "pyyaml", "scikit-learn (==0.24.1)", "jsonschema (>=3.2.0)", "jsonref (>=0.2)", "pydantic (>=1.8.2)"]
 
 [[package]]
@@ -4462,7 +4584,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "yapf"
-version = "0.31.0"
+version = "0.32.0"
 description = "A formatter for Python code."
 category = "main"
 optional = true
@@ -4481,15 +4603,15 @@ termcolor = ">=1.1.0,<2.0.0"
 
 [[package]]
 name = "zipp"
-version = "3.6.0"
+version = "3.7.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [extras]
 atari = ["ale-py", "AutoROM", "stable-baselines3"]
@@ -4506,12 +4628,12 @@ spyder = ["spyder"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<3.10"
-content-hash = "cace981d14d5862babb007bf140cb7304760e8cdf69b6f48e2e7e911bde73145"
+content-hash = "340df3ea47e965ceb0a5e33b5e8c288ac91f92205eec11dc23148caaf93959b2"
 
 [metadata.files]
 absl-py = [
-    {file = "absl-py-0.15.0.tar.gz", hash = "sha256:72d782fbeafba66ba3e525d46bccac949b9a174dbf66233e50ece09ee688dc81"},
-    {file = "absl_py-0.15.0-py3-none-any.whl", hash = "sha256:ea907384af023a7e681368bedb896159ab100c7db593efbbd5cde22af11270cd"},
+    {file = "absl-py-1.0.0.tar.gz", hash = "sha256:ac511215c01ee9ae47b19716599e8ccfa746f2e18de72bdf641b79b22afa27ea"},
+    {file = "absl_py-1.0.0-py3-none-any.whl", hash = "sha256:84e6dcdc69c947d0c13e5457d056bd43cade4c2393dce00d684aedea77ddc2a3"},
 ]
 alabaster = [
     {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
@@ -4542,13 +4664,9 @@ appnope = [
     {file = "appnope-0.1.2-py2.py3-none-any.whl", hash = "sha256:93aa393e9d6c54c5cd570ccadd8edad61ea0c4b9ea7a01409020c9aa019eb442"},
     {file = "appnope-0.1.2.tar.gz", hash = "sha256:dd83cd4b5b460958838f6eb3000c660b1f9caf2a5b1de4264e941512f603258a"},
 ]
-argcomplete = [
-    {file = "argcomplete-1.12.3-py2.py3-none-any.whl", hash = "sha256:291f0beca7fd49ce285d2f10e4c1c77e9460cf823eef2de54df0c0fec88b0d81"},
-    {file = "argcomplete-1.12.3.tar.gz", hash = "sha256:2c7dbffd8c045ea534921e63b0be6fe65e88599990d8dc408ac8c542b72a5445"},
-]
 arrow = [
-    {file = "arrow-1.2.1-py3-none-any.whl", hash = "sha256:6b2914ef3997d1fd7b37a71ce9dd61a6e329d09e1c7b44f4d3099ca4a5c0933e"},
-    {file = "arrow-1.2.1.tar.gz", hash = "sha256:c2dde3c382d9f7e6922ce636bf0b318a7a853df40ecb383b29192e6c5cc82840"},
+    {file = "arrow-1.2.2-py3-none-any.whl", hash = "sha256:d622c46ca681b5b3e3574fcb60a04e5cc81b9625112d5fb2b44220c36c892177"},
+    {file = "arrow-1.2.2.tar.gz", hash = "sha256:05caf1fd3d9a11a1135b2b6f09887421153b94558e5ef4d090b567b47173ac2b"},
 ]
 astroid = [
     {file = "astroid-2.6.6-py3-none-any.whl", hash = "sha256:ab7f36e8a78b8e54a62028ba6beef7561db4cdb6f2a5009ecc44a6f42b5697ef"},
@@ -4559,8 +4677,8 @@ atomicwrites = [
     {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
-    {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
-    {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
+    {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
+    {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
 ]
 autopep8 = [
     {file = "autopep8-1.5.7-py2.py3-none-any.whl", hash = "sha256:aa213493c30dcdac99537249ee65b24af0b2c29f2e83cd8b3f68760441ed0db9"},
@@ -4574,8 +4692,8 @@ autorom = [
     {file = "AutoROM.accept-rom-license-0.4.2.tar.gz", hash = "sha256:f08654c9d2a6837c5ec951c0364bda352510920ea0523005a2d4460c7d2be7f2"},
 ]
 awscli = [
-    {file = "awscli-1.21.12-py3-none-any.whl", hash = "sha256:1e144696a09ed7dad44a00b3bbd4e5da9c026fe9a33624b02fad1de411c9bdc5"},
-    {file = "awscli-1.21.12.tar.gz", hash = "sha256:e9417f5c4f4851a659d14eeae930b50ab3490361e2473573134bc839e6aefa32"},
+    {file = "awscli-1.22.45-py3-none-any.whl", hash = "sha256:4da9430559db13bdde4d4d9f9b473153cb7ea2bdaf18ac226e1e266ee19f72d2"},
+    {file = "awscli-1.22.45.tar.gz", hash = "sha256:8a2e30068c9aac7525e05e6e05b2c110625c58609ed51d2ff20b21d5e12a6b1b"},
 ]
 babel = [
     {file = "Babel-2.9.1-py2.py3-none-any.whl", hash = "sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9"},
@@ -4599,24 +4717,24 @@ binaryornot = [
     {file = "binaryornot-0.4.4.tar.gz", hash = "sha256:359501dfc9d40632edc9fac890e19542db1a287bbcfa58175b66658392018061"},
 ]
 black = [
-    {file = "black-21.10b0-py3-none-any.whl", hash = "sha256:6eb7448da9143ee65b856a5f3676b7dda98ad9abe0f87fce8c59291f15e82a5b"},
-    {file = "black-21.10b0.tar.gz", hash = "sha256:a9952229092e325fe5f3dae56d81f639b23f7131eb840781947e4b2886030f33"},
+    {file = "black-21.12b0-py3-none-any.whl", hash = "sha256:a615e69ae185e08fdd73e4715e260e2479c861b5740057fde6e8b4e3b7dd589f"},
+    {file = "black-21.12b0.tar.gz", hash = "sha256:77b80f693a569e2e527958459634f18df9b0ba2625ba4e0c2d5da5be42e6f2b3"},
 ]
 bleach = [
     {file = "bleach-4.1.0-py2.py3-none-any.whl", hash = "sha256:4d2651ab93271d1129ac9cbc679f524565cc8a1b791909c4a51eac4446a15994"},
     {file = "bleach-4.1.0.tar.gz", hash = "sha256:0900d8b37eba61a802ee40ac0061f8c2b5dee29c1927dd1d233e075ebf5a71da"},
 ]
 boto3 = [
-    {file = "boto3-1.19.12-py3-none-any.whl", hash = "sha256:b9105554477978e80fda1103ff21ecf07502080667730e45383e1d3951c87954"},
-    {file = "boto3-1.19.12.tar.gz", hash = "sha256:182a2b756a2c2180b473bc8452227062394a24e3701548be23ebc30d85976c64"},
+    {file = "boto3-1.20.45-py3-none-any.whl", hash = "sha256:2ea0e0aa1494ef87a342260da8d9381000d774e73d83ee3d7c2906fefcbe2c32"},
+    {file = "boto3-1.20.45.tar.gz", hash = "sha256:3d9cb5edeff09598b7065abe5b42affb0b6e1c0c805ab57c051d0f3592a0f02b"},
 ]
 botocore = [
-    {file = "botocore-1.22.12-py3-none-any.whl", hash = "sha256:1d1094fb53ebe4535d8840fbd7c14aadb65bde7ff03a65f9a4f1d76bd03e16ff"},
-    {file = "botocore-1.22.12.tar.gz", hash = "sha256:fc59b55e8c5dde64b017b2f114c25f8cce397b667e812aea7eafb4b59b49d7cb"},
+    {file = "botocore-1.23.45-py3-none-any.whl", hash = "sha256:793a0a4b572bfb157ba17971e4d783766f59c5a0f117407bbeefeb577efa1ed1"},
+    {file = "botocore-1.23.45.tar.gz", hash = "sha256:782323846dad22ea814a64bd64b89c7f04550812d3945ce77748b2bac6fe745b"},
 ]
 cachetools = [
-    {file = "cachetools-4.2.4-py3-none-any.whl", hash = "sha256:92971d3cb7d2a97efff7c7bb1657f21a8f5fb309a37530537c71b1774189f2d1"},
-    {file = "cachetools-4.2.4.tar.gz", hash = "sha256:89ea6f1b638d5a73a4f9226be57ac5e4f399d22770b92355f92dcb0f7f001693"},
+    {file = "cachetools-5.0.0-py3-none-any.whl", hash = "sha256:8fecd4203a38af17928be7b90689d8083603073622229ca7077b72d8e5a976e4"},
+    {file = "cachetools-5.0.0.tar.gz", hash = "sha256:486471dfa8799eb7ec503a8059e263db000cdda20075ce5e48903087f79d5fd6"},
 ]
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
@@ -4679,8 +4797,8 @@ chardet = [
     {file = "chardet-4.0.0.tar.gz", hash = "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa"},
 ]
 charset-normalizer = [
-    {file = "charset-normalizer-2.0.7.tar.gz", hash = "sha256:e019de665e2bcf9c2b64e2e5aa025fa991da8720daa3c1138cadd2fd1856aed0"},
-    {file = "charset_normalizer-2.0.7-py3-none-any.whl", hash = "sha256:f7af805c321bfa1ce6714c51f254e0d5bb5e5834039bc17db7ebe3a4cec9492b"},
+    {file = "charset-normalizer-2.0.10.tar.gz", hash = "sha256:876d180e9d7432c5d1dfd4c5d26b72f099d503e8fcc0feb7532c9289be60fcbd"},
+    {file = "charset_normalizer-2.0.10-py3-none-any.whl", hash = "sha256:cb957888737fc0bbcd78e3df769addb41fd1ff8cf950dc9e7ad7793f1bf44455"},
 ]
 click = [
     {file = "click-8.0.3-py3-none-any.whl", hash = "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3"},
@@ -4695,79 +4813,86 @@ colorama = [
     {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
 ]
 configparser = [
-    {file = "configparser-5.1.0-py3-none-any.whl", hash = "sha256:f99c2256b24c551de13cf9e42c7b5db96fb133f0ca4de5dcb1df1aaf89f48298"},
-    {file = "configparser-5.1.0.tar.gz", hash = "sha256:202b9679a809b703720afa2eacaad4c6c2d63196070e5d9edc953c0489dfd536"},
+    {file = "configparser-5.2.0-py3-none-any.whl", hash = "sha256:e8b39238fb6f0153a069aa253d349467c3c4737934f253ef6abac5fe0eca1e5d"},
+    {file = "configparser-5.2.0.tar.gz", hash = "sha256:1b35798fdf1713f1c3139016cfcbc461f09edbf099d1fb658d4b7479fcaa3daa"},
 ]
 cookiecutter = [
     {file = "cookiecutter-1.7.3-py2.py3-none-any.whl", hash = "sha256:f8671531fa96ab14339d0c59b4f662a4f12a2ecacd94a0f70a3500843da588e2"},
     {file = "cookiecutter-1.7.3.tar.gz", hash = "sha256:6b9a4d72882e243be077a7397d0f1f76fe66cf3df91f3115dbb5330e214fa457"},
 ]
 cryptography = [
-    {file = "cryptography-35.0.0-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:d57e0cdc1b44b6cdf8af1d01807db06886f10177469312fbde8f44ccbb284bc9"},
-    {file = "cryptography-35.0.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:ced40344e811d6abba00295ced98c01aecf0c2de39481792d87af4fa58b7b4d6"},
-    {file = "cryptography-35.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:54b2605e5475944e2213258e0ab8696f4f357a31371e538ef21e8d61c843c28d"},
-    {file = "cryptography-35.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:7b7ceeff114c31f285528ba8b390d3e9cfa2da17b56f11d366769a807f17cbaa"},
-    {file = "cryptography-35.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d69645f535f4b2c722cfb07a8eab916265545b3475fdb34e0be2f4ee8b0b15e"},
-    {file = "cryptography-35.0.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a2d0e0acc20ede0f06ef7aa58546eee96d2592c00f450c9acb89c5879b61992"},
-    {file = "cryptography-35.0.0-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:07bb7fbfb5de0980590ddfc7f13081520def06dc9ed214000ad4372fb4e3c7f6"},
-    {file = "cryptography-35.0.0-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:7eba2cebca600a7806b893cb1d541a6e910afa87e97acf2021a22b32da1df52d"},
-    {file = "cryptography-35.0.0-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:18d90f4711bf63e2fb21e8c8e51ed8189438e6b35a6d996201ebd98a26abbbe6"},
-    {file = "cryptography-35.0.0-cp36-abi3-win32.whl", hash = "sha256:c10c797ac89c746e488d2ee92bd4abd593615694ee17b2500578b63cad6b93a8"},
-    {file = "cryptography-35.0.0-cp36-abi3-win_amd64.whl", hash = "sha256:7075b304cd567694dc692ffc9747f3e9cb393cc4aa4fb7b9f3abd6f5c4e43588"},
-    {file = "cryptography-35.0.0-pp36-pypy36_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a688ebcd08250eab5bb5bca318cc05a8c66de5e4171a65ca51db6bd753ff8953"},
-    {file = "cryptography-35.0.0-pp36-pypy36_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d99915d6ab265c22873f1b4d6ea5ef462ef797b4140be4c9d8b179915e0985c6"},
-    {file = "cryptography-35.0.0-pp36-pypy36_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:928185a6d1ccdb816e883f56ebe92e975a262d31cc536429041921f8cb5a62fd"},
-    {file = "cryptography-35.0.0-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:ebeddd119f526bcf323a89f853afb12e225902a24d29b55fe18dd6fcb2838a76"},
-    {file = "cryptography-35.0.0-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:22a38e96118a4ce3b97509443feace1d1011d0571fae81fc3ad35f25ba3ea999"},
-    {file = "cryptography-35.0.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb80e8a1f91e4b7ef8b33041591e6d89b2b8e122d787e87eeb2b08da71bb16ad"},
-    {file = "cryptography-35.0.0-pp37-pypy37_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:abb5a361d2585bb95012a19ed9b2c8f412c5d723a9836418fab7aaa0243e67d2"},
-    {file = "cryptography-35.0.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:1ed82abf16df40a60942a8c211251ae72858b25b7421ce2497c2eb7a1cee817c"},
-    {file = "cryptography-35.0.0.tar.gz", hash = "sha256:9933f28f70d0517686bd7de36166dda42094eac49415459d9bdf5e7df3e0086d"},
+    {file = "cryptography-36.0.1-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:73bc2d3f2444bcfeac67dd130ff2ea598ea5f20b40e36d19821b4df8c9c5037b"},
+    {file = "cryptography-36.0.1-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:2d87cdcb378d3cfed944dac30596da1968f88fb96d7fc34fdae30a99054b2e31"},
+    {file = "cryptography-36.0.1-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:74d6c7e80609c0f4c2434b97b80c7f8fdfaa072ca4baab7e239a15d6d70ed73a"},
+    {file = "cryptography-36.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:6c0c021f35b421ebf5976abf2daacc47e235f8b6082d3396a2fe3ccd537ab173"},
+    {file = "cryptography-36.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d59a9d55027a8b88fd9fd2826c4392bd487d74bf628bb9d39beecc62a644c12"},
+    {file = "cryptography-36.0.1-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0a817b961b46894c5ca8a66b599c745b9a3d9f822725221f0e0fe49dc043a3a3"},
+    {file = "cryptography-36.0.1-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:94ae132f0e40fe48f310bba63f477f14a43116f05ddb69d6fa31e93f05848ae2"},
+    {file = "cryptography-36.0.1-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:7be0eec337359c155df191d6ae00a5e8bbb63933883f4f5dffc439dac5348c3f"},
+    {file = "cryptography-36.0.1-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:e0344c14c9cb89e76eb6a060e67980c9e35b3f36691e15e1b7a9e58a0a6c6dc3"},
+    {file = "cryptography-36.0.1-cp36-abi3-win32.whl", hash = "sha256:4caa4b893d8fad33cf1964d3e51842cd78ba87401ab1d2e44556826df849a8ca"},
+    {file = "cryptography-36.0.1-cp36-abi3-win_amd64.whl", hash = "sha256:391432971a66cfaf94b21c24ab465a4cc3e8bf4a939c1ca5c3e3a6e0abebdbcf"},
+    {file = "cryptography-36.0.1-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:bb5829d027ff82aa872d76158919045a7c1e91fbf241aec32cb07956e9ebd3c9"},
+    {file = "cryptography-36.0.1-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ebc15b1c22e55c4d5566e3ca4db8689470a0ca2babef8e3a9ee057a8b82ce4b1"},
+    {file = "cryptography-36.0.1-pp37-pypy37_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:596f3cd67e1b950bc372c33f1a28a0692080625592ea6392987dba7f09f17a94"},
+    {file = "cryptography-36.0.1-pp38-pypy38_pp73-macosx_10_10_x86_64.whl", hash = "sha256:30ee1eb3ebe1644d1c3f183d115a8c04e4e603ed6ce8e394ed39eea4a98469ac"},
+    {file = "cryptography-36.0.1-pp38-pypy38_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ec63da4e7e4a5f924b90af42eddf20b698a70e58d86a72d943857c4c6045b3ee"},
+    {file = "cryptography-36.0.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca238ceb7ba0bdf6ce88c1b74a87bffcee5afbfa1e41e173b1ceb095b39add46"},
+    {file = "cryptography-36.0.1-pp38-pypy38_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:ca28641954f767f9822c24e927ad894d45d5a1e501767599647259cbf030b903"},
+    {file = "cryptography-36.0.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:39bdf8e70eee6b1c7b289ec6e5d84d49a6bfa11f8b8646b5b3dfe41219153316"},
+    {file = "cryptography-36.0.1.tar.gz", hash = "sha256:53e5c1dc3d7a953de055d77bef2ff607ceef7a2aac0353b5d630ab67f7423638"},
 ]
 cycler = [
     {file = "cycler-0.11.0-py3-none-any.whl", hash = "sha256:3a27e95f763a428a739d2add979fa7494c912a32c17c4c38c4d5f082cad165a3"},
     {file = "cycler-0.11.0.tar.gz", hash = "sha256:9c87405839a19696e837b3b818fed3f5f69f16f1eec1a1ad77e043dcea9c772f"},
 ]
 cython = [
-    {file = "Cython-0.29.24-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:6a2cf2ccccc25413864928dfd730c29db6f63eaf98206c1e600003a445ca7f58"},
-    {file = "Cython-0.29.24-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:b28f92e617f540d3f21f8fd479a9c6491be920ffff672a4c61b7fc4d7f749f39"},
-    {file = "Cython-0.29.24-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:37bcfa5df2a3009f49624695d917c3804fccbdfcdc5eda6378754a879711a4d5"},
-    {file = "Cython-0.29.24-cp27-cp27m-win32.whl", hash = "sha256:9164aeef1af6f837e4fc20402a31d256188ba4d535e262c6cb78caf57ad744f8"},
-    {file = "Cython-0.29.24-cp27-cp27m-win_amd64.whl", hash = "sha256:73ac33a4379056a02031baa4def255717fadb9181b5ac2b244792d53eae1c925"},
-    {file = "Cython-0.29.24-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:09ac3087ac7a3d489ebcb3fb8402e00c13d1a3a1c6bc73fd3b0d756a3e341e79"},
-    {file = "Cython-0.29.24-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:774cb8fd931ee1ba52c472bc1c19077cd6895c1b24014ae07bb27df59aed5ebe"},
-    {file = "Cython-0.29.24-cp34-cp34m-win32.whl", hash = "sha256:5dd56d0be50073f0e54825a8bc3393852de0eed126339ecbca0ae149dba55cfc"},
-    {file = "Cython-0.29.24-cp34-cp34m-win_amd64.whl", hash = "sha256:88dc3c250dec280b0489a83950b15809762e27232f4799b1b8d0bad503f5ab84"},
-    {file = "Cython-0.29.24-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:5fa12ebafc2f688ea6d26ab6d1d2e634a9872509ba7135b902bb0d8b368fb04b"},
-    {file = "Cython-0.29.24-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:60c958bcab0ff315b4036a949bed1c65334e1f6a69e17e9966d742febb59043a"},
-    {file = "Cython-0.29.24-cp35-cp35m-win32.whl", hash = "sha256:166f9f29cd0058ce1a14a7b3a2458b849ed34b1ec5fd4108af3fdd2c24afcbb0"},
-    {file = "Cython-0.29.24-cp35-cp35m-win_amd64.whl", hash = "sha256:76cbca0188d278e93d12ebdaf5990678e6e436485fdfad49dbe9b07717d41a3c"},
-    {file = "Cython-0.29.24-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f2e9381497b12e8f622af620bde0d1d094035d79b899abb2ddd3a7891f535083"},
-    {file = "Cython-0.29.24-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:d8d1a087f35e39384303f5e6b75d465d6f29d746d7138eae9d3b6e8e6f769eae"},
-    {file = "Cython-0.29.24-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:112efa54a58293a4fb0acf0dd8e5b3736e95b595eee24dd88615648e445abe41"},
-    {file = "Cython-0.29.24-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4cf4452f0e4d50e11701bca38f3857fe6fa16593e7fd6a4d5f7be66f611b7da2"},
-    {file = "Cython-0.29.24-cp36-cp36m-win32.whl", hash = "sha256:854fe2193d3ad4c8b61932ff54d6dbe10c5fa8749eb8958d72cc0ab28243f833"},
-    {file = "Cython-0.29.24-cp36-cp36m-win_amd64.whl", hash = "sha256:84826ec1c11cda56261a252ddecac0c7d6b02e47e81b94f40b27b4c23c29c17c"},
-    {file = "Cython-0.29.24-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6ade74eece909fd3a437d9a5084829180751d7ade118e281e9824dd75eafaff2"},
-    {file = "Cython-0.29.24-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:0a142c6b862e6ed6b02209d543062c038c110585b5e32d1ad7c9717af4f07e41"},
-    {file = "Cython-0.29.24-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:10cb3def9774fa99e4583617a5616874aed3255dc241fd1f4a3c2978c78e1c53"},
-    {file = "Cython-0.29.24-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f41ef7edd76dd23315925e003f0c58c8585f3ab24be6885c4b3f60e77c82746"},
-    {file = "Cython-0.29.24-cp37-cp37m-win32.whl", hash = "sha256:821c2d416ad7d006b069657ee1034c0e0cb45bdbe9ab6ab631e8c495dfcfa4ac"},
-    {file = "Cython-0.29.24-cp37-cp37m-win_amd64.whl", hash = "sha256:2d9e61ed1056a3b6a4b9156b62297ad18b357a7948e57a2f49b061217696567e"},
-    {file = "Cython-0.29.24-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:55b0ee28c2c8118bfb3ad9b25cf7a6cbd724e442ea96956e32ccd908d5e3e043"},
-    {file = "Cython-0.29.24-cp38-cp38-manylinux1_i686.whl", hash = "sha256:eb2843f8cc01c645725e6fc690a84e99cdb266ce8ebe427cf3a680ff09f876aa"},
-    {file = "Cython-0.29.24-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:661dbdea519d9cfb288867252b75fef73ffa8e8bb674cec27acf70646afb369b"},
-    {file = "Cython-0.29.24-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bc05de569f811be1fcfde6756c9048ae518f0c4b6d9f8f024752c5365d934cac"},
-    {file = "Cython-0.29.24-cp38-cp38-win32.whl", hash = "sha256:a102cfa795c6b3b81a29bdb9dbec545367cd7f353c03e6f30a056fdfefd92854"},
-    {file = "Cython-0.29.24-cp38-cp38-win_amd64.whl", hash = "sha256:416046a98255eff97ec02077d20ebeaae52682dfca1c35aadf31260442b92514"},
-    {file = "Cython-0.29.24-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ad43e684ade673565f6f9d6638015112f6c7f11aa2a632167b79014f613f0f5f"},
-    {file = "Cython-0.29.24-cp39-cp39-manylinux1_i686.whl", hash = "sha256:afb521523cb46ddaa8d269b421f88ea2731fee05e65b952b96d4db760f5a2a1c"},
-    {file = "Cython-0.29.24-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:0d414458cb22f8a90d64260da6dace5d5fcebde43f31be52ca51f818c46db8cb"},
-    {file = "Cython-0.29.24-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8cb87777e82d1996aef6c146560a19270684271c9c669ba62ac6803b3cd2ff82"},
-    {file = "Cython-0.29.24-cp39-cp39-win32.whl", hash = "sha256:91339ee4b465924a3ea4b2a9cec7f7227bc4cadf673ce859d24c2b9ef60b1214"},
-    {file = "Cython-0.29.24-cp39-cp39-win_amd64.whl", hash = "sha256:5fb977945a2111f6b64501fdf7ed0ec162cc502b84457fd648d6a558ea8de0d6"},
-    {file = "Cython-0.29.24-py2.py3-none-any.whl", hash = "sha256:f96411f0120b5cae483923aaacd2872af8709be4b46522daedc32f051d778385"},
-    {file = "Cython-0.29.24.tar.gz", hash = "sha256:cdf04d07c3600860e8c2ebaad4e8f52ac3feb212453c1764a49ac08c827e8443"},
+    {file = "Cython-0.29.26-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c4b003b6b7aa9e74552ef8d4e6009b3e3c3e8fa585710b3a6d062e088e460c1b"},
+    {file = "Cython-0.29.26-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:ce804a021c92fea66c8c100781a111706f21bade7a546895c5a9c57fe2df8b24"},
+    {file = "Cython-0.29.26-cp27-cp27m-win32.whl", hash = "sha256:8e07121b34221458a2151d37e137b8f5b011a9c51dd38db2499a6198590aa319"},
+    {file = "Cython-0.29.26-cp27-cp27m-win_amd64.whl", hash = "sha256:233a87db76941626f1db08f4b25a4a5b425b13b64ed0e673c3641f7b650a48d8"},
+    {file = "Cython-0.29.26-cp27-cp27mu-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:93840f2071c1f15e613509eadee1fbcd335e8666772437fe5038e24059edd48c"},
+    {file = "Cython-0.29.26-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:10402f0f1564ffc6ecb9c45e07f995771d05bb0b0e1d151e40574638292ee3a5"},
+    {file = "Cython-0.29.26-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:6773cce9d4b3b6168d8feb2b6f06b658ef1e11cbfec075041745666d8e2a5e45"},
+    {file = "Cython-0.29.26-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:c813799d533194b7d85203d881d8b4f567a8c644a67f50d47f1ffbf316df412f"},
+    {file = "Cython-0.29.26-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:362fbb9cb4627c7786231429768b54aaba5459a2a0e46c25e59f202ca6155437"},
+    {file = "Cython-0.29.26-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2b834ff6e4d10ba6d7a0d676dd71c1b427a181ddbbbbf79e91d1861557aab59f"},
+    {file = "Cython-0.29.26-cp34-cp34m-win32.whl", hash = "sha256:0c3093bc99facfc97e5019f6c5bc39987663792265c1334d9fc9e37c3a3dcd6f"},
+    {file = "Cython-0.29.26-cp34-cp34m-win_amd64.whl", hash = "sha256:bbf0149680c1fca07200a3ed372b22e6bad7851d191b717a61f9a68af370e180"},
+    {file = "Cython-0.29.26-cp35-cp35m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a1cc55db32cd39474081d478263b96e036552cdbbab8831c90ea43fb385a9b66"},
+    {file = "Cython-0.29.26-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:ebe32e002a9e6553de399033e259ece72aa17c77f740b265e66f122572a8a278"},
+    {file = "Cython-0.29.26-cp35-cp35m-win32.whl", hash = "sha256:6b385f68789c3e8a75b4827e8a4970ff04605ad3cb1c0b41005cc69368dad65d"},
+    {file = "Cython-0.29.26-cp35-cp35m-win_amd64.whl", hash = "sha256:1519eb639de308f5763eb0666b4cc7bd3958268f3f6228cc610b7b4d6c94b68b"},
+    {file = "Cython-0.29.26-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:e118525defec3f67471d8ee5ce04340d43195410a87e5d7ec8a1a9e953c0066a"},
+    {file = "Cython-0.29.26-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:706ea55f58c2722206e51cd9a8754ed0995c4c4231d24b095875d2641d745222"},
+    {file = "Cython-0.29.26-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:77913fe27c5e22c995bac090d01e200ff91e5f58aa944e2d2e94cbf67ea2ae34"},
+    {file = "Cython-0.29.26-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:51923120f57a42c59f5ee6bba9e89a31a394ae8cd419c753f64d8a3aea1ee8b7"},
+    {file = "Cython-0.29.26-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:82881565d04027728d7762edd8c085927a840873af7ee049d703e0ca226bc08d"},
+    {file = "Cython-0.29.26-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:531303085503959338e6cdac630626280ef111aecbb22d48321673a8c3897c0a"},
+    {file = "Cython-0.29.26-cp36-cp36m-win32.whl", hash = "sha256:0205b685802eb4c039b14f67b7ac3f00c55ff04b9e3871df2249576d3e59ba42"},
+    {file = "Cython-0.29.26-cp36-cp36m-win_amd64.whl", hash = "sha256:7df94e56872df8f396ca669466fee60256f69f678654239f706b1e643c2ac4a5"},
+    {file = "Cython-0.29.26-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:4b7d04b393d9a4b5fec0cbc4b0f29fe083a9d862d95231a6e7608978bd661d7e"},
+    {file = "Cython-0.29.26-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:af91dd63ac5f1f7fc70dc91ea063f727db42b5eb934d1f3832611be18e25171e"},
+    {file = "Cython-0.29.26-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:d83dad8dc6c63706cb3178dc79010b3865b1345090727189d2cd61758a825ee8"},
+    {file = "Cython-0.29.26-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ca10e9fde0eaba1407ab353ff07a26daaa3e4dbe356108a149e482d441f070dd"},
+    {file = "Cython-0.29.26-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:fec66cd0a48697fab903854566235aecf1084f62e3163d6589ae7335a1b4d448"},
+    {file = "Cython-0.29.26-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:b3041e45aefaa4449fd671902132c0ac1f72eedaedac745c0e1a70a13bf990bb"},
+    {file = "Cython-0.29.26-cp37-cp37m-win32.whl", hash = "sha256:ed76fb98979f02b5e89079906071983a36f3634d3028b86f935cf0196f24fcaa"},
+    {file = "Cython-0.29.26-cp37-cp37m-win_amd64.whl", hash = "sha256:4d868e1a41f5123f51a20c1b8e82f7cb6fa3370c104e98e707f7c910e8cadad1"},
+    {file = "Cython-0.29.26-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:868f309095e557f06dc58723ae865e8c65cfedb2646a562bd8080c92d69e4e4b"},
+    {file = "Cython-0.29.26-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:be550b566345bf53b95616334793ce42a128cf1d9dcde1e28cbf7ce52ea61d6d"},
+    {file = "Cython-0.29.26-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:be13be1e2b9b7395588f2a23bfa692f2f3e6f7936ccf7825c83431b8c8c3452b"},
+    {file = "Cython-0.29.26-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:41ee918480371ae5e5851ba9b1ead5a183e24aedb27bf807c7405d124e943f40"},
+    {file = "Cython-0.29.26-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:c91b1ba0d43f7f7ccde8121c672207c7891735ddcc83496af1e0ab617ddc4aba"},
+    {file = "Cython-0.29.26-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:5ecf5cf5b57086cc6c1cfc76d6353bbd7023e95da32e0883f1302ca50e481c33"},
+    {file = "Cython-0.29.26-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:0ffce25bf50fa926ec6bf8d6f29650e7cb33fae445938c9880e1ce9b776353ef"},
+    {file = "Cython-0.29.26-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:5041adfef502d67ecd5e291a7cf645a37fed7a9dac557f40d491053f35204d00"},
+    {file = "Cython-0.29.26-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:5fd5db458c9d3d2c2abd047f3190624d9cce8a80a8e0ca0baa69cfd133a523bc"},
+    {file = "Cython-0.29.26-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:75eaa22911d2ec37a3841f77b710b178c805cd378b5e1c4fb82dbc35620d2062"},
+    {file = "Cython-0.29.26-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:3aed8c642e8fb27024bca46830b7f62335a44a92354acf708d6b8d050f945a3a"},
+    {file = "Cython-0.29.26-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:b5ca05c2bfba0c2480b5fd390ecffe46b8da574d887d600388d6e3caf3f99a88"},
+    {file = "Cython-0.29.26-py2.py3-none-any.whl", hash = "sha256:f5e15ff892c8afad64931ee3dd723c4755c2c516606f9aae7613bebfac62b0f6"},
+    {file = "Cython-0.29.26.tar.gz", hash = "sha256:af377d543a762867da11fcf6e558f7a4a535ff8693f30cce123fab10c00fa312"},
 ]
 debugpy = [
     {file = "debugpy-1.5.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:70b422c63a833630c33e3f9cdbd9b6971f8c5afd452697e464339a21bbe862ba"},
@@ -4793,8 +4918,8 @@ debugpy = [
     {file = "debugpy-1.5.1.zip", hash = "sha256:d2b09e91fbd1efa4f4fda121d49af89501beda50c18ed7499712c71a4bf3452e"},
 ]
 decorator = [
-    {file = "decorator-5.1.0-py3-none-any.whl", hash = "sha256:7b12e7c3c6ab203a29e157335e9122cb03de9ab7264b137594103fd4a683b374"},
-    {file = "decorator-5.1.0.tar.gz", hash = "sha256:e59913af105b9860aa2c8d3272d9de5a56a4e608db9a2f167a8480b323d529a7"},
+    {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
+    {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
 ]
 defusedxml = [
     {file = "defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"},
@@ -4822,12 +4947,16 @@ fasteners = [
     {file = "fasteners-0.15.tar.gz", hash = "sha256:3a176da6b70df9bb88498e1a18a9e4a8579ed5b9141207762368a1017bf8f5ef"},
 ]
 filelock = [
-    {file = "filelock-3.3.2-py3-none-any.whl", hash = "sha256:bb2a1c717df74c48a2d00ed625e5a66f8572a3a30baacb7657add1d7bac4097b"},
-    {file = "filelock-3.3.2.tar.gz", hash = "sha256:7afc856f74fa7006a289fd10fa840e1eebd8bbff6bffb69c26c54a0512ea8cf8"},
+    {file = "filelock-3.4.2-py3-none-any.whl", hash = "sha256:cf0fc6a2f8d26bd900f19bf33915ca70ba4dd8c56903eeb14e1e7a2fd7590146"},
+    {file = "filelock-3.4.2.tar.gz", hash = "sha256:38b4f4c989f9d06d44524df1b24bd19e167d851f19b50bf3e3559952dddc5b80"},
 ]
 flake8 = [
     {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
     {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
+]
+fonttools = [
+    {file = "fonttools-4.29.0-py3-none-any.whl", hash = "sha256:ed9496e5650b977a697c50ac99c8e8331f9eae3f99e5ae649623359103306dfe"},
+    {file = "fonttools-4.29.0.zip", hash = "sha256:f4834250db2c9855c3385459579dbb5cdf74349ab059ea0e619359b65ae72037"},
 ]
 free-mujoco-py = [
     {file = "free-mujoco-py-2.1.6.tar.gz", hash = "sha256:77e18302e21979bbd77a7c1584070815843cab1b1249f8a17667e15aba528a9a"},
@@ -4842,8 +4971,8 @@ gitdb = [
     {file = "gitdb-4.0.9.tar.gz", hash = "sha256:bac2fd45c0a1c9cf619e63a90d62bdc63892ef92387424b855792a6cabe789aa"},
 ]
 gitpython = [
-    {file = "GitPython-3.1.24-py3-none-any.whl", hash = "sha256:dc0a7f2f697657acc8d7f89033e8b1ea94dd90356b2983bca89dc8d2ab3cc647"},
-    {file = "GitPython-3.1.24.tar.gz", hash = "sha256:df83fdf5e684fef7c6ee2c02fc68a5ceb7e7e759d08b694088d0cacb4eba59e5"},
+    {file = "GitPython-3.1.26-py3-none-any.whl", hash = "sha256:26ac35c212d1f7b16036361ca5cff3ec66e11753a0d677fb6c48fa4e1a9dd8d6"},
+    {file = "GitPython-3.1.26.tar.gz", hash = "sha256:fc8868f63a2e6d268fb25f481995ba185a85a66fcad126f039323ff6635669ee"},
 ]
 glcontext = [
     {file = "glcontext-2.3.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e558960888be5a4aa8e2f6f43b5320a227c8519bc3517bf7202cb40925114a6d"},
@@ -4879,62 +5008,60 @@ glfw = [
     {file = "glfw-1.12.0.tar.gz", hash = "sha256:f195ed7a43475e4f1603903d6999f3a6b470fda88bd1749ff10adc520abe8fb1"},
 ]
 google-auth = [
-    {file = "google-auth-2.3.3.tar.gz", hash = "sha256:d83570a664c10b97a1dc6f8df87e5fdfff012f48f62be131e449c20dfc32630e"},
-    {file = "google_auth-2.3.3-py2.py3-none-any.whl", hash = "sha256:a348a50b027679cb7dae98043ac8dbcc1d7951f06d8387496071a1e05a2465c0"},
+    {file = "google-auth-2.5.0.tar.gz", hash = "sha256:6577bbf990ef342a24e12e0c8e9d364af6642acdf206c9045bdb8e039fb4fec9"},
+    {file = "google_auth-2.5.0-py2.py3-none-any.whl", hash = "sha256:ee6199b602594c0dcaa00dc3492e62569f24a788f0aca867b989cef444e4a202"},
 ]
 google-auth-oauthlib = [
     {file = "google-auth-oauthlib-0.4.6.tar.gz", hash = "sha256:a90a072f6993f2c327067bf65270046384cda5a8ecb20b94ea9a687f1f233a7a"},
     {file = "google_auth_oauthlib-0.4.6-py2.py3-none-any.whl", hash = "sha256:3f2a6e802eebbb6fb736a370fbf3b055edcb6b52878bf2f26330b5e041316c73"},
 ]
 grpcio = [
-    {file = "grpcio-1.41.1-cp310-cp310-linux_armv7l.whl", hash = "sha256:ead9885b53777bed4b0694ff0baea9d2c519ff774b17b177bde43d73e2b4aa38"},
-    {file = "grpcio-1.41.1-cp310-cp310-macosx_10_10_universal2.whl", hash = "sha256:3b4b7c1ab18283eb64af5648d20eabef9237a2aec09e30a805f18adc9497258d"},
-    {file = "grpcio-1.41.1-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:f68aa98f5970eccb6c94456f3447a99916c42fbddae1971256bc4e7c40a6593b"},
-    {file = "grpcio-1.41.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:71d9ed5a732a54b9c87764609f2fd2bc4ae72fa85e271038eb132ea723222209"},
-    {file = "grpcio-1.41.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0aa1af3e1480b6dd3092ee67c4b67b1ea88d638fcdc4d1a611ae11e311800b34"},
-    {file = "grpcio-1.41.1-cp310-cp310-win32.whl", hash = "sha256:766f1b943abc3e27842b72fba6e28fb9f57c9b84029fd7e91146e4c37034d937"},
-    {file = "grpcio-1.41.1-cp310-cp310-win_amd64.whl", hash = "sha256:3713e3918da6ae10812a64e75620a172f01af2ff0a1c99d6481c910e1d4a9053"},
-    {file = "grpcio-1.41.1-cp36-cp36m-linux_armv7l.whl", hash = "sha256:3f0b70cf8632028714a8341b841b011a47900b1c163bf5fababb4ab3888c9b6c"},
-    {file = "grpcio-1.41.1-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:8824b36e6b0e45fefe0b4eac5ad460830e0cbc856a0c794f711289b4b8933d53"},
-    {file = "grpcio-1.41.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:788154b32bf712e9711d001df024af5f7b2522117876c129bb27b9ad6e5461fb"},
-    {file = "grpcio-1.41.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:c32c470e077b34a52e87e7de26644ad0f9e9ff89a785ff7e6466870869659e05"},
-    {file = "grpcio-1.41.1-cp36-cp36m-manylinux_2_17_aarch64.whl", hash = "sha256:a3bb4302389b23f2006ecaaea5eb4a39cc80ea98d1964159e59c1c20ef39a483"},
-    {file = "grpcio-1.41.1-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e156ea12adb7a7ca8d8280c9df850c15510b790c785fc26c9a3fb928cd221fd4"},
-    {file = "grpcio-1.41.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2eb8180a6d9e47fc865a4e92a2678f3202145021ef2c1bccf165fa5744f6ec95"},
-    {file = "grpcio-1.41.1-cp36-cp36m-win32.whl", hash = "sha256:888d8519709652dd39415de5f79abd50257201b345dd4f40151feffc3dad3232"},
-    {file = "grpcio-1.41.1-cp36-cp36m-win_amd64.whl", hash = "sha256:734690b3f35468f8ed4003ec7622d2d47567f1881f5fcdca34f1e52551c2ef55"},
-    {file = "grpcio-1.41.1-cp37-cp37m-linux_armv7l.whl", hash = "sha256:133fb9a3cf4519543e4e41eb18b5dac0da26941aeabca8122dbcf3decbad2d21"},
-    {file = "grpcio-1.41.1-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:a5ac91db3c588296366554b2d91116fc3a9f05bae516cafae07220e1f05bfef7"},
-    {file = "grpcio-1.41.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:b8dd1b6456c6fb3681affe0f81dff4b3bc46f825fc05e086d64216545da9ad92"},
-    {file = "grpcio-1.41.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:9e403d07d77ed4495ad3c18994191525b11274693e72e464241c9139e2f9cd7c"},
-    {file = "grpcio-1.41.1-cp37-cp37m-manylinux_2_17_aarch64.whl", hash = "sha256:9d1be99f216b18f8a9dbdfbdbcc9a6caee504d0d27295fdbb5c8da35f5254a69"},
-    {file = "grpcio-1.41.1-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ebbe9582ef06559a2358827a588ab4b92a2639517de8fe428288772820ab03b5"},
-    {file = "grpcio-1.41.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd570720871dc84d2adc8430ce287319c9238d1e2f70c140f9bc54c690fabd1b"},
-    {file = "grpcio-1.41.1-cp37-cp37m-win32.whl", hash = "sha256:0c075616d5e86fb65fd4784d5a87d6e5a1882d277dce5c33d9b67cfc71d79899"},
-    {file = "grpcio-1.41.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9170b5d2082fc00c057c6ccd6b893033c1ade05717fcec1d63557c3bc7afdb1b"},
-    {file = "grpcio-1.41.1-cp38-cp38-linux_armv7l.whl", hash = "sha256:61aa02f4505c5bbbaeba80fef1bd6871d1aef05a8778a707ab91303ee0865ad0"},
-    {file = "grpcio-1.41.1-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:d1461672b2eaef9affb60a71014ebd2f789deea7c9acb1d4bd163de92dd8e044"},
-    {file = "grpcio-1.41.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:c35b847bc6bd3c3a118a13277d91a772e7dd163ce7dd2791239f9941b6eaafe3"},
-    {file = "grpcio-1.41.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:8487fb0649ebebc9c5dca1a6dc4eb7fddf701183426b3eefeb3584639d223d43"},
-    {file = "grpcio-1.41.1-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:6ca497ccecaa8727f14c4ccc9ffb70a19c6413fe1d4650500c90a7febd662860"},
-    {file = "grpcio-1.41.1-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b1232c5efc8a9e4b7a13db235c51135412beb9e62e618a2a89dd0463edb3d929"},
-    {file = "grpcio-1.41.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:31a47af7356fb5ed3120636dd75c5efb571ecf15737484119e31286687f0e52a"},
-    {file = "grpcio-1.41.1-cp38-cp38-win32.whl", hash = "sha256:7a22a7378ea59ad1e6f2e79f9da6862eb9e1f6586253aee784d419a49e3f4bd9"},
-    {file = "grpcio-1.41.1-cp38-cp38-win_amd64.whl", hash = "sha256:32b7ca83f1a6929217098aaaac89fc49879ae714c95501d40df41a0e7506164c"},
-    {file = "grpcio-1.41.1-cp39-cp39-linux_armv7l.whl", hash = "sha256:3213dfe3abfc3fda7f30e86aa5967dce0c2eb4cc90a0504f95434091bf6b219a"},
-    {file = "grpcio-1.41.1-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:fd11995e3402af0f838844194707da8b3235f1719bcac961493f0138f1325893"},
-    {file = "grpcio-1.41.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:23a3f03e1d9ac429ff78d23d2ab07756d3728ee1a68b5f244d8435006608b6aa"},
-    {file = "grpcio-1.41.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:fc2eadfb5ec956c556c138fab0dfc1d2395c57ae0bfea047edae1976a26b250c"},
-    {file = "grpcio-1.41.1-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:2a34c8979de10b04a44d2cad07d41d83643e65e49f84a05b1adf150aeb41c95f"},
-    {file = "grpcio-1.41.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:72d0bdc3605dc8f4187b302e1180643963896e3f2917a52becb51afb54448e3e"},
-    {file = "grpcio-1.41.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:740f5b21a7108a8c08bf522434752dc1d306274d47ca8b4d51af5588a16b6113"},
-    {file = "grpcio-1.41.1-cp39-cp39-win32.whl", hash = "sha256:2f2ee78a6ae88d668ceda56fa4a18d8a38b34c2f2e1332083dd1da1a92870703"},
-    {file = "grpcio-1.41.1-cp39-cp39-win_amd64.whl", hash = "sha256:c3a446b6a1f8077cc03d0d496fc1cecdd3d0b66860c0c5b65cc92d0549117840"},
-    {file = "grpcio-1.41.1.tar.gz", hash = "sha256:9b751271b029432a526a4970dc9b70d93eb6f0963b6a841b574f780b72651969"},
+    {file = "grpcio-1.43.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:a4e786a8ee8b30b25d70ee52cda6d1dbba2a8ca2f1208d8e20ed8280774f15c8"},
+    {file = "grpcio-1.43.0-cp310-cp310-macosx_10_10_universal2.whl", hash = "sha256:af9c3742f6c13575c0d4147a8454da0ff5308c4d9469462ff18402c6416942fe"},
+    {file = "grpcio-1.43.0-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:fdac966699707b5554b815acc272d81e619dd0999f187cd52a61aef075f870ee"},
+    {file = "grpcio-1.43.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6e463b4aa0a6b31cf2e57c4abc1a1b53531a18a570baeed39d8d7b65deb16b7e"},
+    {file = "grpcio-1.43.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f11d05402e0ac3a284443d8a432d3dfc76a6bd3f7b5858cddd75617af2d7bd9b"},
+    {file = "grpcio-1.43.0-cp310-cp310-win32.whl", hash = "sha256:c36f418c925a41fccada8f7ae9a3d3e227bfa837ddbfddd3d8b0ac252d12dda9"},
+    {file = "grpcio-1.43.0-cp310-cp310-win_amd64.whl", hash = "sha256:772b943f34374744f70236bbbe0afe413ed80f9ae6303503f85e2b421d4bca92"},
+    {file = "grpcio-1.43.0-cp36-cp36m-linux_armv7l.whl", hash = "sha256:cbc9b83211d905859dcf234ad39d7193ff0f05bfc3269c364fb0d114ee71de59"},
+    {file = "grpcio-1.43.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:fb7229fa2a201a0c377ff3283174ec966da8f9fd7ffcc9a92f162d2e7fc9025b"},
+    {file = "grpcio-1.43.0-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:17b75f220ee6923338155b4fcef4c38802b9a57bc57d112c9599a13a03e99f8d"},
+    {file = "grpcio-1.43.0-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:6620a5b751b099b3b25553cfc03dfcd873cda06f9bb2ff7e9948ac7090e20f05"},
+    {file = "grpcio-1.43.0-cp36-cp36m-manylinux_2_17_aarch64.whl", hash = "sha256:1898f999383baac5fcdbdef8ea5b1ef204f38dc211014eb6977ac6e55944d738"},
+    {file = "grpcio-1.43.0-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:47b6821238d8978014d23b1132713dac6c2d72cbb561cf257608b1673894f90a"},
+    {file = "grpcio-1.43.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80398e9fb598060fa41050d1220f5a2440fe74ff082c36dda41ac3215ebb5ddd"},
+    {file = "grpcio-1.43.0-cp36-cp36m-win32.whl", hash = "sha256:0110310eff07bb69782f53b7a947490268c4645de559034c43c0a635612e250f"},
+    {file = "grpcio-1.43.0-cp36-cp36m-win_amd64.whl", hash = "sha256:45401d00f2ee46bde75618bf33e9df960daa7980e6e0e7328047191918c98504"},
+    {file = "grpcio-1.43.0-cp37-cp37m-linux_armv7l.whl", hash = "sha256:af78ac55933811e6a25141336b1f2d5e0659c2f568d44d20539b273792563ca7"},
+    {file = "grpcio-1.43.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:8b2b9dc4d7897566723b77422e11c009a0ebd397966b165b21b89a62891a9fdf"},
+    {file = "grpcio-1.43.0-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:77ef653f966934b3bfdd00e4f2064b68880eb40cf09b0b99edfa5ee22a44f559"},
+    {file = "grpcio-1.43.0-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:e95b5d62ec26d0cd0b90c202d73e7cb927c369c3358e027225239a4e354967dc"},
+    {file = "grpcio-1.43.0-cp37-cp37m-manylinux_2_17_aarch64.whl", hash = "sha256:04239e8f71db832c26bbbedb4537b37550a39d77681d748ab4678e58dd6455d6"},
+    {file = "grpcio-1.43.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4b4a7152187a49767a47d1413edde2304c96f41f7bc92cc512e230dfd0fba095"},
+    {file = "grpcio-1.43.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8cc936a29c65ab39714e1ba67a694c41218f98b6e2a64efb83f04d9abc4386b"},
+    {file = "grpcio-1.43.0-cp37-cp37m-win32.whl", hash = "sha256:577e024c8dd5f27cd98ba850bc4e890f07d4b5942e5bc059a3d88843a2f48f66"},
+    {file = "grpcio-1.43.0-cp37-cp37m-win_amd64.whl", hash = "sha256:138f57e3445d4a48d9a8a5af1538fdaafaa50a0a3c243f281d8df0edf221dc02"},
+    {file = "grpcio-1.43.0-cp38-cp38-linux_armv7l.whl", hash = "sha256:08cf25f2936629db062aeddbb594bd76b3383ab0ede75ef0461a3b0bc3a2c150"},
+    {file = "grpcio-1.43.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:01f4b887ed703fe82ebe613e1d2dadea517891725e17e7a6134dcd00352bd28c"},
+    {file = "grpcio-1.43.0-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:0aa8285f284338eb68962fe1a830291db06f366ea12f213399b520c062b01f65"},
+    {file = "grpcio-1.43.0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:0edbfeb6729aa9da33ce7e28fb7703b3754934115454ae45e8cc1db601756fd3"},
+    {file = "grpcio-1.43.0-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:c354017819201053d65212befd1dcb65c2d91b704d8977e696bae79c47cd2f82"},
+    {file = "grpcio-1.43.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:50cfb7e1067ee5e00b8ab100a6b7ea322d37ec6672c0455106520b5891c4b5f5"},
+    {file = "grpcio-1.43.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:57f1aeb65ed17dfb2f6cd717cc109910fe395133af7257a9c729c0b9604eac10"},
+    {file = "grpcio-1.43.0-cp38-cp38-win32.whl", hash = "sha256:fa26a8bbb3fe57845acb1329ff700d5c7eaf06414c3e15f4cb8923f3a466ef64"},
+    {file = "grpcio-1.43.0-cp38-cp38-win_amd64.whl", hash = "sha256:ade8b79a6b6aea68adb9d4bfeba5d647667d842202c5d8f3ba37ac1dc8e5c09c"},
+    {file = "grpcio-1.43.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:124e718faf96fe44c98b05f3f475076be8b5198bb4c52a13208acf88a8548ba9"},
+    {file = "grpcio-1.43.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:2f96142d0abc91290a63ba203f01649e498302b1b6007c67bad17f823ecde0cf"},
+    {file = "grpcio-1.43.0-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:31e6e489ccd8f08884b9349a39610982df48535881ec34f05a11c6e6b6ebf9d0"},
+    {file = "grpcio-1.43.0-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:0e731f660e1e68238f56f4ce11156f02fd06dc58bc7834778d42c0081d4ef5ad"},
+    {file = "grpcio-1.43.0-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:1f16725a320460435a8a5339d8b06c4e00d307ab5ad56746af2e22b5f9c50932"},
+    {file = "grpcio-1.43.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a4b4543e13acb4806917d883d0f70f21ba93b29672ea81f4aaba14821aaf9bb0"},
+    {file = "grpcio-1.43.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:594aaa0469f4fca7773e80d8c27bf1298e7bbce5f6da0f084b07489a708f16ab"},
+    {file = "grpcio-1.43.0-cp39-cp39-win32.whl", hash = "sha256:5449ae564349e7a738b8c38583c0aad954b0d5d1dd3cea68953bfc32eaee11e3"},
+    {file = "grpcio-1.43.0-cp39-cp39-win_amd64.whl", hash = "sha256:bdf41550815a831384d21a498b20597417fd31bd084deb17d31ceb39ad9acc79"},
+    {file = "grpcio-1.43.0.tar.gz", hash = "sha256:735d9a437c262ab039d02defddcb9f8f545d7009ae61c0114e19dda3843febe5"},
 ]
-gym = [
-    {file = "gym-0.21.0.tar.gz", hash = "sha256:0fd1ce165c754b4017e37a617b097c032b8c3feb8a0394ccc8777c7c50dddff3"},
-]
+gym = []
 gym3 = [
     {file = "gym3-0.3.3-py3-none-any.whl", hash = "sha256:bacc0e124f8ce5e1d8a9dceb85725123332954f13ef4e226133506597548838a"},
 ]
@@ -4943,8 +5070,8 @@ idna = [
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
 imageio = [
-    {file = "imageio-2.10.3-py3-none-any.whl", hash = "sha256:93ee376a8dc96182ead8d773c3ac2becf79c6f2b93d38f31d7ac036c62a6c72e"},
-    {file = "imageio-2.10.3.tar.gz", hash = "sha256:469c59fe71c81cdc41c84f842d62dd2739a08fac8cb85f5a518a92a6227e2ed6"},
+    {file = "imageio-2.14.1-py3-none-any.whl", hash = "sha256:4bc1257abe5d8c9ef89132dccd9d783c1c0bdbbcfb98c0e5fe84e8b7b9ee4975"},
+    {file = "imageio-2.14.1.tar.gz", hash = "sha256:709c18f800981e4286abe4bd86b6c9b5bb6e285b6b933b5ba0962ef8e7994058"},
 ]
 imageio-ffmpeg = [
     {file = "imageio-ffmpeg-0.3.0.tar.gz", hash = "sha256:28500544acdebc195159d53a4670b76d596f368b218317bad5d3cbf43b00d6c2"},
@@ -4954,12 +5081,12 @@ imageio-ffmpeg = [
     {file = "imageio_ffmpeg-0.3.0-py3-none-win_amd64.whl", hash = "sha256:991416c0eed0d221229e67342b8264a8b9defdec61d8a9e7688b90dbb838fb1e"},
 ]
 imagesize = [
-    {file = "imagesize-1.2.0-py2.py3-none-any.whl", hash = "sha256:6965f19a6a2039c7d48bca7dba2473069ff854c36ae6f19d2cde309d998228a1"},
-    {file = "imagesize-1.2.0.tar.gz", hash = "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"},
+    {file = "imagesize-1.3.0-py2.py3-none-any.whl", hash = "sha256:1db2f82529e53c3e929e8926a1fa9235aa82d0bd0c580359c67ec31b2fddaa8c"},
+    {file = "imagesize-1.3.0.tar.gz", hash = "sha256:cd1750d452385ca327479d45b64d9c7729ecf0b3969a58148298c77092261f9d"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.8.1-py3-none-any.whl", hash = "sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15"},
-    {file = "importlib_metadata-4.8.1.tar.gz", hash = "sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1"},
+    {file = "importlib_metadata-4.10.1-py3-none-any.whl", hash = "sha256:899e2a40a8c4a1aec681feef45733de8a6c58f3f6a0dbed2eb6574b4387a77b6"},
+    {file = "importlib_metadata-4.10.1.tar.gz", hash = "sha256:951f0d8a5b7260e9db5e41d429285b5f451e928479f19d80818878527d36e95e"},
 ]
 importlib-resources = [
     {file = "importlib_resources-5.4.0-py3-none-any.whl", hash = "sha256:33a95faed5fc19b4bc16b29a6eeae248a3fe69dd55d4d229d2b480e23eeaad45"},
@@ -4977,32 +5104,32 @@ intervaltree = [
     {file = "intervaltree-3.1.0.tar.gz", hash = "sha256:902b1b88936918f9b2a19e0e5eb7ccb430ae45cde4f39ea4b36932920d33952d"},
 ]
 ipykernel = [
-    {file = "ipykernel-6.5.0-py3-none-any.whl", hash = "sha256:f43de132feea90f86d68c51013afe9694f9415f440053ec9909dd656c75b04b5"},
-    {file = "ipykernel-6.5.0.tar.gz", hash = "sha256:299795cca2c4aed7e233e3ad5360e1c73627fd0dcec11a9e75d5b2df43629353"},
+    {file = "ipykernel-6.7.0-py3-none-any.whl", hash = "sha256:6203ccd5510ff148e9433fd4a2707c5ce8d688f026427f46e13d7ebf9b3e9787"},
+    {file = "ipykernel-6.7.0.tar.gz", hash = "sha256:d82b904fdc2fd8c7b1fbe0fa481c68a11b4cd4c8ef07e6517da1f10cc3114d24"},
 ]
 ipython = [
-    {file = "ipython-7.29.0-py3-none-any.whl", hash = "sha256:a658beaf856ce46bc453366d5dc6b2ddc6c481efd3540cb28aa3943819caac9f"},
-    {file = "ipython-7.29.0.tar.gz", hash = "sha256:4f69d7423a5a1972f6347ff233e38bbf4df6a150ef20fbb00c635442ac3060aa"},
+    {file = "ipython-7.31.1-py3-none-any.whl", hash = "sha256:55df3e0bd0f94e715abd968bedd89d4e8a7bce4bf498fb123fed4f5398fea874"},
+    {file = "ipython-7.31.1.tar.gz", hash = "sha256:b5548ec5329a4bcf054a5deed5099b0f9622eb9ea51aaa7104d215fece201d8c"},
 ]
 ipython-genutils = [
     {file = "ipython_genutils-0.2.0-py2.py3-none-any.whl", hash = "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8"},
     {file = "ipython_genutils-0.2.0.tar.gz", hash = "sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"},
 ]
 isort = [
-    {file = "isort-5.10.0-py3-none-any.whl", hash = "sha256:1a18ccace2ed8910bd9458b74a3ecbafd7b2f581301b0ab65cfdd4338272d76f"},
-    {file = "isort-5.10.0.tar.gz", hash = "sha256:e52ff6d38012b131628cf0f26c51e7bd3a7c81592eefe3ac71411e692f1b9345"},
+    {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
+    {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
 ]
 jedi = [
-    {file = "jedi-0.18.0-py2.py3-none-any.whl", hash = "sha256:18456d83f65f400ab0c2d3319e48520420ef43b23a086fdc05dff34132f0fb93"},
-    {file = "jedi-0.18.0.tar.gz", hash = "sha256:92550a404bad8afed881a137ec9a461fed49eca661414be45059329614ed0707"},
+    {file = "jedi-0.18.1-py2.py3-none-any.whl", hash = "sha256:637c9635fcf47945ceb91cd7f320234a7be540ded6f3e99a50cb6febdfd1ba8d"},
+    {file = "jedi-0.18.1.tar.gz", hash = "sha256:74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab"},
 ]
 jeepney = [
     {file = "jeepney-0.7.1-py3-none-any.whl", hash = "sha256:1b5a0ea5c0e7b166b2f5895b91a08c14de8915afda4407fb5022a195224958ac"},
     {file = "jeepney-0.7.1.tar.gz", hash = "sha256:fa9e232dfa0c498bd0b8a3a73b8d8a31978304dcef0515adc859d4e096f96f4f"},
 ]
 jinja2 = [
-    {file = "Jinja2-3.0.2-py3-none-any.whl", hash = "sha256:8569982d3f0889eed11dd620c706d39b60c36d6d25843961f33f77fb6bc6b20c"},
-    {file = "Jinja2-3.0.2.tar.gz", hash = "sha256:827a0e32839ab1600d4eb1c4c33ec5a8edfbc5cb42dafa13b81f182f97784b45"},
+    {file = "Jinja2-3.0.3-py3-none-any.whl", hash = "sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8"},
+    {file = "Jinja2-3.0.3.tar.gz", hash = "sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"},
 ]
 jinja2-time = [
     {file = "jinja2-time-0.2.0.tar.gz", hash = "sha256:d14eaa4d315e7688daa4969f616f226614350c48730bfa1692d2caebd8c90d40"},
@@ -5013,8 +5140,8 @@ jmespath = [
     {file = "jmespath-0.10.0.tar.gz", hash = "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9"},
 ]
 jsonschema = [
-    {file = "jsonschema-4.2.1-py3-none-any.whl", hash = "sha256:2a0f162822a64d95287990481b45d82f096e99721c86534f48201b64ebca6e8c"},
-    {file = "jsonschema-4.2.1.tar.gz", hash = "sha256:390713469ae64b8a58698bb3cbc3859abe6925b565a973f87323ef21b09a27a8"},
+    {file = "jsonschema-4.4.0-py3-none-any.whl", hash = "sha256:77281a1f71684953ee8b3d488371b162419767973789272434bbc3f29d9c8823"},
+    {file = "jsonschema-4.4.0.tar.gz", hash = "sha256:636694eb41b3535ed608fe04129f26542b59ed99808b4f688aa32dcf55317a83"},
 ]
 jupyter-client = [
     {file = "jupyter_client-6.2.0-py3-none-any.whl", hash = "sha256:9715152067e3f7ea3b56f341c9a0f9715c8c7cc316ee0eb13c3c84f5ca0065f5"},
@@ -5029,8 +5156,8 @@ jupyterlab-pygments = [
     {file = "jupyterlab_pygments-0.1.2.tar.gz", hash = "sha256:cfcda0873626150932f438eccf0f8bf22bfa92345b814890ab360d666b254146"},
 ]
 keyring = [
-    {file = "keyring-23.2.1-py3-none-any.whl", hash = "sha256:bd2145a237ed70c8ce72978b497619ddfcae640b6dcf494402d5143e37755c6e"},
-    {file = "keyring-23.2.1.tar.gz", hash = "sha256:6334aee6073db2fb1f30892697b1730105b5e9a77ce7e61fca6b435225493efe"},
+    {file = "keyring-23.5.0-py3-none-any.whl", hash = "sha256:b0d28928ac3ec8e42ef4cc227822647a19f1d544f21f96457965dc01cf555261"},
+    {file = "keyring-23.5.0.tar.gz", hash = "sha256:9012508e141a80bd1c0b6778d5c610dd9f8c464d75ac6774248500503f972fb9"},
 ]
 kiwisolver = [
     {file = "kiwisolver-1.3.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1d819553730d3c2724582124aee8a03c846ec4362ded1034c16fb3ef309264e6"},
@@ -5079,32 +5206,47 @@ kiwisolver = [
     {file = "kiwisolver-1.3.2.tar.gz", hash = "sha256:fc4453705b81d03568d5b808ad8f09c77c47534f6ac2e72e733f9ca4714aa75c"},
 ]
 lazy-object-proxy = [
-    {file = "lazy-object-proxy-1.6.0.tar.gz", hash = "sha256:489000d368377571c6f982fba6497f2aa13c6d1facc40660963da62f5c379726"},
-    {file = "lazy_object_proxy-1.6.0-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:c6938967f8528b3668622a9ed3b31d145fab161a32f5891ea7b84f6b790be05b"},
-    {file = "lazy_object_proxy-1.6.0-cp27-cp27m-win32.whl", hash = "sha256:ebfd274dcd5133e0afae738e6d9da4323c3eb021b3e13052d8cbd0e457b1256e"},
-    {file = "lazy_object_proxy-1.6.0-cp27-cp27m-win_amd64.whl", hash = "sha256:ed361bb83436f117f9917d282a456f9e5009ea12fd6de8742d1a4752c3017e93"},
-    {file = "lazy_object_proxy-1.6.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:d900d949b707778696fdf01036f58c9876a0d8bfe116e8d220cfd4b15f14e741"},
-    {file = "lazy_object_proxy-1.6.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5743a5ab42ae40caa8421b320ebf3a998f89c85cdc8376d6b2e00bd12bd1b587"},
-    {file = "lazy_object_proxy-1.6.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:bf34e368e8dd976423396555078def5cfc3039ebc6fc06d1ae2c5a65eebbcde4"},
-    {file = "lazy_object_proxy-1.6.0-cp36-cp36m-win32.whl", hash = "sha256:b579f8acbf2bdd9ea200b1d5dea36abd93cabf56cf626ab9c744a432e15c815f"},
-    {file = "lazy_object_proxy-1.6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:4f60460e9f1eb632584c9685bccea152f4ac2130e299784dbaf9fae9f49891b3"},
-    {file = "lazy_object_proxy-1.6.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d7124f52f3bd259f510651450e18e0fd081ed82f3c08541dffc7b94b883aa981"},
-    {file = "lazy_object_proxy-1.6.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:22ddd618cefe54305df49e4c069fa65715be4ad0e78e8d252a33debf00f6ede2"},
-    {file = "lazy_object_proxy-1.6.0-cp37-cp37m-win32.whl", hash = "sha256:9d397bf41caad3f489e10774667310d73cb9c4258e9aed94b9ec734b34b495fd"},
-    {file = "lazy_object_proxy-1.6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:24a5045889cc2729033b3e604d496c2b6f588c754f7a62027ad4437a7ecc4837"},
-    {file = "lazy_object_proxy-1.6.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:17e0967ba374fc24141738c69736da90e94419338fd4c7c7bef01ee26b339653"},
-    {file = "lazy_object_proxy-1.6.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:410283732af311b51b837894fa2f24f2c0039aa7f220135192b38fcc42bd43d3"},
-    {file = "lazy_object_proxy-1.6.0-cp38-cp38-win32.whl", hash = "sha256:85fb7608121fd5621cc4377a8961d0b32ccf84a7285b4f1d21988b2eae2868e8"},
-    {file = "lazy_object_proxy-1.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:d1c2676e3d840852a2de7c7d5d76407c772927addff8d742b9808fe0afccebdf"},
-    {file = "lazy_object_proxy-1.6.0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:b865b01a2e7f96db0c5d12cfea590f98d8c5ba64ad222300d93ce6ff9138bcad"},
-    {file = "lazy_object_proxy-1.6.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:4732c765372bd78a2d6b2150a6e99d00a78ec963375f236979c0626b97ed8e43"},
-    {file = "lazy_object_proxy-1.6.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:9698110e36e2df951c7c36b6729e96429c9c32b3331989ef19976592c5f3c77a"},
-    {file = "lazy_object_proxy-1.6.0-cp39-cp39-win32.whl", hash = "sha256:1fee665d2638491f4d6e55bd483e15ef21f6c8c2095f235fef72601021e64f61"},
-    {file = "lazy_object_proxy-1.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:f5144c75445ae3ca2057faac03fda5a902eff196702b0a24daf1d6ce0650514b"},
+    {file = "lazy-object-proxy-1.7.1.tar.gz", hash = "sha256:d609c75b986def706743cdebe5e47553f4a5a1da9c5ff66d76013ef396b5a8a4"},
+    {file = "lazy_object_proxy-1.7.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bb8c5fd1684d60a9902c60ebe276da1f2281a318ca16c1d0a96db28f62e9166b"},
+    {file = "lazy_object_proxy-1.7.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a57d51ed2997e97f3b8e3500c984db50a554bb5db56c50b5dab1b41339b37e36"},
+    {file = "lazy_object_proxy-1.7.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd45683c3caddf83abbb1249b653a266e7069a09f486daa8863fb0e7496a9fdb"},
+    {file = "lazy_object_proxy-1.7.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:8561da8b3dd22d696244d6d0d5330618c993a215070f473b699e00cf1f3f6443"},
+    {file = "lazy_object_proxy-1.7.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fccdf7c2c5821a8cbd0a9440a456f5050492f2270bd54e94360cac663398739b"},
+    {file = "lazy_object_proxy-1.7.1-cp310-cp310-win32.whl", hash = "sha256:898322f8d078f2654d275124a8dd19b079080ae977033b713f677afcfc88e2b9"},
+    {file = "lazy_object_proxy-1.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:85b232e791f2229a4f55840ed54706110c80c0a210d076eee093f2b2e33e1bfd"},
+    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:46ff647e76f106bb444b4533bb4153c7370cdf52efc62ccfc1a28bdb3cc95442"},
+    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:12f3bb77efe1367b2515f8cb4790a11cffae889148ad33adad07b9b55e0ab22c"},
+    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c19814163728941bb871240d45c4c30d33b8a2e85972c44d4e63dd7107faba44"},
+    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:e40f2013d96d30217a51eeb1db28c9ac41e9d0ee915ef9d00da639c5b63f01a1"},
+    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:2052837718516a94940867e16b1bb10edb069ab475c3ad84fd1e1a6dd2c0fcfc"},
+    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-win32.whl", hash = "sha256:6a24357267aa976abab660b1d47a34aaf07259a0c3859a34e536f1ee6e76b5bb"},
+    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-win_amd64.whl", hash = "sha256:6aff3fe5de0831867092e017cf67e2750c6a1c7d88d84d2481bd84a2e019ec35"},
+    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6a6e94c7b02641d1311228a102607ecd576f70734dc3d5e22610111aeacba8a0"},
+    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c4ce15276a1a14549d7e81c243b887293904ad2d94ad767f42df91e75fd7b5b6"},
+    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e368b7f7eac182a59ff1f81d5f3802161932a41dc1b1cc45c1f757dc876b5d2c"},
+    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:6ecbb350991d6434e1388bee761ece3260e5228952b1f0c46ffc800eb313ff42"},
+    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:553b0f0d8dbf21890dd66edd771f9b1b5f51bd912fa5f26de4449bfc5af5e029"},
+    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-win32.whl", hash = "sha256:c7a683c37a8a24f6428c28c561c80d5f4fd316ddcf0c7cab999b15ab3f5c5c69"},
+    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-win_amd64.whl", hash = "sha256:df2631f9d67259dc9620d831384ed7732a198eb434eadf69aea95ad18c587a28"},
+    {file = "lazy_object_proxy-1.7.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:07fa44286cda977bd4803b656ffc1c9b7e3bc7dff7d34263446aec8f8c96f88a"},
+    {file = "lazy_object_proxy-1.7.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4dca6244e4121c74cc20542c2ca39e5c4a5027c81d112bfb893cf0790f96f57e"},
+    {file = "lazy_object_proxy-1.7.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:91ba172fc5b03978764d1df5144b4ba4ab13290d7bab7a50f12d8117f8630c38"},
+    {file = "lazy_object_proxy-1.7.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:043651b6cb706eee4f91854da4a089816a6606c1428fd391573ef8cb642ae4f7"},
+    {file = "lazy_object_proxy-1.7.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b9e89b87c707dd769c4ea91f7a31538888aad05c116a59820f28d59b3ebfe25a"},
+    {file = "lazy_object_proxy-1.7.1-cp38-cp38-win32.whl", hash = "sha256:9d166602b525bf54ac994cf833c385bfcc341b364e3ee71e3bf5a1336e677b55"},
+    {file = "lazy_object_proxy-1.7.1-cp38-cp38-win_amd64.whl", hash = "sha256:8f3953eb575b45480db6568306893f0bd9d8dfeeebd46812aa09ca9579595148"},
+    {file = "lazy_object_proxy-1.7.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:dd7ed7429dbb6c494aa9bc4e09d94b778a3579be699f9d67da7e6804c422d3de"},
+    {file = "lazy_object_proxy-1.7.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:70ed0c2b380eb6248abdef3cd425fc52f0abd92d2b07ce26359fcbc399f636ad"},
+    {file = "lazy_object_proxy-1.7.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7096a5e0c1115ec82641afbdd70451a144558ea5cf564a896294e346eb611be1"},
+    {file = "lazy_object_proxy-1.7.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:f769457a639403073968d118bc70110e7dce294688009f5c24ab78800ae56dc8"},
+    {file = "lazy_object_proxy-1.7.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:39b0e26725c5023757fc1ab2a89ef9d7ab23b84f9251e28f9cc114d5b59c1b09"},
+    {file = "lazy_object_proxy-1.7.1-cp39-cp39-win32.whl", hash = "sha256:2130db8ed69a48a3440103d4a520b89d8a9405f1b06e2cc81640509e8bf6548f"},
+    {file = "lazy_object_proxy-1.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:677ea950bef409b47e51e733283544ac3d660b709cfce7b187f5ace137960d61"},
+    {file = "lazy_object_proxy-1.7.1-pp37.pp38-none-any.whl", hash = "sha256:d66906d5785da8e0be7360912e99c9188b70f52c422f9fc18223347235691a84"},
 ]
 markdown = [
-    {file = "Markdown-3.3.4-py3-none-any.whl", hash = "sha256:96c3ba1261de2f7547b46a00ea8463832c921d3f9d6aba3f255a6f71386db20c"},
-    {file = "Markdown-3.3.4.tar.gz", hash = "sha256:31b5b491868dcc87d6c24b7e3d19a0d730d59d3e46f4eea6430a321bed387a49"},
+    {file = "Markdown-3.3.6-py3-none-any.whl", hash = "sha256:9923332318f843411e9932237530df53162e29dc7a4e2b91e35764583c46c9a3"},
+    {file = "Markdown-3.3.6.tar.gz", hash = "sha256:76df8ae32294ec39dcf89340382882dfa12975f87f45c3ed1ecdb1e8cefc7006"},
 ]
 markupsafe = [
     {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
@@ -5143,27 +5285,41 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
 ]
 matplotlib = [
-    {file = "matplotlib-3.4.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5c988bb43414c7c2b0a31bd5187b4d27fd625c080371b463a6d422047df78913"},
-    {file = "matplotlib-3.4.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:f1c5efc278d996af8a251b2ce0b07bbeccb821f25c8c9846bdcb00ffc7f158aa"},
-    {file = "matplotlib-3.4.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:eeb1859efe7754b1460e1d4991bbd4a60a56f366bc422ef3a9c5ae05f0bc70b5"},
-    {file = "matplotlib-3.4.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:844a7b0233e4ff7fba57e90b8799edaa40b9e31e300b8d5efc350937fa8b1bea"},
-    {file = "matplotlib-3.4.3-cp37-cp37m-win32.whl", hash = "sha256:85f0c9cf724715e75243a7b3087cf4a3de056b55e05d4d76cc58d610d62894f3"},
-    {file = "matplotlib-3.4.3-cp37-cp37m-win_amd64.whl", hash = "sha256:c70b6311dda3e27672f1bf48851a0de816d1ca6aaf3d49365fbdd8e959b33d2b"},
-    {file = "matplotlib-3.4.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b884715a59fec9ad3b6048ecf3860f3b2ce965e676ef52593d6fa29abcf7d330"},
-    {file = "matplotlib-3.4.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:a78a3b51f29448c7f4d4575e561f6b0dbb8d01c13c2046ab6c5220eb25c06506"},
-    {file = "matplotlib-3.4.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6a724e3a48a54b8b6e7c4ae38cd3d07084508fa47c410c8757e9db9791421838"},
-    {file = "matplotlib-3.4.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:48e1e0859b54d5f2e29bb78ca179fd59b971c6ceb29977fb52735bfd280eb0f5"},
-    {file = "matplotlib-3.4.3-cp38-cp38-win32.whl", hash = "sha256:01c9de93a2ca0d128c9064f23709362e7fefb34910c7c9e0b8ab0de8258d5eda"},
-    {file = "matplotlib-3.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:ebfb01a65c3f5d53a8c2a8133fec2b5221281c053d944ae81ff5822a68266617"},
-    {file = "matplotlib-3.4.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b8b53f336a4688cfce615887505d7e41fd79b3594bf21dd300531a4f5b4f746a"},
-    {file = "matplotlib-3.4.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:fcd6f1954943c0c192bfbebbac263f839d7055409f1173f80d8b11a224d236da"},
-    {file = "matplotlib-3.4.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:6be8df61b1626e1a142c57e065405e869e9429b4a6dab4a324757d0dc4d42235"},
-    {file = "matplotlib-3.4.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:41b6e307458988891fcdea2d8ecf84a8c92d53f84190aa32da65f9505546e684"},
-    {file = "matplotlib-3.4.3-cp39-cp39-win32.whl", hash = "sha256:f72657f1596199dc1e4e7a10f52a4784ead8a711f4e5b59bea95bdb97cf0e4fd"},
-    {file = "matplotlib-3.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:f15edcb0629a0801738925fe27070480f446fcaa15de65946ff946ad99a59a40"},
-    {file = "matplotlib-3.4.3-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:556965514b259204637c360d213de28d43a1f4aed1eca15596ce83f768c5a56f"},
-    {file = "matplotlib-3.4.3-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:54a026055d5f8614f184e588f6e29064019a0aa8448450214c0b60926d62d919"},
-    {file = "matplotlib-3.4.3.tar.gz", hash = "sha256:fc4f526dfdb31c9bd6b8ca06bf9fab663ca12f3ec9cdf4496fb44bc680140318"},
+    {file = "matplotlib-3.5.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:456cc8334f6d1124e8ff856b42d2cc1c84335375a16448189999496549f7182b"},
+    {file = "matplotlib-3.5.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8a77906dc2ef9b67407cec0bdbf08e3971141e535db888974a915be5e1e3efc6"},
+    {file = "matplotlib-3.5.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8e70ae6475cfd0fad3816dcbf6cac536dc6f100f7474be58d59fa306e6e768a4"},
+    {file = "matplotlib-3.5.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:53273c5487d1c19c3bc03b9eb82adaf8456f243b97ed79d09dded747abaf1235"},
+    {file = "matplotlib-3.5.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e3b6f3fd0d8ca37861c31e9a7cab71a0ef14c639b4c95654ea1dd153158bf0df"},
+    {file = "matplotlib-3.5.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e8c87cdaf06fd7b2477f68909838ff4176f105064a72ca9d24d3f2a29f73d393"},
+    {file = "matplotlib-3.5.1-cp310-cp310-win32.whl", hash = "sha256:e2f28a07b4f82abb40267864ad7b3a4ed76f1b1663e81c7efc84a9b9248f672f"},
+    {file = "matplotlib-3.5.1-cp310-cp310-win_amd64.whl", hash = "sha256:d70a32ee1f8b55eed3fd4e892f0286df8cccc7e0475c11d33b5d0a148f5c7599"},
+    {file = "matplotlib-3.5.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:68fa30cec89b6139dc559ed6ef226c53fd80396da1919a1b5ef672c911aaa767"},
+    {file = "matplotlib-3.5.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2e3484d8455af3fdb0424eae1789af61f6a79da0c80079125112fd5c1b604218"},
+    {file = "matplotlib-3.5.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e293b16cf303fe82995e41700d172a58a15efc5331125d08246b520843ef21ee"},
+    {file = "matplotlib-3.5.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:e3520a274a0e054e919f5b3279ee5dbccf5311833819ccf3399dab7c83e90a25"},
+    {file = "matplotlib-3.5.1-cp37-cp37m-win32.whl", hash = "sha256:2252bfac85cec7af4a67e494bfccf9080bcba8a0299701eab075f48847cca907"},
+    {file = "matplotlib-3.5.1-cp37-cp37m-win_amd64.whl", hash = "sha256:abf67e05a1b7f86583f6ebd01f69b693b9c535276f4e943292e444855870a1b8"},
+    {file = "matplotlib-3.5.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:6c094e4bfecd2fa7f9adffd03d8abceed7157c928c2976899de282f3600f0a3d"},
+    {file = "matplotlib-3.5.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:506b210cc6e66a0d1c2bb765d055f4f6bc2745070fb1129203b67e85bbfa5c18"},
+    {file = "matplotlib-3.5.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b04fc29bcef04d4e2d626af28d9d892be6aba94856cb46ed52bcb219ceac8943"},
+    {file = "matplotlib-3.5.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:577ed20ec9a18d6bdedb4616f5e9e957b4c08563a9f985563a31fd5b10564d2a"},
+    {file = "matplotlib-3.5.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e486f60db0cd1c8d68464d9484fd2a94011c1ac8593d765d0211f9daba2bd535"},
+    {file = "matplotlib-3.5.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:b71f3a7ca935fc759f2aed7cec06cfe10bc3100fadb5dbd9c435b04e557971e1"},
+    {file = "matplotlib-3.5.1-cp38-cp38-win32.whl", hash = "sha256:d24e5bb8028541ce25e59390122f5e48c8506b7e35587e5135efcb6471b4ac6c"},
+    {file = "matplotlib-3.5.1-cp38-cp38-win_amd64.whl", hash = "sha256:778d398c4866d8e36ee3bf833779c940b5f57192fa0a549b3ad67bc4c822771b"},
+    {file = "matplotlib-3.5.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:bb1c613908f11bac270bc7494d68b1ef6e7c224b7a4204d5dacf3522a41e2bc3"},
+    {file = "matplotlib-3.5.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:edf5e4e1d5fb22c18820e8586fb867455de3b109c309cb4fce3aaed85d9468d1"},
+    {file = "matplotlib-3.5.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:40e0d7df05e8efe60397c69b467fc8f87a2affeb4d562fe92b72ff8937a2b511"},
+    {file = "matplotlib-3.5.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a350ca685d9f594123f652ba796ee37219bf72c8e0fc4b471473d87121d6d34"},
+    {file = "matplotlib-3.5.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3e66497cd990b1a130e21919b004da2f1dc112132c01ac78011a90a0f9229778"},
+    {file = "matplotlib-3.5.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:87900c67c0f1728e6db17c6809ec05c025c6624dcf96a8020326ea15378fe8e7"},
+    {file = "matplotlib-3.5.1-cp39-cp39-win32.whl", hash = "sha256:b8a4fb2a0c5afbe9604f8a91d7d0f27b1832c3e0b5e365f95a13015822b4cd65"},
+    {file = "matplotlib-3.5.1-cp39-cp39-win_amd64.whl", hash = "sha256:fe8d40c434a8e2c68d64c6d6a04e77f21791a93ff6afe0dce169597c110d3079"},
+    {file = "matplotlib-3.5.1-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:34a1fc29f8f96e78ec57a5eff5e8d8b53d3298c3be6df61e7aa9efba26929522"},
+    {file = "matplotlib-3.5.1-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:b19a761b948e939a9e20173aaae76070025f0024fc8f7ba08bef22a5c8573afc"},
+    {file = "matplotlib-3.5.1-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6803299cbf4665eca14428d9e886de62e24f4223ac31ab9c5d6d5339a39782c7"},
+    {file = "matplotlib-3.5.1-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:14334b9902ec776461c4b8c6516e26b450f7ebe0b3ef8703bf5cdfbbaecf774a"},
+    {file = "matplotlib-3.5.1.tar.gz", hash = "sha256:b2e9810e09c3a47b73ce9cab5a72243a1258f61e7900969097a817232246ce1c"},
 ]
 matplotlib-inline = [
     {file = "matplotlib-inline-0.1.3.tar.gz", hash = "sha256:a04bfba22e0d1395479f866853ec1ee28eea1485c1d69a6faf00dc3e24ff34ee"},
@@ -5231,131 +5387,112 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 nbclient = [
-    {file = "nbclient-0.5.4-py3-none-any.whl", hash = "sha256:95a300c6fbe73721736cf13972a46d8d666f78794b832866ed7197a504269e11"},
-    {file = "nbclient-0.5.4.tar.gz", hash = "sha256:6c8ad36a28edad4562580847f9f1636fe5316a51a323ed85a24a4ad37d4aefce"},
+    {file = "nbclient-0.5.10-py3-none-any.whl", hash = "sha256:5b582e21c8b464e6676a9d60acc6871d7fbc3b080f74bef265a9f90411b31f6f"},
+    {file = "nbclient-0.5.10.tar.gz", hash = "sha256:b5fdea88d6fa52ca38de6c2361401cfe7aaa7cd24c74effc5e489cec04d79088"},
 ]
 nbconvert = [
-    {file = "nbconvert-6.2.0-py3-none-any.whl", hash = "sha256:b1b9dc4f1ff6cafae0e6d91f42fb9046fdc32e6beb6d7e2fa2cd7191ad535240"},
-    {file = "nbconvert-6.2.0.tar.gz", hash = "sha256:16ceecd0afaa8fd26c245fa32e2c52066c02f13aa73387fffafd84750baea863"},
+    {file = "nbconvert-6.4.1-py3-none-any.whl", hash = "sha256:fe93bc42485c54c5a49a2324c834aca1ff315f320a535bed3e3c4e085d3eebe3"},
+    {file = "nbconvert-6.4.1.tar.gz", hash = "sha256:7dce3f977c2f9651841a3c49b5b7314c742f24dd118b99e51b8eec13c504f555"},
 ]
 nbformat = [
     {file = "nbformat-5.1.3-py3-none-any.whl", hash = "sha256:eb8447edd7127d043361bc17f2f5a807626bc8e878c7709a1c647abda28a9171"},
     {file = "nbformat-5.1.3.tar.gz", hash = "sha256:b516788ad70771c6250977c1374fcca6edebe6126fd2adb5a69aa5c2356fd1c8"},
 ]
 nest-asyncio = [
-    {file = "nest_asyncio-1.5.1-py3-none-any.whl", hash = "sha256:76d6e972265063fe92a90b9cc4fb82616e07d586b346ed9d2c89a4187acea39c"},
-    {file = "nest_asyncio-1.5.1.tar.gz", hash = "sha256:afc5a1c515210a23c461932765691ad39e8eba6551c055ac8d5546e69250d0aa"},
+    {file = "nest_asyncio-1.5.4-py3-none-any.whl", hash = "sha256:3fdd0d6061a2bb16f21fe8a9c6a7945be83521d81a0d15cff52e9edee50101d6"},
+    {file = "nest_asyncio-1.5.4.tar.gz", hash = "sha256:f969f6013a16fadb4adcf09d11a68a4f617c6049d7af7ac2c676110169a63abd"},
 ]
 numpy = [
-    {file = "numpy-1.21.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8890b3360f345e8360133bc078d2dacc2843b6ee6059b568781b15b97acbe39f"},
-    {file = "numpy-1.21.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:69077388c5a4b997442b843dbdc3a85b420fb693ec8e33020bb24d647c164fa5"},
-    {file = "numpy-1.21.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e89717274b41ebd568cd7943fc9418eeb49b1785b66031bc8a7f6300463c5898"},
-    {file = "numpy-1.21.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b78ecfa070460104934e2caf51694ccd00f37d5e5dbe76f021b1b0b0d221823"},
-    {file = "numpy-1.21.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:615d4e328af7204c13ae3d4df7615a13ff60a49cb0d9106fde07f541207883ca"},
-    {file = "numpy-1.21.4-cp310-cp310-win_amd64.whl", hash = "sha256:1403b4e2181fc72664737d848b60e65150f272fe5a1c1cbc16145ed43884065a"},
-    {file = "numpy-1.21.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:74b85a17528ca60cf98381a5e779fc0264b4a88b46025e6bcbe9621f46bb3e63"},
-    {file = "numpy-1.21.4-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:92aafa03da8658609f59f18722b88f0a73a249101169e28415b4fa148caf7e41"},
-    {file = "numpy-1.21.4-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5d95668e727c75b3f5088ec7700e260f90ec83f488e4c0aaccb941148b2cd377"},
-    {file = "numpy-1.21.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f5162ec777ba7138906c9c274353ece5603646c6965570d82905546579573f73"},
-    {file = "numpy-1.21.4-cp37-cp37m-win32.whl", hash = "sha256:81225e58ef5fce7f1d80399575576fc5febec79a8a2742e8ef86d7b03beef49f"},
-    {file = "numpy-1.21.4-cp37-cp37m-win_amd64.whl", hash = "sha256:32fe5b12061f6446adcbb32cf4060a14741f9c21e15aaee59a207b6ce6423469"},
-    {file = "numpy-1.21.4-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:c449eb870616a7b62e097982c622d2577b3dbc800aaf8689254ec6e0197cbf1e"},
-    {file = "numpy-1.21.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2e4ed57f45f0aa38beca2a03b6532e70e548faf2debbeb3291cfc9b315d9be8f"},
-    {file = "numpy-1.21.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:1247ef28387b7bb7f21caf2dbe4767f4f4175df44d30604d42ad9bd701ebb31f"},
-    {file = "numpy-1.21.4-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:34f3456f530ae8b44231c63082c8899fe9c983fd9b108c997c4b1c8c2d435333"},
-    {file = "numpy-1.21.4-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4c9c23158b87ed0e70d9a50c67e5c0b3f75bcf2581a8e34668d4e9d7474d76c6"},
-    {file = "numpy-1.21.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4799be6a2d7d3c33699a6f77201836ac975b2e1b98c2a07f66a38f499cb50ce"},
-    {file = "numpy-1.21.4-cp38-cp38-win32.whl", hash = "sha256:bc988afcea53e6156546e5b2885b7efab089570783d9d82caf1cfd323b0bb3dd"},
-    {file = "numpy-1.21.4-cp38-cp38-win_amd64.whl", hash = "sha256:170b2a0805c6891ca78c1d96ee72e4c3ed1ae0a992c75444b6ab20ff038ba2cd"},
-    {file = "numpy-1.21.4-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:fde96af889262e85aa033f8ee1d3241e32bf36228318a61f1ace579df4e8170d"},
-    {file = "numpy-1.21.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c885bfc07f77e8fee3dc879152ba993732601f1f11de248d4f357f0ffea6a6d4"},
-    {file = "numpy-1.21.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9e6f5f50d1eff2f2f752b3089a118aee1ea0da63d56c44f3865681009b0af162"},
-    {file = "numpy-1.21.4-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ad010846cdffe7ec27e3f933397f8a8d6c801a48634f419e3d075db27acf5880"},
-    {file = "numpy-1.21.4-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c74c699b122918a6c4611285cc2cad4a3aafdb135c22a16ec483340ef97d573c"},
-    {file = "numpy-1.21.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9864424631775b0c052f3bd98bc2712d131b3e2cd95d1c0c68b91709170890b0"},
-    {file = "numpy-1.21.4-cp39-cp39-win32.whl", hash = "sha256:b1e2312f5b8843a3e4e8224b2b48fe16119617b8fc0a54df8f50098721b5bed2"},
-    {file = "numpy-1.21.4-cp39-cp39-win_amd64.whl", hash = "sha256:e3c3e990274444031482a31280bf48674441e0a5b55ddb168f3a6db3e0c38ec8"},
-    {file = "numpy-1.21.4-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a3deb31bc84f2b42584b8c4001c85d1934dbfb4030827110bc36bfd11509b7bf"},
-    {file = "numpy-1.21.4.zip", hash = "sha256:e6c76a87633aa3fa16614b61ccedfae45b91df2767cf097aa9c933932a7ed1e0"},
+    {file = "numpy-1.21.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:301e408a052fdcda5cdcf03021ebafc3c6ea093021bf9d1aa47c54d48bdad166"},
+    {file = "numpy-1.21.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a7e8f6216f180f3fd4efb73de5d1eaefb5f5a1ee5b645c67333033e39440e63a"},
+    {file = "numpy-1.21.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fc7a7d7b0ed72589fd8b8486b9b42a564f10b8762be8bd4d9df94b807af4a089"},
+    {file = "numpy-1.21.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:58ca1d7c8aef6e996112d0ce873ac9dfa1eaf4a1196b4ff7ff73880a09923ba7"},
+    {file = "numpy-1.21.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc4b2fb01f1b4ddbe2453468ea0719f4dbb1f5caa712c8b21bb3dd1480cd30d9"},
+    {file = "numpy-1.21.5-cp310-cp310-win_amd64.whl", hash = "sha256:cc1b30205d138d1005adb52087ff45708febbef0e420386f58664f984ef56954"},
+    {file = "numpy-1.21.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:08de8472d9f7571f9d51b27b75e827f5296295fa78817032e84464be8bb905bc"},
+    {file = "numpy-1.21.5-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:4fe6a006557b87b352c04596a6e3f12a57d6e5f401d804947bd3188e6b0e0e76"},
+    {file = "numpy-1.21.5-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3d893b0871322eaa2f8c7072cdb552d8e2b27645b7875a70833c31e9274d4611"},
+    {file = "numpy-1.21.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:341dddcfe3b7b6427a28a27baa59af5ad51baa59bfec3264f1ab287aa3b30b13"},
+    {file = "numpy-1.21.5-cp37-cp37m-win32.whl", hash = "sha256:ca9c23848292c6fe0a19d212790e62f398fd9609aaa838859be8459bfbe558aa"},
+    {file = "numpy-1.21.5-cp37-cp37m-win_amd64.whl", hash = "sha256:025b497014bc33fc23897859350f284323f32a2fff7654697f5a5fc2a19e9939"},
+    {file = "numpy-1.21.5-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:3a5098df115340fb17fc93867317a947e1dcd978c3888c5ddb118366095851f8"},
+    {file = "numpy-1.21.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:311283acf880cfcc20369201bd75da907909afc4666966c7895cbed6f9d2c640"},
+    {file = "numpy-1.21.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b545ebadaa2b878c8630e5bcdb97fc4096e779f335fc0f943547c1c91540c815"},
+    {file = "numpy-1.21.5-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c5562bcc1a9b61960fc8950ade44d00e3de28f891af0acc96307c73613d18f6e"},
+    {file = "numpy-1.21.5-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:eed2afaa97ec33b4411995be12f8bdb95c87984eaa28d76cf628970c8a2d689a"},
+    {file = "numpy-1.21.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:61bada43d494515d5b122f4532af226fdb5ee08fe5b5918b111279843dc6836a"},
+    {file = "numpy-1.21.5-cp38-cp38-win32.whl", hash = "sha256:7b9d6b14fc9a4864b08d1ba57d732b248f0e482c7b2ff55c313137e3ed4d8449"},
+    {file = "numpy-1.21.5-cp38-cp38-win_amd64.whl", hash = "sha256:dbce7adeb66b895c6aaa1fad796aaefc299ced597f6fbd9ceddb0dd735245354"},
+    {file = "numpy-1.21.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:507c05c7a37b3683eb08a3ff993bd1ee1e6c752f77c2f275260533b265ecdb6c"},
+    {file = "numpy-1.21.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:00c9fa73a6989895b8815d98300a20ac993c49ac36c8277e8ffeaa3631c0dbbb"},
+    {file = "numpy-1.21.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:69a5a8d71c308d7ef33ef72371c2388a90e3495dbb7993430e674006f94797d5"},
+    {file = "numpy-1.21.5-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2d8adfca843bc46ac199a4645233f13abf2011a0b2f4affc5c37cd552626f27b"},
+    {file = "numpy-1.21.5-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c293d3c0321996cd8ffe84215ffe5d269fd9d1d12c6f4ffe2b597a7c30d3e593"},
+    {file = "numpy-1.21.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3c978544be9e04ed12016dd295a74283773149b48f507d69b36f91aa90a643e5"},
+    {file = "numpy-1.21.5-cp39-cp39-win32.whl", hash = "sha256:2a9add27d7fc0fdb572abc3b2486eb3b1395da71e0254c5552b2aad2a18b5441"},
+    {file = "numpy-1.21.5-cp39-cp39-win_amd64.whl", hash = "sha256:1964db2d4a00348b7a60ee9d013c8cb0c566644a589eaa80995126eac3b99ced"},
+    {file = "numpy-1.21.5-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a7c4b701ca418cd39e28ec3b496e6388fe06de83f5f0cb74794fa31cfa384c02"},
+    {file = "numpy-1.21.5.zip", hash = "sha256:6a5928bc6241264dce5ed509e66f33676fc97f464e7a919edc672fb5532221ee"},
 ]
 numpydoc = [
-    {file = "numpydoc-1.1.0-py3-none-any.whl", hash = "sha256:c53d6311190b9e3b9285bc979390ba0257ba9acde5eca1a7065fc8dfca9d46e8"},
-    {file = "numpydoc-1.1.0.tar.gz", hash = "sha256:c36fd6cb7ffdc9b4e165a43f67bf6271a7b024d0bb6b00ac468c9e2bfc76448e"},
+    {file = "numpydoc-1.2-py3-none-any.whl", hash = "sha256:3ecbb9feae080031714b63128912988ebdfd4c582a085d25b8d9f7ac23c2d9ef"},
+    {file = "numpydoc-1.2.tar.gz", hash = "sha256:0cec233740c6b125913005d16e8a9996e060528afcb8b7cad3f2706629dfd6f7"},
 ]
 oauthlib = [
     {file = "oauthlib-3.1.1-py2.py3-none-any.whl", hash = "sha256:42bf6354c2ed8c6acb54d971fce6f88193d97297e18602a3a886603f9d7730cc"},
     {file = "oauthlib-3.1.1.tar.gz", hash = "sha256:8f0215fcc533dd8dd1bee6f4c412d4f0cd7297307d43ac61666389e3bc3198a3"},
 ]
 opencv-python = [
-    {file = "opencv-python-4.5.4.58.tar.gz", hash = "sha256:48288428f407bacba5f73d460feb4a1ecafe87db3d7cfc0730a49fb32f589bbf"},
-    {file = "opencv_python-4.5.4.58-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0eba0bfe62c48a02a5af3a0944e872c99f57f98653bed14d51c6991a58f9e1d1"},
-    {file = "opencv_python-4.5.4.58-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:9bcca50c5444b5cfb01624666b69f91ba8f2d2bf4ef37b111697aafdeb81c99f"},
-    {file = "opencv_python-4.5.4.58-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:8f7886acabaebf0361bd3dbccaa0d08e3f65ab13b7c739eb11e028f01ad13582"},
-    {file = "opencv_python-4.5.4.58-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:d4b1d0b98ee72ba5dd720166790fc93ce459281e138ee79b0d41420b3da52b2e"},
-    {file = "opencv_python-4.5.4.58-cp310-cp310-win32.whl", hash = "sha256:69a78e40a374ac14e4bf15a13dbb6c30fd2fbd5fcd3674d020a31b88861d5aaf"},
-    {file = "opencv_python-4.5.4.58-cp310-cp310-win_amd64.whl", hash = "sha256:315c357522b6310ef7a0718d9f0c5d3110e59c19140705499a3c29bdd8c0124f"},
-    {file = "opencv_python-4.5.4.58-cp36-cp36m-macosx_10_15_x86_64.whl", hash = "sha256:887a61097092dc0bf23fa24646dbc8cfeeb753649cb28a3782a93a6879e3b7d2"},
-    {file = "opencv_python-4.5.4.58-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:22bcc3153a7d4f95aff79457eef81ef5e40ab1851b189e014412b5e9fbee2573"},
-    {file = "opencv_python-4.5.4.58-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:92e9b2261ec764229c948d77fe0d922ee033348ca6519939b87861016c1614b3"},
-    {file = "opencv_python-4.5.4.58-cp36-cp36m-win32.whl", hash = "sha256:0d6249a49122a78afc6685ddb1377a87e46414ae61c84535c4c6024397f1f3e8"},
-    {file = "opencv_python-4.5.4.58-cp36-cp36m-win_amd64.whl", hash = "sha256:eaa144013b597e4dcabc8d8230edfe810319de01b5609556d415a20e2b707547"},
-    {file = "opencv_python-4.5.4.58-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:26feeeb280de179f5dbb8976ebf7ceb836bd263973cb5daec8ca36e8ef7b5773"},
-    {file = "opencv_python-4.5.4.58-cp37-cp37m-macosx_11_0_arm64.whl", hash = "sha256:4a13381bdfc0fb4b080efcc27c46561d0bd752f126226e9f19aa9cbcf6677f40"},
-    {file = "opencv_python-4.5.4.58-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:ac852fcaac93439f2f7116ddffdc23fd366c872200ade2272446f9898180cecb"},
-    {file = "opencv_python-4.5.4.58-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:02872e0a9358526646d691f390143e9c21109c210095314abaa0641211cda077"},
-    {file = "opencv_python-4.5.4.58-cp37-cp37m-win32.whl", hash = "sha256:6b87bab220d17e03eeedbcc6652d9d7e7bb09886dbd0f810310697a948b4c6fd"},
-    {file = "opencv_python-4.5.4.58-cp37-cp37m-win_amd64.whl", hash = "sha256:a2a7f09b8843b85f3e1b02c5ea3ddc0cb9f5ad9698380109b37069ee8db7746d"},
-    {file = "opencv_python-4.5.4.58-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:c44f5c51e92322ed832607204249c190764dec6cf29e8ba6d679b10326be1c1b"},
-    {file = "opencv_python-4.5.4.58-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9b2c198af083a693d42a82bddc4d1f7e6bb02c64192ff7fac1fd1d43a8cf1be6"},
-    {file = "opencv_python-4.5.4.58-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:637f4d3ad81bd27f273ede4c5fa6c26afb85c097c9715baf107cc270e37f5fea"},
-    {file = "opencv_python-4.5.4.58-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:2fff48a641a74d1def31c1e88f9e5ce50ba4d0f87d085dfbf8bc844e12f6cd54"},
-    {file = "opencv_python-4.5.4.58-cp38-cp38-win32.whl", hash = "sha256:8ddf4dcd8199209e33f21deb0c6d8ab62b21802816bba895fefc346b6d2e522d"},
-    {file = "opencv_python-4.5.4.58-cp38-cp38-win_amd64.whl", hash = "sha256:085c5fcf5a6479c34aca3fd0f59055e704083d6a44009d6583c675ff1a5a0625"},
-    {file = "opencv_python-4.5.4.58-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:4abe9c4fb6fe16daa9fcdd68b5357d3530431341aa655203f8e84f394e1fe6d4"},
-    {file = "opencv_python-4.5.4.58-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4b614fbd81aeda53ce28e645aaee18fda7c7f2a48eb7f1a70a7c6c3427946342"},
-    {file = "opencv_python-4.5.4.58-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:215bdf069847d4e3b0447a34e9eb4046dd4ca523d41fe4381c1c55f6704fd0dc"},
-    {file = "opencv_python-4.5.4.58-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc34cdbfbab463750713118c8259a5d364547adab8ed91e94ba888349f33590a"},
-    {file = "opencv_python-4.5.4.58-cp39-cp39-win32.whl", hash = "sha256:9998ce60884f3cda074f02b56d2b57ee6bd863e2ddba132da2b0af3b9487d584"},
-    {file = "opencv_python-4.5.4.58-cp39-cp39-win_amd64.whl", hash = "sha256:5370a11757fbe94b176771269aff599f4da8676c2a672b13bcbca043f2e3eea8"},
+    {file = "opencv-python-4.5.5.62.tar.gz", hash = "sha256:3efe232b32d5e1327e7c82bc6d61230737821c5190ce5c783e64a1bc8d514e18"},
+    {file = "opencv_python-4.5.5.62-cp36-abi3-macosx_10_15_x86_64.whl", hash = "sha256:2601388def0d6b957cc30dd88f8ff74a5651ae6940dd9e488241608cfa2b15c7"},
+    {file = "opencv_python-4.5.5.62-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:71fdc49df412b102d97f14927321309043c79c4a3582cce1dc803370ff9c39c0"},
+    {file = "opencv_python-4.5.5.62-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:130cc75d56b29aa3c5de8b6ac438242dd2574ba6eaa8bccdffdcfd6b78632f7f"},
+    {file = "opencv_python-4.5.5.62-cp36-abi3-win32.whl", hash = "sha256:3a75c7ad45b032eea0c72e389aac6dd435f5c87e87f60237095c083400bc23aa"},
+    {file = "opencv_python-4.5.5.62-cp36-abi3-win_amd64.whl", hash = "sha256:c463d2276d8662b972d20ca9644702188507de200ca5405b89e1fe71c5c99989"},
+    {file = "opencv_python-4.5.5.62-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:ac92e743e22681f30001942d78512c1e39bce53dbffc504e5645fdc45c0f2c47"},
 ]
 packaging = [
-    {file = "packaging-21.2-py3-none-any.whl", hash = "sha256:14317396d1e8cdb122989b916fa2c7e9ca8e2be9e8060a6eff75b6b7b4d8a7e0"},
-    {file = "packaging-21.2.tar.gz", hash = "sha256:096d689d78ca690e4cd8a89568ba06d07ca097e3306a4381635073ca91479966"},
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
 pandas = [
-    {file = "pandas-1.3.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:372d72a3d8a5f2dbaf566a5fa5fa7f230842ac80f29a931fb4b071502cf86b9a"},
-    {file = "pandas-1.3.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d99d2350adb7b6c3f7f8f0e5dfb7d34ff8dd4bc0a53e62c445b7e43e163fce63"},
-    {file = "pandas-1.3.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c2646458e1dce44df9f71a01dc65f7e8fa4307f29e5c0f2f92c97f47a5bf22f5"},
-    {file = "pandas-1.3.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5298a733e5bfbb761181fd4672c36d0c627320eb999c59c65156c6a90c7e1b4f"},
-    {file = "pandas-1.3.4-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22808afb8f96e2269dcc5b846decacb2f526dd0b47baebc63d913bf847317c8f"},
-    {file = "pandas-1.3.4-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b528e126c13816a4374e56b7b18bfe91f7a7f6576d1aadba5dee6a87a7f479ae"},
-    {file = "pandas-1.3.4-cp37-cp37m-win32.whl", hash = "sha256:fe48e4925455c964db914b958f6e7032d285848b7538a5e1b19aeb26ffaea3ec"},
-    {file = "pandas-1.3.4-cp37-cp37m-win_amd64.whl", hash = "sha256:eaca36a80acaacb8183930e2e5ad7f71539a66805d6204ea88736570b2876a7b"},
-    {file = "pandas-1.3.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:42493f8ae67918bf129869abea8204df899902287a7f5eaf596c8e54e0ac7ff4"},
-    {file = "pandas-1.3.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a388960f979665b447f0847626e40f99af8cf191bce9dc571d716433130cb3a7"},
-    {file = "pandas-1.3.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ba0aac1397e1d7b654fccf263a4798a9e84ef749866060d19e577e927d66e1b"},
-    {file = "pandas-1.3.4-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f567e972dce3bbc3a8076e0b675273b4a9e8576ac629149cf8286ee13c259ae5"},
-    {file = "pandas-1.3.4-cp38-cp38-win32.whl", hash = "sha256:c1aa4de4919358c5ef119f6377bc5964b3a7023c23e845d9db7d9016fa0c5b1c"},
-    {file = "pandas-1.3.4-cp38-cp38-win_amd64.whl", hash = "sha256:dd324f8ee05925ee85de0ea3f0d66e1362e8c80799eb4eb04927d32335a3e44a"},
-    {file = "pandas-1.3.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d47750cf07dee6b55d8423471be70d627314277976ff2edd1381f02d52dbadf9"},
-    {file = "pandas-1.3.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d1dc09c0013d8faa7474574d61b575f9af6257ab95c93dcf33a14fd8d2c1bab"},
-    {file = "pandas-1.3.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10e10a2527db79af6e830c3d5842a4d60383b162885270f8cffc15abca4ba4a9"},
-    {file = "pandas-1.3.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:35c77609acd2e4d517da41bae0c11c70d31c87aae8dd1aabd2670906c6d2c143"},
-    {file = "pandas-1.3.4-cp39-cp39-win32.whl", hash = "sha256:003ba92db58b71a5f8add604a17a059f3068ef4e8c0c365b088468d0d64935fd"},
-    {file = "pandas-1.3.4-cp39-cp39-win_amd64.whl", hash = "sha256:a51528192755f7429c5bcc9e80832c517340317c861318fea9cea081b57c9afd"},
-    {file = "pandas-1.3.4.tar.gz", hash = "sha256:a2aa18d3f0b7d538e21932f637fbfe8518d085238b429e4790a35e1e44a96ffc"},
+    {file = "pandas-1.3.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:62d5b5ce965bae78f12c1c0df0d387899dd4211ec0bdc52822373f13a3a022b9"},
+    {file = "pandas-1.3.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:adfeb11be2d54f275142c8ba9bf67acee771b7186a5745249c7d5a06c670136b"},
+    {file = "pandas-1.3.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:60a8c055d58873ad81cae290d974d13dd479b82cbb975c3e1fa2cf1920715296"},
+    {file = "pandas-1.3.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fd541ab09e1f80a2a1760032d665f6e032d8e44055d602d65eeea6e6e85498cb"},
+    {file = "pandas-1.3.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2651d75b9a167cc8cc572cf787ab512d16e316ae00ba81874b560586fa1325e0"},
+    {file = "pandas-1.3.5-cp310-cp310-win_amd64.whl", hash = "sha256:aaf183a615ad790801fa3cf2fa450e5b6d23a54684fe386f7e3208f8b9bfbef6"},
+    {file = "pandas-1.3.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:344295811e67f8200de2390093aeb3c8309f5648951b684d8db7eee7d1c81fb7"},
+    {file = "pandas-1.3.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:552020bf83b7f9033b57cbae65589c01e7ef1544416122da0c79140c93288f56"},
+    {file = "pandas-1.3.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5cce0c6bbeb266b0e39e35176ee615ce3585233092f685b6a82362523e59e5b4"},
+    {file = "pandas-1.3.5-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7d28a3c65463fd0d0ba8bbb7696b23073efee0510783340a44b08f5e96ffce0c"},
+    {file = "pandas-1.3.5-cp37-cp37m-win32.whl", hash = "sha256:a62949c626dd0ef7de11de34b44c6475db76995c2064e2d99c6498c3dba7fe58"},
+    {file = "pandas-1.3.5-cp37-cp37m-win_amd64.whl", hash = "sha256:8025750767e138320b15ca16d70d5cdc1886e8f9cc56652d89735c016cd8aea6"},
+    {file = "pandas-1.3.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:fe95bae4e2d579812865db2212bb733144e34d0c6785c0685329e5b60fcb85dd"},
+    {file = "pandas-1.3.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f261553a1e9c65b7a310302b9dbac31cf0049a51695c14ebe04e4bfd4a96f02"},
+    {file = "pandas-1.3.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8b6dbec5f3e6d5dc80dcfee250e0a2a652b3f28663492f7dab9a24416a48ac39"},
+    {file = "pandas-1.3.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d3bc49af96cd6285030a64779de5b3688633a07eb75c124b0747134a63f4c05f"},
+    {file = "pandas-1.3.5-cp38-cp38-win32.whl", hash = "sha256:b6b87b2fb39e6383ca28e2829cddef1d9fc9e27e55ad91ca9c435572cdba51bf"},
+    {file = "pandas-1.3.5-cp38-cp38-win_amd64.whl", hash = "sha256:a395692046fd8ce1edb4c6295c35184ae0c2bbe787ecbe384251da609e27edcb"},
+    {file = "pandas-1.3.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:bd971a3f08b745a75a86c00b97f3007c2ea175951286cdda6abe543e687e5f2f"},
+    {file = "pandas-1.3.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37f06b59e5bc05711a518aa10beaec10942188dccb48918bb5ae602ccbc9f1a0"},
+    {file = "pandas-1.3.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c21778a688d3712d35710501f8001cdbf96eb70a7c587a3d5613573299fdca6"},
+    {file = "pandas-1.3.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3345343206546545bc26a05b4602b6a24385b5ec7c75cb6059599e3d56831da2"},
+    {file = "pandas-1.3.5-cp39-cp39-win32.whl", hash = "sha256:c69406a2808ba6cf580c2255bcf260b3f214d2664a3a4197d0e640f573b46fd3"},
+    {file = "pandas-1.3.5-cp39-cp39-win_amd64.whl", hash = "sha256:32e1a26d5ade11b547721a72f9bfc4bd113396947606e00d5b4a5b79b3dcb006"},
+    {file = "pandas-1.3.5.tar.gz", hash = "sha256:1e4285f5de1012de20ca46b188ccf33521bff61ba5c5ebd78b4fb28e5416a9f1"},
 ]
 pandocfilters = [
     {file = "pandocfilters-1.5.0-py2.py3-none-any.whl", hash = "sha256:33aae3f25fd1a026079f5d27bdd52496f0e0803b3469282162bafdcbdf6ef14f"},
     {file = "pandocfilters-1.5.0.tar.gz", hash = "sha256:0b679503337d233b4339a817bfc8c50064e2eff681314376a47cb582305a7a38"},
 ]
 paramiko = [
-    {file = "paramiko-2.8.0-py2.py3-none-any.whl", hash = "sha256:def3ec612399bab4e9f5eb66b0ae5983980db9dd9120d9e9c6ea3ff673865d1c"},
-    {file = "paramiko-2.8.0.tar.gz", hash = "sha256:e673b10ee0f1c80d46182d3af7751d033d9b573dd7054d2d0aa46be186c3c1d2"},
+    {file = "paramiko-2.9.2-py2.py3-none-any.whl", hash = "sha256:04097dbd96871691cdb34c13db1883066b8a13a0df2afd4cb0a92221f51c2603"},
+    {file = "paramiko-2.9.2.tar.gz", hash = "sha256:944a9e5dbdd413ab6c7951ea46b0ab40713235a9c4c5ca81cfe45c6f14fa677b"},
 ]
 parso = [
-    {file = "parso-0.8.2-py2.py3-none-any.whl", hash = "sha256:a8c4922db71e4fdb90e0d0bc6e50f9b273d3397925e5e60a717e719201778d22"},
-    {file = "parso-0.8.2.tar.gz", hash = "sha256:12b83492c6239ce32ff5eed6d3639d6a536170723c6f3f1506869f1ace413398"},
+    {file = "parso-0.8.3-py2.py3-none-any.whl", hash = "sha256:c001d4636cd3aecdaf33cbb40aebb59b094be2a74c556778ef5576c175e19e75"},
+    {file = "parso-0.8.3.tar.gz", hash = "sha256:8c07be290bb59f03588915921e29e8a50002acaf2cdc5fa0e0114f91709fafa0"},
 ]
 pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
@@ -5365,7 +5502,7 @@ pathtools = [
     {file = "pathtools-0.1.2.tar.gz", hash = "sha256:7c35c5421a39bb82e58018febd90e3b6e5db34c5443aaaf742b3f33d4655f1c0"},
 ]
 pettingzoo = [
-    {file = "PettingZoo-1.13.1.tar.gz", hash = "sha256:b95d0a9e6e2ca61188ad0b72a2bc4b68a3b21ca0c85d0971e42c9c71c66abd73"},
+    {file = "PettingZoo-1.14.0.tar.gz", hash = "sha256:060cda064d5241513c8cb8a780d92579e5eb97c9d8318c17a5c02b3dff600317"},
 ]
 pexpect = [
     {file = "pexpect-4.8.0-py2.py3-none-any.whl", hash = "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937"},
@@ -5376,51 +5513,42 @@ pickleshare = [
     {file = "pickleshare-0.7.5.tar.gz", hash = "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca"},
 ]
 pillow = [
-    {file = "Pillow-8.4.0-cp310-cp310-macosx_10_10_universal2.whl", hash = "sha256:81f8d5c81e483a9442d72d182e1fb6dcb9723f289a57e8030811bac9ea3fef8d"},
-    {file = "Pillow-8.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3f97cfb1e5a392d75dd8b9fd274d205404729923840ca94ca45a0af57e13dbe6"},
-    {file = "Pillow-8.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb9fc393f3c61f9054e1ed26e6fe912c7321af2f41ff49d3f83d05bacf22cc78"},
-    {file = "Pillow-8.4.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d82cdb63100ef5eedb8391732375e6d05993b765f72cb34311fab92103314649"},
-    {file = "Pillow-8.4.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:62cc1afda735a8d109007164714e73771b499768b9bb5afcbbee9d0ff374b43f"},
-    {file = "Pillow-8.4.0-cp310-cp310-win32.whl", hash = "sha256:e3dacecfbeec9a33e932f00c6cd7996e62f53ad46fbe677577394aaa90ee419a"},
-    {file = "Pillow-8.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:620582db2a85b2df5f8a82ddeb52116560d7e5e6b055095f04ad828d1b0baa39"},
-    {file = "Pillow-8.4.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:1bc723b434fbc4ab50bb68e11e93ce5fb69866ad621e3c2c9bdb0cd70e345f55"},
-    {file = "Pillow-8.4.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:72cbcfd54df6caf85cc35264c77ede902452d6df41166010262374155947460c"},
-    {file = "Pillow-8.4.0-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:70ad9e5c6cb9b8487280a02c0ad8a51581dcbbe8484ce058477692a27c151c0a"},
-    {file = "Pillow-8.4.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:25a49dc2e2f74e65efaa32b153527fc5ac98508d502fa46e74fa4fd678ed6645"},
-    {file = "Pillow-8.4.0-cp36-cp36m-win32.whl", hash = "sha256:93ce9e955cc95959df98505e4608ad98281fff037350d8c2671c9aa86bcf10a9"},
-    {file = "Pillow-8.4.0-cp36-cp36m-win_amd64.whl", hash = "sha256:2e4440b8f00f504ee4b53fe30f4e381aae30b0568193be305256b1462216feff"},
-    {file = "Pillow-8.4.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:8c803ac3c28bbc53763e6825746f05cc407b20e4a69d0122e526a582e3b5e153"},
-    {file = "Pillow-8.4.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8a17b5d948f4ceeceb66384727dde11b240736fddeda54ca740b9b8b1556b29"},
-    {file = "Pillow-8.4.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1394a6ad5abc838c5cd8a92c5a07535648cdf6d09e8e2d6df916dfa9ea86ead8"},
-    {file = "Pillow-8.4.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:792e5c12376594bfcb986ebf3855aa4b7c225754e9a9521298e460e92fb4a488"},
-    {file = "Pillow-8.4.0-cp37-cp37m-win32.whl", hash = "sha256:d99ec152570e4196772e7a8e4ba5320d2d27bf22fdf11743dd882936ed64305b"},
-    {file = "Pillow-8.4.0-cp37-cp37m-win_amd64.whl", hash = "sha256:7b7017b61bbcdd7f6363aeceb881e23c46583739cb69a3ab39cb384f6ec82e5b"},
-    {file = "Pillow-8.4.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:d89363f02658e253dbd171f7c3716a5d340a24ee82d38aab9183f7fdf0cdca49"},
-    {file = "Pillow-8.4.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0a0956fdc5defc34462bb1c765ee88d933239f9a94bc37d132004775241a7585"},
-    {file = "Pillow-8.4.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b7bb9de00197fb4261825c15551adf7605cf14a80badf1761d61e59da347779"},
-    {file = "Pillow-8.4.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:72b9e656e340447f827885b8d7a15fc8c4e68d410dc2297ef6787eec0f0ea409"},
-    {file = "Pillow-8.4.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a5a4532a12314149d8b4e4ad8ff09dde7427731fcfa5917ff16d0291f13609df"},
-    {file = "Pillow-8.4.0-cp38-cp38-win32.whl", hash = "sha256:82aafa8d5eb68c8463b6e9baeb4f19043bb31fefc03eb7b216b51e6a9981ae09"},
-    {file = "Pillow-8.4.0-cp38-cp38-win_amd64.whl", hash = "sha256:066f3999cb3b070a95c3652712cffa1a748cd02d60ad7b4e485c3748a04d9d76"},
-    {file = "Pillow-8.4.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:5503c86916d27c2e101b7f71c2ae2cddba01a2cf55b8395b0255fd33fa4d1f1a"},
-    {file = "Pillow-8.4.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4acc0985ddf39d1bc969a9220b51d94ed51695d455c228d8ac29fcdb25810e6e"},
-    {file = "Pillow-8.4.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b052a619a8bfcf26bd8b3f48f45283f9e977890263e4571f2393ed8898d331b"},
-    {file = "Pillow-8.4.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:493cb4e415f44cd601fcec11c99836f707bb714ab03f5ed46ac25713baf0ff20"},
-    {file = "Pillow-8.4.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8831cb7332eda5dc89b21a7bce7ef6ad305548820595033a4b03cf3091235ed"},
-    {file = "Pillow-8.4.0-cp39-cp39-win32.whl", hash = "sha256:5e9ac5f66616b87d4da618a20ab0a38324dbe88d8a39b55be8964eb520021e02"},
-    {file = "Pillow-8.4.0-cp39-cp39-win_amd64.whl", hash = "sha256:3eb1ce5f65908556c2d8685a8f0a6e989d887ec4057326f6c22b24e8a172c66b"},
-    {file = "Pillow-8.4.0-pp36-pypy36_pp73-macosx_10_10_x86_64.whl", hash = "sha256:ddc4d832a0f0b4c52fff973a0d44b6c99839a9d016fe4e6a1cb8f3eea96479c2"},
-    {file = "Pillow-8.4.0-pp36-pypy36_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9a3e5ddc44c14042f0844b8cf7d2cd455f6cc80fd7f5eefbe657292cf601d9ad"},
-    {file = "Pillow-8.4.0-pp36-pypy36_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c70e94281588ef053ae8998039610dbd71bc509e4acbc77ab59d7d2937b10698"},
-    {file = "Pillow-8.4.0-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:3862b7256046fcd950618ed22d1d60b842e3a40a48236a5498746f21189afbbc"},
-    {file = "Pillow-8.4.0-pp37-pypy37_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a4901622493f88b1a29bd30ec1a2f683782e57c3c16a2dbc7f2595ba01f639df"},
-    {file = "Pillow-8.4.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:84c471a734240653a0ec91dec0996696eea227eafe72a33bd06c92697728046b"},
-    {file = "Pillow-8.4.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:244cf3b97802c34c41905d22810846802a3329ddcb93ccc432870243211c79fc"},
-    {file = "Pillow-8.4.0.tar.gz", hash = "sha256:b8e2f83c56e141920c39464b852de3719dfbfb6e3c99a2d8da0edf4fb33176ed"},
+    {file = "Pillow-9.0.0-cp310-cp310-macosx_10_10_universal2.whl", hash = "sha256:113723312215b25c22df1fdf0e2da7a3b9c357a7d24a93ebbe80bfda4f37a8d4"},
+    {file = "Pillow-9.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:bb47a548cea95b86494a26c89d153fd31122ed65255db5dcbc421a2d28eb3379"},
+    {file = "Pillow-9.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:31b265496e603985fad54d52d11970383e317d11e18e856971bdbb86af7242a4"},
+    {file = "Pillow-9.0.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d154ed971a4cc04b93a6d5b47f37948d1f621f25de3e8fa0c26b2d44f24e3e8f"},
+    {file = "Pillow-9.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80fe92813d208ce8aa7d76da878bdc84b90809f79ccbad2a288e9bcbeac1d9bd"},
+    {file = "Pillow-9.0.0-cp310-cp310-win32.whl", hash = "sha256:d5dcea1387331c905405b09cdbfb34611050cc52c865d71f2362f354faee1e9f"},
+    {file = "Pillow-9.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:52abae4c96b5da630a8b4247de5428f593465291e5b239f3f843a911a3cf0105"},
+    {file = "Pillow-9.0.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:72c3110228944019e5f27232296c5923398496b28be42535e3b2dc7297b6e8b6"},
+    {file = "Pillow-9.0.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:97b6d21771da41497b81652d44191489296555b761684f82b7b544c49989110f"},
+    {file = "Pillow-9.0.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:72f649d93d4cc4d8cf79c91ebc25137c358718ad75f99e99e043325ea7d56100"},
+    {file = "Pillow-9.0.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7aaf07085c756f6cb1c692ee0d5a86c531703b6e8c9cae581b31b562c16b98ce"},
+    {file = "Pillow-9.0.0-cp37-cp37m-win32.whl", hash = "sha256:03b27b197deb4ee400ed57d8d4e572d2d8d80f825b6634daf6e2c18c3c6ccfa6"},
+    {file = "Pillow-9.0.0-cp37-cp37m-win_amd64.whl", hash = "sha256:a09a9d4ec2b7887f7a088bbaacfd5c07160e746e3d47ec5e8050ae3b2a229e9f"},
+    {file = "Pillow-9.0.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:490e52e99224858f154975db61c060686df8a6b3f0212a678e5d2e2ce24675c9"},
+    {file = "Pillow-9.0.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:500d397ddf4bbf2ca42e198399ac13e7841956c72645513e8ddf243b31ad2128"},
+    {file = "Pillow-9.0.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ebd8b9137630a7bbbff8c4b31e774ff05bbb90f7911d93ea2c9371e41039b52"},
+    {file = "Pillow-9.0.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fd0e5062f11cb3e730450a7d9f323f4051b532781026395c4323b8ad055523c4"},
+    {file = "Pillow-9.0.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9f3b4522148586d35e78313db4db0df4b759ddd7649ef70002b6c3767d0fdeb7"},
+    {file = "Pillow-9.0.0-cp38-cp38-win32.whl", hash = "sha256:0b281fcadbb688607ea6ece7649c5d59d4bbd574e90db6cd030e9e85bde9fecc"},
+    {file = "Pillow-9.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:b5050d681bcf5c9f2570b93bee5d3ec8ae4cf23158812f91ed57f7126df91762"},
+    {file = "Pillow-9.0.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:c2067b3bb0781f14059b112c9da5a91c80a600a97915b4f48b37f197895dd925"},
+    {file = "Pillow-9.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:2d16b6196fb7a54aff6b5e3ecd00f7c0bab1b56eee39214b2b223a9d938c50af"},
+    {file = "Pillow-9.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:98cb63ca63cb61f594511c06218ab4394bf80388b3d66cd61d0b1f63ee0ea69f"},
+    {file = "Pillow-9.0.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bc462d24500ba707e9cbdef436c16e5c8cbf29908278af053008d9f689f56dee"},
+    {file = "Pillow-9.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3586e12d874ce2f1bc875a3ffba98732ebb12e18fb6d97be482bd62b56803281"},
+    {file = "Pillow-9.0.0-cp39-cp39-win32.whl", hash = "sha256:68e06f8b2248f6dc8b899c3e7ecf02c9f413aab622f4d6190df53a78b93d97a5"},
+    {file = "Pillow-9.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:6579f9ba84a3d4f1807c4aab4be06f373017fc65fff43498885ac50a9b47a553"},
+    {file = "Pillow-9.0.0-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:47f5cf60bcb9fbc46011f75c9b45a8b5ad077ca352a78185bd3e7f1d294b98bb"},
+    {file = "Pillow-9.0.0-pp37-pypy37_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2fd8053e1f8ff1844419842fd474fc359676b2e2a2b66b11cc59f4fa0a301315"},
+    {file = "Pillow-9.0.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c5439bfb35a89cac50e81c751317faea647b9a3ec11c039900cd6915831064d"},
+    {file = "Pillow-9.0.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:95545137fc56ce8c10de646074d242001a112a92de169986abd8c88c27566a05"},
+    {file = "Pillow-9.0.0.tar.gz", hash = "sha256:ee6e2963e92762923956fe5d3479b1fdc3b76c83f290aad131a2f98c3df0593e"},
 ]
 platformdirs = [
-    {file = "platformdirs-2.4.0-py3-none-any.whl", hash = "sha256:8868bbe3c3c80d42f20156f22e7131d2fb321f5bc86a2a345375c6481a67021d"},
-    {file = "platformdirs-2.4.0.tar.gz", hash = "sha256:367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2"},
+    {file = "platformdirs-2.4.1-py3-none-any.whl", hash = "sha256:1d7385c7db91728b83efd0ca99a5afb296cab9d0ed8313a45ed8ba17967ecfca"},
+    {file = "platformdirs-2.4.1.tar.gz", hash = "sha256:440633ddfebcc36264232365d7840a970e75e1018d15b4327d11f91909045fda"},
 ]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
@@ -5431,78 +5559,82 @@ poyo = [
     {file = "poyo-0.5.0.tar.gz", hash = "sha256:e26956aa780c45f011ca9886f044590e2d8fd8b61db7b1c1cf4e0869f48ed4dd"},
 ]
 procgen = [
-    {file = "procgen-0.10.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b6a4f2e4be87ebdaa8e2963a2789a32ef7a60ac2a436cc97e6e2090e3d07fdd8"},
-    {file = "procgen-0.10.4-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:a90c559251ea3181034e2007f9ca814f4cc97383c0a53708a0acc87f5f661dcb"},
-    {file = "procgen-0.10.4-cp36-cp36m-win_amd64.whl", hash = "sha256:f75eb6636c991b61691cc300abbb13098c1fa5bdf46abfc8f328245db971fe22"},
-    {file = "procgen-0.10.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:01700f7e3284f704072726f6e44c7e56e56bbe7955e73114c5bd093cb47fa580"},
-    {file = "procgen-0.10.4-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:2e852b6fb5f514686d5e2ea05fa989b1107ece8ab6c024f46d7a836a27249d9a"},
-    {file = "procgen-0.10.4-cp37-cp37m-win_amd64.whl", hash = "sha256:47502fa8796af50c3987484dadafb6f102c62c8afcfbb6fba021f9ee7f60c4bb"},
-    {file = "procgen-0.10.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9616bd533630be66150eb2bcbeed43e06f1bc5ebb6c518e9494d43c9290c6f57"},
-    {file = "procgen-0.10.4-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:1a8de0d3c999069a4a6db971c5f93c407831a7e4af4f8432582d0198bf2db729"},
-    {file = "procgen-0.10.4-cp38-cp38-win_amd64.whl", hash = "sha256:c502c6c50e8716b07c35b3e1c8620605adf685e79e6c24d21cd95cd94e8e569b"},
+    {file = "procgen-0.10.7-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:277c0e781dc80ec568f0da428185d0b767ff1b6610304af85c7b7522d0ecfec6"},
+    {file = "procgen-0.10.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b594d14e42f0f2166e59a9e294477b906eb99c90c3343b570b7124cbc865f53"},
+    {file = "procgen-0.10.7-cp310-cp310-win_amd64.whl", hash = "sha256:a102baeb3d4dfffd2909787ef601a75f5f3988cd0f4402143684af88927d044a"},
+    {file = "procgen-0.10.7-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a5ae5421b83b6e0757c6b0ecd5156a04c739878ce42d5bb5eca1318c190aeed4"},
+    {file = "procgen-0.10.7-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6a61be92dcdd3cc4ba1d4f5d2535d13faf0a86433a99f8757c1891f5ac46b8fd"},
+    {file = "procgen-0.10.7-cp37-cp37m-win_amd64.whl", hash = "sha256:c26ae8fd472b4fe95563cd4f04c15963981dba9c8ec70ed424949bf77073b239"},
+    {file = "procgen-0.10.7-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4a42a83922580d26ca1dcc3f814a3e9311d99d0fcc222898accff4a6632023c4"},
+    {file = "procgen-0.10.7-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9add41424c574cfb5c98b87121dfd5d660737d354020aea5bca459fb072cb831"},
+    {file = "procgen-0.10.7-cp38-cp38-win_amd64.whl", hash = "sha256:4ac15ae94ab667196f432b3a639c44bc7d7a43fcf717001f4279f6a9b561e800"},
+    {file = "procgen-0.10.7-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:852d917f4ba9ba6e1c59a5c69747874660177e496e5c02b19ab2dd146101bd16"},
+    {file = "procgen-0.10.7-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2987d6e37cd532fa96f8c9d76104f51f3a3df9310c668a62cd4f9859245a3797"},
+    {file = "procgen-0.10.7-cp39-cp39-win_amd64.whl", hash = "sha256:18590d38a3cbc34470d80000b12814cf9ff267ae59e129054908f4c448207a85"},
 ]
 promise = [
     {file = "promise-2.3.tar.gz", hash = "sha256:dfd18337c523ba4b6a58801c164c1904a9d4d1b1747c7d5dbf45b693a49d93d0"},
 ]
 prompt-toolkit = [
-    {file = "prompt_toolkit-3.0.22-py3-none-any.whl", hash = "sha256:48d85cdca8b6c4f16480c7ce03fd193666b62b0a21667ca56b4bb5ad679d1170"},
-    {file = "prompt_toolkit-3.0.22.tar.gz", hash = "sha256:449f333dd120bd01f5d296a8ce1452114ba3a71fae7288d2f0ae2c918764fa72"},
+    {file = "prompt_toolkit-3.0.26-py3-none-any.whl", hash = "sha256:4bcf119be2200c17ed0d518872ef922f1de336eb6d1ddbd1e089ceb6447d97c6"},
+    {file = "prompt_toolkit-3.0.26.tar.gz", hash = "sha256:a51d41a6a45fd9def54365bca8f0402c8f182f2b6f7e29c74d55faeb9fb38ac4"},
 ]
 protobuf = [
-    {file = "protobuf-3.19.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d80f80eb175bf5f1169139c2e0c5ada98b1c098e2b3c3736667f28cbbea39fc8"},
-    {file = "protobuf-3.19.1-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:a529e7df52204565bcd33738a7a5f288f3d2d37d86caa5d78c458fa5fabbd54d"},
-    {file = "protobuf-3.19.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28ccea56d4dc38d35cd70c43c2da2f40ac0be0a355ef882242e8586c6d66666f"},
-    {file = "protobuf-3.19.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:8b30a7de128c46b5ecb343917d9fa737612a6e8280f440874e5cc2ba0d79b8f6"},
-    {file = "protobuf-3.19.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5935c8ce02e3d89c7900140a8a42b35bc037ec07a6aeb61cc108be8d3c9438a6"},
-    {file = "protobuf-3.19.1-cp36-cp36m-win32.whl", hash = "sha256:74f33edeb4f3b7ed13d567881da8e5a92a72b36495d57d696c2ea1ae0cfee80c"},
-    {file = "protobuf-3.19.1-cp36-cp36m-win_amd64.whl", hash = "sha256:038daf4fa38a7e818dd61f51f22588d61755160a98db087a046f80d66b855942"},
-    {file = "protobuf-3.19.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e51561d72efd5bd5c91490af1f13e32bcba8dab4643761eb7de3ce18e64a853"},
-    {file = "protobuf-3.19.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:6e8ea9173403219239cdfd8d946ed101f2ab6ecc025b0fda0c6c713c35c9981d"},
-    {file = "protobuf-3.19.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db3532d9f7a6ebbe2392041350437953b6d7a792de10e629c1e4f5a6b1fe1ac6"},
-    {file = "protobuf-3.19.1-cp37-cp37m-win32.whl", hash = "sha256:615b426a177780ce381ecd212edc1e0f70db8557ed72560b82096bd36b01bc04"},
-    {file = "protobuf-3.19.1-cp37-cp37m-win_amd64.whl", hash = "sha256:d8919368410110633717c406ab5c97e8df5ce93020cfcf3012834f28b1fab1ea"},
-    {file = "protobuf-3.19.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:71b0250b0cfb738442d60cab68abc166de43411f2a4f791d31378590bfb71bd7"},
-    {file = "protobuf-3.19.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:3cd0458870ea7d1c58e948ac8078f6ba8a7ecc44a57e03032ed066c5bb318089"},
-    {file = "protobuf-3.19.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:655264ed0d0efe47a523e2255fc1106a22f6faab7cc46cfe99b5bae085c2a13e"},
-    {file = "protobuf-3.19.1-cp38-cp38-win32.whl", hash = "sha256:b691d996c6d0984947c4cf8b7ae2fe372d99b32821d0584f0b90277aa36982d3"},
-    {file = "protobuf-3.19.1-cp38-cp38-win_amd64.whl", hash = "sha256:e7e8d2c20921f8da0dea277dfefc6abac05903ceac8e72839b2da519db69206b"},
-    {file = "protobuf-3.19.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fd390367fc211cc0ffcf3a9e149dfeca78fecc62adb911371db0cec5c8b7472d"},
-    {file = "protobuf-3.19.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d83e1ef8cb74009bebee3e61cc84b1c9cd04935b72bca0cbc83217d140424995"},
-    {file = "protobuf-3.19.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:36d90676d6f426718463fe382ec6274909337ca6319d375eebd2044e6c6ac560"},
-    {file = "protobuf-3.19.1-cp39-cp39-win32.whl", hash = "sha256:e7b24c11df36ee8e0c085e5b0dc560289e4b58804746fb487287dda51410f1e2"},
-    {file = "protobuf-3.19.1-cp39-cp39-win_amd64.whl", hash = "sha256:77d2fadcf369b3f22859ab25bd12bb8e98fb11e05d9ff9b7cd45b711c719c002"},
-    {file = "protobuf-3.19.1-py2.py3-none-any.whl", hash = "sha256:e813b1c9006b6399308e917ac5d298f345d95bb31f46f02b60cd92970a9afa17"},
-    {file = "protobuf-3.19.1.tar.gz", hash = "sha256:62a8e4baa9cb9e064eb62d1002eca820857ab2138440cb4b3ea4243830f94ca7"},
+    {file = "protobuf-3.19.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1cb2ed66aac593adbf6dca4f07cd7ee7e2958b17bbc85b2cc8bc564ebeb258ec"},
+    {file = "protobuf-3.19.3-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:898bda9cd37ec0c781b598891e86435de80c3bfa53eb483a9dac5a11ec93e942"},
+    {file = "protobuf-3.19.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8ad761ef3be34c8bdc7285bec4b40372a8dad9e70cfbdc1793cd3cf4c1a4ce74"},
+    {file = "protobuf-3.19.3-cp310-cp310-win32.whl", hash = "sha256:2cddcbcc222f3144765ccccdb35d3621dc1544da57a9aca7e1944c1a4fe3db11"},
+    {file = "protobuf-3.19.3-cp310-cp310-win_amd64.whl", hash = "sha256:6202df8ee8457cb00810c6e76ced480f22a1e4e02c899a14e7b6e6e1de09f938"},
+    {file = "protobuf-3.19.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:397d82f1c58b76445469c8c06b8dee1ff67b3053639d054f52599a458fac9bc6"},
+    {file = "protobuf-3.19.3-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e54b8650e849ee8e95e481024bff92cf98f5ec61c7650cb838d928a140adcb63"},
+    {file = "protobuf-3.19.3-cp36-cp36m-win32.whl", hash = "sha256:3bf3a07d17ba3511fe5fa916afb7351f482ab5dbab5afe71a7a384274a2cd550"},
+    {file = "protobuf-3.19.3-cp36-cp36m-win_amd64.whl", hash = "sha256:afa8122de8064fd577f49ae9eef433561c8ace97a0a7b969d56e8b1d39b5d177"},
+    {file = "protobuf-3.19.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:18c40a1b8721026a85187640f1786d52407dc9c1ba8ec38accb57a46e84015f6"},
+    {file = "protobuf-3.19.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:af7238849fa79285d448a24db686517570099739527a03c9c2971cce99cc5ae2"},
+    {file = "protobuf-3.19.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e765e6dfbbb02c55e4d6d1145743401a84fc0b508f5a81b2c5a738cf86353139"},
+    {file = "protobuf-3.19.3-cp37-cp37m-win32.whl", hash = "sha256:c781402ed5396ab56358d7b866d78c03a77cbc26ba0598d8bb0ac32084b1a257"},
+    {file = "protobuf-3.19.3-cp37-cp37m-win_amd64.whl", hash = "sha256:544fe9705189b249380fae07952d220c97f5c6c9372a6f936cc83a79601dcb70"},
+    {file = "protobuf-3.19.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:84bf3aa3efb00dbe1c7ed55da0f20800b0662541e582d7e62b3e1464d61ed365"},
+    {file = "protobuf-3.19.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:3f80a3491eaca767cdd86cb8660dc778f634b44abdb0dffc9b2a8e8d0cd617d0"},
+    {file = "protobuf-3.19.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9401d96552befcc7311f5ef8f0fa7dba0ef5fd805466b158b141606cd0ab6a8"},
+    {file = "protobuf-3.19.3-cp38-cp38-win32.whl", hash = "sha256:ef02d112c025e83db5d1188a847e358beab3e4bbfbbaf10eaf69e67359af51b2"},
+    {file = "protobuf-3.19.3-cp38-cp38-win_amd64.whl", hash = "sha256:1291a0a7db7d792745c99d4657b4c5c4942695c8b1ac1bfb993a34035ec123f7"},
+    {file = "protobuf-3.19.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:49677e5e9c7ea1245a90c2e8a00d304598f22ea3aa0628f0e0a530a9e70665fa"},
+    {file = "protobuf-3.19.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:df2ba379ee42427e8fcc6a0a76843bff6efb34ef5266b17f95043939b5e25b69"},
+    {file = "protobuf-3.19.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2acd7ca329be544d1a603d5f13a4e34a3791c90d651ebaf130ba2e43ae5397c6"},
+    {file = "protobuf-3.19.3-cp39-cp39-win32.whl", hash = "sha256:b53519b2ebec70cfe24b4ddda21e9843f0918d7c3627a785393fb35d402ab8ad"},
+    {file = "protobuf-3.19.3-cp39-cp39-win_amd64.whl", hash = "sha256:8ceaf5fdb72c8e1fcb7be9f2b3b07482ce058a3548180c0bdd5c7e4ac5e14165"},
+    {file = "protobuf-3.19.3-py2.py3-none-any.whl", hash = "sha256:f6d4b5b7595a57e69eb7314c67bef4a3c745b4caf91accaf72913d8e0635111b"},
+    {file = "protobuf-3.19.3.tar.gz", hash = "sha256:d975a6314fbf5c524d4981e24294739216b5fb81ef3c14b86fb4b045d6690907"},
 ]
 psutil = [
-    {file = "psutil-5.8.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:0066a82f7b1b37d334e68697faba68e5ad5e858279fd6351c8ca6024e8d6ba64"},
-    {file = "psutil-5.8.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:0ae6f386d8d297177fd288be6e8d1afc05966878704dad9847719650e44fc49c"},
-    {file = "psutil-5.8.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:12d844996d6c2b1d3881cfa6fa201fd635971869a9da945cf6756105af73d2df"},
-    {file = "psutil-5.8.0-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:02b8292609b1f7fcb34173b25e48d0da8667bc85f81d7476584d889c6e0f2131"},
-    {file = "psutil-5.8.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:6ffe81843131ee0ffa02c317186ed1e759a145267d54fdef1bc4ea5f5931ab60"},
-    {file = "psutil-5.8.0-cp27-none-win32.whl", hash = "sha256:ea313bb02e5e25224e518e4352af4bf5e062755160f77e4b1767dd5ccb65f876"},
-    {file = "psutil-5.8.0-cp27-none-win_amd64.whl", hash = "sha256:5da29e394bdedd9144c7331192e20c1f79283fb03b06e6abd3a8ae45ffecee65"},
-    {file = "psutil-5.8.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:74fb2557d1430fff18ff0d72613c5ca30c45cdbfcddd6a5773e9fc1fe9364be8"},
-    {file = "psutil-5.8.0-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:74f2d0be88db96ada78756cb3a3e1b107ce8ab79f65aa885f76d7664e56928f6"},
-    {file = "psutil-5.8.0-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:99de3e8739258b3c3e8669cb9757c9a861b2a25ad0955f8e53ac662d66de61ac"},
-    {file = "psutil-5.8.0-cp36-cp36m-win32.whl", hash = "sha256:36b3b6c9e2a34b7d7fbae330a85bf72c30b1c827a4366a07443fc4b6270449e2"},
-    {file = "psutil-5.8.0-cp36-cp36m-win_amd64.whl", hash = "sha256:52de075468cd394ac98c66f9ca33b2f54ae1d9bff1ef6b67a212ee8f639ec06d"},
-    {file = "psutil-5.8.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c6a5fd10ce6b6344e616cf01cc5b849fa8103fbb5ba507b6b2dee4c11e84c935"},
-    {file = "psutil-5.8.0-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:61f05864b42fedc0771d6d8e49c35f07efd209ade09a5afe6a5059e7bb7bf83d"},
-    {file = "psutil-5.8.0-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:0dd4465a039d343925cdc29023bb6960ccf4e74a65ad53e768403746a9207023"},
-    {file = "psutil-5.8.0-cp37-cp37m-win32.whl", hash = "sha256:1bff0d07e76114ec24ee32e7f7f8d0c4b0514b3fae93e3d2aaafd65d22502394"},
-    {file = "psutil-5.8.0-cp37-cp37m-win_amd64.whl", hash = "sha256:fcc01e900c1d7bee2a37e5d6e4f9194760a93597c97fee89c4ae51701de03563"},
-    {file = "psutil-5.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6223d07a1ae93f86451d0198a0c361032c4c93ebd4bf6d25e2fb3edfad9571ef"},
-    {file = "psutil-5.8.0-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:d225cd8319aa1d3c85bf195c4e07d17d3cd68636b8fc97e6cf198f782f99af28"},
-    {file = "psutil-5.8.0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:28ff7c95293ae74bf1ca1a79e8805fcde005c18a122ca983abf676ea3466362b"},
-    {file = "psutil-5.8.0-cp38-cp38-win32.whl", hash = "sha256:ce8b867423291cb65cfc6d9c4955ee9bfc1e21fe03bb50e177f2b957f1c2469d"},
-    {file = "psutil-5.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:90f31c34d25b1b3ed6c40cdd34ff122b1887a825297c017e4cbd6796dd8b672d"},
-    {file = "psutil-5.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6323d5d845c2785efb20aded4726636546b26d3b577aded22492908f7c1bdda7"},
-    {file = "psutil-5.8.0-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:245b5509968ac0bd179287d91210cd3f37add77dad385ef238b275bad35fa1c4"},
-    {file = "psutil-5.8.0-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:90d4091c2d30ddd0a03e0b97e6a33a48628469b99585e2ad6bf21f17423b112b"},
-    {file = "psutil-5.8.0-cp39-cp39-win32.whl", hash = "sha256:ea372bcc129394485824ae3e3ddabe67dc0b118d262c568b4d2602a7070afdb0"},
-    {file = "psutil-5.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:f4634b033faf0d968bb9220dd1c793b897ab7f1189956e1aa9eae752527127d3"},
-    {file = "psutil-5.8.0.tar.gz", hash = "sha256:0c9ccb99ab76025f2f0bbecf341d4656e9c1351db8cc8a03ccd62e318ab4b5c6"},
+    {file = "psutil-5.9.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:55ce319452e3d139e25d6c3f85a1acf12d1607ddedea5e35fb47a552c051161b"},
+    {file = "psutil-5.9.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:7336292a13a80eb93c21f36bde4328aa748a04b68c13d01dfddd67fc13fd0618"},
+    {file = "psutil-5.9.0-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:cb8d10461c1ceee0c25a64f2dd54872b70b89c26419e147a05a10b753ad36ec2"},
+    {file = "psutil-5.9.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:7641300de73e4909e5d148e90cc3142fb890079e1525a840cf0dfd39195239fd"},
+    {file = "psutil-5.9.0-cp27-none-win32.whl", hash = "sha256:ea42d747c5f71b5ccaa6897b216a7dadb9f52c72a0fe2b872ef7d3e1eacf3ba3"},
+    {file = "psutil-5.9.0-cp27-none-win_amd64.whl", hash = "sha256:ef216cc9feb60634bda2f341a9559ac594e2eeaadd0ba187a4c2eb5b5d40b91c"},
+    {file = "psutil-5.9.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:90a58b9fcae2dbfe4ba852b57bd4a1dded6b990a33d6428c7614b7d48eccb492"},
+    {file = "psutil-5.9.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ff0d41f8b3e9ebb6b6110057e40019a432e96aae2008951121ba4e56040b84f3"},
+    {file = "psutil-5.9.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:742c34fff804f34f62659279ed5c5b723bb0195e9d7bd9907591de9f8f6558e2"},
+    {file = "psutil-5.9.0-cp310-cp310-win32.whl", hash = "sha256:8293942e4ce0c5689821f65ce6522ce4786d02af57f13c0195b40e1edb1db61d"},
+    {file = "psutil-5.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:9b51917c1af3fa35a3f2dabd7ba96a2a4f19df3dec911da73875e1edaf22a40b"},
+    {file = "psutil-5.9.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3d00a664e31921009a84367266b35ba0aac04a2a6cad09c550a89041034d19a0"},
+    {file = "psutil-5.9.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7779be4025c540d1d65a2de3f30caeacc49ae7a2152108adeaf42c7534a115ce"},
+    {file = "psutil-5.9.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:072664401ae6e7c1bfb878c65d7282d4b4391f1bc9a56d5e03b5a490403271b5"},
+    {file = "psutil-5.9.0-cp37-cp37m-win32.whl", hash = "sha256:df2c8bd48fb83a8408c8390b143c6a6fa10cb1a674ca664954de193fdcab36a9"},
+    {file = "psutil-5.9.0-cp37-cp37m-win_amd64.whl", hash = "sha256:1d7b433519b9a38192dfda962dd8f44446668c009833e1429a52424624f408b4"},
+    {file = "psutil-5.9.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c3400cae15bdb449d518545cbd5b649117de54e3596ded84aacabfbb3297ead2"},
+    {file = "psutil-5.9.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b2237f35c4bbae932ee98902a08050a27821f8f6dfa880a47195e5993af4702d"},
+    {file = "psutil-5.9.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1070a9b287846a21a5d572d6dddd369517510b68710fca56b0e9e02fd24bed9a"},
+    {file = "psutil-5.9.0-cp38-cp38-win32.whl", hash = "sha256:76cebf84aac1d6da5b63df11fe0d377b46b7b500d892284068bacccf12f20666"},
+    {file = "psutil-5.9.0-cp38-cp38-win_amd64.whl", hash = "sha256:3151a58f0fbd8942ba94f7c31c7e6b310d2989f4da74fcbf28b934374e9bf841"},
+    {file = "psutil-5.9.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:539e429da49c5d27d5a58e3563886057f8fc3868a5547b4f1876d9c0f007bccf"},
+    {file = "psutil-5.9.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:58c7d923dc209225600aec73aa2c4ae8ea33b1ab31bc11ef8a5933b027476f07"},
+    {file = "psutil-5.9.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3611e87eea393f779a35b192b46a164b1d01167c9d323dda9b1e527ea69d697d"},
+    {file = "psutil-5.9.0-cp39-cp39-win32.whl", hash = "sha256:4e2fb92e3aeae3ec3b7b66c528981fd327fb93fd906a77215200404444ec1845"},
+    {file = "psutil-5.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:7d190ee2eaef7831163f254dc58f6d2e2a22e27382b936aab51c835fc080c3d3"},
+    {file = "psutil-5.9.0.tar.gz", hash = "sha256:869842dbd66bb80c3217158e629d6fceaecc3a3166d3d1faee515b05dd26ca25"},
 ]
 ptyprocess = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
@@ -5543,14 +5675,13 @@ pyasn1-modules = [
     {file = "pyasn1_modules-0.2.8-py3.7.egg", hash = "sha256:c29a5e5cc7a3f05926aff34e097e84f8589cd790ce0ed41b67aed6857b26aafd"},
 ]
 pybullet = [
-    {file = "pybullet-3.2.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:f45d0b0ef1e24eb911ec7de834f6e8dbd00472a27c20352c957fdd03d890045e"},
-    {file = "pybullet-3.2.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:1f2c6f6ca973ae07ff5114d7d89b71c18800b1c5cb9f66af86963494b0b6930e"},
-    {file = "pybullet-3.2.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:62d8fd9d695230e36d15895325b3a41c2131445c32bc716c614752364f554aac"},
-    {file = "pybullet-3.2.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:335b8dbdc8e81bda701d027189128d2feb0f560e65e7041f22116763a5b945e4"},
-    {file = "pybullet-3.2.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:0f301d5f15077d3e843bf6fbb2f456efe48546a6998dca12834b56effd4a8e82"},
-    {file = "pybullet-3.2.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2bb9e1177776e5825818837146c89e5ade1536e82465a868261d898486c93323"},
-    {file = "pybullet-3.2.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:2945e370e29328bcde6cb77b351920bb7942e8613dfbe65370d6ab0c2dfc82b3"},
-    {file = "pybullet-3.2.0.tar.gz", hash = "sha256:df02fb0ab74a6e7c4e1d7a3e2ffd7e4760a30cdeccb9fa6dd19f334122ec00f2"},
+    {file = "pybullet-3.2.1-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a7558b63c754ee13e5937d348a6a1e496bc317983b0229a0351f896bd5678ed7"},
+    {file = "pybullet-3.2.1-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:ed73517895eee6b238e5bc140040edab9fd6883b49fce2fed03f8fe87877e36d"},
+    {file = "pybullet-3.2.1-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:86ea0d85d538ffdbdc4684708fc81bff3371b14b5ad2207e67d653b5083879d2"},
+    {file = "pybullet-3.2.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:10f0b947eeea4d42f324a727be701bef1cfebf3cb532332a9c7549cf34b76475"},
+    {file = "pybullet-3.2.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:8c3cfff5f2c3797891ccfdfe5893945be9545c44596034f7240a2c766b1f4d73"},
+    {file = "pybullet-3.2.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:ef8101bcac2f618b4b9fdd926394d5611b0c7c8df8217f98b728da254b597cb6"},
+    {file = "pybullet-3.2.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6196110885debf7528f03ab9aecd5f61d5de4654a39c8cbea3ce496220ea6e4f"},
 ]
 pycodestyle = [
     {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
@@ -5569,72 +5700,72 @@ pyflakes = [
     {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
 ]
 pygame = [
-    {file = "pygame-2.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c84a93e6d33dafce9e25080ac557342333e15ef7e378ba84cb6181c52a8fd663"},
-    {file = "pygame-2.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a0842458b49257ab539b7b6622a242cabcddcb61178b8ae074aaceb890be75b6"},
-    {file = "pygame-2.1.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6efa3fa472acb97c784224b59a89e80da6231f0dbf54df8442ffa3352c0534d6"},
-    {file = "pygame-2.1.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:02a26b3be6cc478f18f4efa506ee5a585f68350857ac5e68e187301e943e3d6d"},
-    {file = "pygame-2.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5c62fbdb30082f7e1dcfa253da48e7b4be7342d275b34b2efa51f6cffc5942b"},
-    {file = "pygame-2.1.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7a305dcf44f03a8dd7baefb97dc24949d7e719fd686cd3211121639aec4ce464"},
-    {file = "pygame-2.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:847b4bc22edb1d77c992b5d56b19e1ab52e14687adb8bc3ed12a8a98fbd7e1ff"},
-    {file = "pygame-2.1.0-cp310-cp310-win32.whl", hash = "sha256:e9368c105a8bccc8adfe7fd7fa5220d2b6c03979a3a57a8178c42f6fa9914ebc"},
-    {file = "pygame-2.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:9a81d057a7dea95850e44118f141a892fde93c938ccb08fbc5dd7f1a26c2f1fe"},
-    {file = "pygame-2.1.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:ada3d33e7e6907d5c3bf771dc58c47ee6994a1e28fed55e4f8f8b817367beb8f"},
-    {file = "pygame-2.1.0-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5a3edc8211d0cf39d1e4d7ded1a0727c53aeb21205963f184199521708bbb05c"},
-    {file = "pygame-2.1.0-cp36-cp36m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:53c6fa767e3eef52d403eda5d032e48b6040ccce03fbd64af2f71843168118da"},
-    {file = "pygame-2.1.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c28c6f764aa03a0245db12346f1da327c6f49bcc20e53aefec6eed57e4fbe1ce"},
-    {file = "pygame-2.1.0-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5d36d530a8994c5bb8889816981f82b7942d8ec7651ca1d922d01302c1feecd2"},
-    {file = "pygame-2.1.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fdd488daa4ad33748d5ea806e311bfe01b9cc506def5288400072fcd66d226cf"},
-    {file = "pygame-2.1.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9284e76923777c21b8bea19d8528be9cd62d0915139ed3c3cde6c43f849466f5"},
-    {file = "pygame-2.1.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:49e5fb589a86169aa95b83d3429ee034799792374e13dbc0da83091d86365a4b"},
-    {file = "pygame-2.1.0-cp36-cp36m-win32.whl", hash = "sha256:c6ee571995527e779b46cafee7ebef2dceb1a9c375143828e019293ff0efa167"},
-    {file = "pygame-2.1.0-cp36-cp36m-win_amd64.whl", hash = "sha256:b400edd7391972e75b4243113089d6ea10b032e1306e8721efabb36d33c2d0f2"},
-    {file = "pygame-2.1.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0d2f80b501aacd74a660d4422793ea1cd4e209bee385aac18d0a07bd671511ee"},
-    {file = "pygame-2.1.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:32cb64627c2eb5c4c067ffe614e08ccb8987d096100d225e070dddce05725b63"},
-    {file = "pygame-2.1.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:38b5a43ab02c162501e62b857ff2cb128076b0786dd4e1d8bea63db8326f9da1"},
-    {file = "pygame-2.1.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba5bf655c892bbf4a9bafb4fcbc4c71023cc9a65f0cae0f3eba09a11018a858e"},
-    {file = "pygame-2.1.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:add546fcbf8954f00647f5e7d595ab9389f6a7542a99fc5dca514e14fd799773"},
-    {file = "pygame-2.1.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:987c0d5fcd7737c31b35df06f78932c48eeff2c97473001e224fdebd3292b2db"},
-    {file = "pygame-2.1.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:594234050b50b57c538842155dc3095c9d4f994266325adb4dd008aee526157f"},
-    {file = "pygame-2.1.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:59a5461ef317e4d233d1bb5ce63311ccad3e911a652bda159d3922351050158c"},
-    {file = "pygame-2.1.0-cp37-cp37m-win32.whl", hash = "sha256:9b2ad10ffaa226ca40ae229143b0a118426aff42e2459b626d355846c59a765d"},
-    {file = "pygame-2.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:4f73058569573af12c8181e032745f11d85f0799510965d938b1f16c7f13afcb"},
-    {file = "pygame-2.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:85844714f82a5379100825473b1a7b24192b4a944aed3128da9386e26adc3bed"},
-    {file = "pygame-2.1.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b0e96c0f68f6bb88da216765920c6dbc55ae83e70435d8ebac87d271fc058646"},
-    {file = "pygame-2.1.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:3d5a76fa826202182d989e8399fca0c3c163fbb4f8ece773e77955a7a62cbed3"},
-    {file = "pygame-2.1.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2bfefabe78bda7a1bfba253cbe2131038402ce2b32e4218feeba6431fe429abb"},
-    {file = "pygame-2.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3804476fab6ec7230aa817ee5c3b378ba956321fdd5f91f51c97452c588869d2"},
-    {file = "pygame-2.1.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:70a11eec9bae6e8970c5bc4b3d0908eb2c42d4bd4ed488e41e49774b7cb41f57"},
-    {file = "pygame-2.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4eff1db92d53dc2e49ed832dd6c76530e1e2b5954eef091f6af41b41d2d5c3ac"},
-    {file = "pygame-2.1.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c1eb91198fc47c2e4fdc19c544b5d94534a70fd877f5c342228feb05e9fc4bef"},
-    {file = "pygame-2.1.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:15d4e42214f93d8c60120e16b690ad03da7f0b3b66f75db8966bccf8c66c4690"},
-    {file = "pygame-2.1.0-cp38-cp38-win32.whl", hash = "sha256:e533f4bf9dc1a91cfd608b9bfb028c6a92383e731c502660933f0f9b812045a6"},
-    {file = "pygame-2.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:692fe4498c353d663d45d05354fb47c9f6bf324d10b53844b9ed7f60e6c8cefa"},
-    {file = "pygame-2.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:472b81ba6b61ffe5879ac3d0da2e5cb235e0e4da471ad4038f013a7710ab53ab"},
-    {file = "pygame-2.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:bb55368d455ab9518b97febd33a8d417988397b019c9408993be034e0b5a7db6"},
-    {file = "pygame-2.1.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f8379052cfbc278b11e31bc97f2e7f5998959c50837c4d54f4e424a541e0c5d9"},
-    {file = "pygame-2.1.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b545634f96132af1d31dcb873cf03a9c4a5654ae39d9ee126db0b2eba2806788"},
-    {file = "pygame-2.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5eb3dede55d005adea8504f8c9230b9dc2c84c1c728efe93a9718fa1af824dc8"},
-    {file = "pygame-2.1.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f628f9f26c8dadf72fabc9ae0ce5fe7f60d76be71a3407abc756b4d1fd030fa0"},
-    {file = "pygame-2.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d4061ac4e81bb36ec8f0a7027582c1c4dd32a939882e008165627103cb0b3985"},
-    {file = "pygame-2.1.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fad7b5351931cb68d19d7ecc0b21021fe23237d8fba8c455b5af4a79e1c7c536"},
-    {file = "pygame-2.1.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a0ab3e4763e0cebf08c55154f4167cdae3683674604a71e1437123225f2a9b36"},
-    {file = "pygame-2.1.0-cp39-cp39-win32.whl", hash = "sha256:64ec45215c2cfc4051bb0f58d26aee3b50a39b1b0a2e6fe8417bb352a6443aad"},
-    {file = "pygame-2.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:86c66b917afc6330a91ac8c7169c36c77ec536578d1d7724644d41f904e2d146"},
-    {file = "pygame-2.1.0-pp36-pypy36_pp73-win32.whl", hash = "sha256:b0e405fdde643f14d60c2dd140f110a5a38f588396a8b61a1a86374f25cba589"},
-    {file = "pygame-2.1.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:646e871ff5ab7f933cde5ea2bff7b6cd74d7369f43e84a291baebe00bb9a8f6f"},
-    {file = "pygame-2.1.0-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:88a2dabe617e6173003b65762c636947719da3e2d881a4ea47298e8d70886386"},
-    {file = "pygame-2.1.0-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7281366b4ebd7f16eac8ec6a6e2adb4c729beda178ea82637d9981e93dd40c9b"},
-    {file = "pygame-2.1.0-pp37-pypy37_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0227728f2ef751fac43b89f4bcc5c65ce39c855b2a3391ddf2e6024dd667e6bd"},
-    {file = "pygame-2.1.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4ab5aba8677d135b94c4714e8256efdfffefc164f354a4d05b846588caf43b99"},
-    {file = "pygame-2.1.0.tar.gz", hash = "sha256:232e51104db0e573221660d172af8e6fc2c0fda183c5dbf2aa52170f29aa9ec9"},
+    {file = "pygame-2.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f149e182d0eeef15d8a9b4c9dad1b87dc6eba3a99bd3c44a777a3a2b053a3dca"},
+    {file = "pygame-2.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dc4444d61d48c5546df5137cdf81554887ddb6e2ef1be7f51eb77ea3b6bdd56f"},
+    {file = "pygame-2.1.2-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a0ccf8e3dce7ca67d523a6020b7e3dbf4b26797a9a8db5cc4c7b5ef20fb64701"},
+    {file = "pygame-2.1.2-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7889dce887ec83c9a0bef8d9eb3669d8863fdaf37c45bacec707d8ad90b24a38"},
+    {file = "pygame-2.1.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:db2f40d5a75fd9cdda473c58b0d8b294da6e0179f00bb3b1fc2f7f29cac09bea"},
+    {file = "pygame-2.1.2-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e4b4cd440d50a9f8551b8989e856aab175593af07eb825cad22fd2f8f6f2ffce"},
+    {file = "pygame-2.1.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:754c2906f2ef47173a14493e1de116b2a56a2c8e1764f1202ba844d080248a5b"},
+    {file = "pygame-2.1.2-cp310-cp310-win32.whl", hash = "sha256:c99b95e62cdda29c2e60235d7763447c168a6a877403e6f9ca5b2e2bb297c2ce"},
+    {file = "pygame-2.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:9649419254d3282dae41f23837de4108b17bc62187c3acd8af2ae3801b765cbd"},
+    {file = "pygame-2.1.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:dcc285ee1f1d0e2672cc52f880fd3f564b1505de710e817f692fbf64a72ca657"},
+    {file = "pygame-2.1.2-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:e1bb25986db77a48f632469c6bc61baf7508ce945aa6161c02180d4ee5ac5b8d"},
+    {file = "pygame-2.1.2-cp36-cp36m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e7a8e18677e0064b7a422f6653a622652d932826a27e50f279d55a8b122a1a83"},
+    {file = "pygame-2.1.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd528dbb91eca16f7522c975d0f9e94b95f6b5024c82c3247dc0383d242d33c6"},
+    {file = "pygame-2.1.2-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fcc9586e17875c0cdf8764597955f9daa979098fd4f80be07ed68276ac225480"},
+    {file = "pygame-2.1.2-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9ce7f3d8af14d7e04eb7eb41c5e5313c43508c252bb2b9eb53e51fc87ada9fd"},
+    {file = "pygame-2.1.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e09044e9e1aa8512d6a9c7ce5f94b881824bcfc401105f3c24f546dfc3bb4aa5"},
+    {file = "pygame-2.1.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:40e4d8d65985bb467d9c5a1305fb53fd6820c61d764979600becab973339676f"},
+    {file = "pygame-2.1.2-cp36-cp36m-win32.whl", hash = "sha256:50d9a21edd551669862c27c9272747401b20b1939abaacb842c08ea1cdd1c04d"},
+    {file = "pygame-2.1.2-cp36-cp36m-win_amd64.whl", hash = "sha256:e18c9466131378421d00fc40b637425229238d506a073d9c537b230b355a25d6"},
+    {file = "pygame-2.1.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:07ca9f683075aea9bd977af9f09a720ebf747343d3ea8103e4f1735283b02330"},
+    {file = "pygame-2.1.2-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:3c8d6637ff75351e581327efefa9d04eeb0f257b533392b6cc6b15ceca4f7c5e"},
+    {file = "pygame-2.1.2-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5ebbefb8b576572c8fc97a3321d37dc2b4afea6b6e3877a67f7158d8c2c4cefe"},
+    {file = "pygame-2.1.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9d6452419e01a0f848aed0597f69fd10a4c2a7750c15d1b0607f86090a39dcf3"},
+    {file = "pygame-2.1.2-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e627300a66a90651fb39e41601d447b1fdbbfffca3f08ef0278d6cc0436b2160"},
+    {file = "pygame-2.1.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a56a811d8821f7b9a594e3d0e0dd8bd39b25e3eea8963d5963263b90fd2ea5c2"},
+    {file = "pygame-2.1.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:24b4f7f30fa2b3d092b60be6fcc725fb91d569fc87a9bcc91614ee8b0c005726"},
+    {file = "pygame-2.1.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:8e87716114e97322fb177e223d889a4be369a0f73212f4f8507fe0cd43253b23"},
+    {file = "pygame-2.1.2-cp37-cp37m-win32.whl", hash = "sha256:20676da24e3e3e6b9fc4eecc7ba09d77ef46c3a83a028763ba1d222476c2e3fb"},
+    {file = "pygame-2.1.2-cp37-cp37m-win_amd64.whl", hash = "sha256:93c4cbfc942dd00410eaa9e84252129f9f9993f37f683006d7b49ab245342254"},
+    {file = "pygame-2.1.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2405414d8c572668e04739875661e030a0c588e197fa95463fe301c3d0a0510b"},
+    {file = "pygame-2.1.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e8632f6b2ddb90f6f3950744bd65d5ef15af615e3034057fa30ff836f48a7179"},
+    {file = "pygame-2.1.2-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ca5ef1315fa67c241a657ab077be44f230c05740c95f0b46409457dceefdc7e5"},
+    {file = "pygame-2.1.2-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1219a963941bd53aa754e8449364c142004fe706c33a9c22ff2a76521a82d078"},
+    {file = "pygame-2.1.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3bb0674aa789848ddc264bfc60c54965bf3bb659c141de4f600e379acc9b944c"},
+    {file = "pygame-2.1.2-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:24254c4244f0d9bdc904f5d3f38e86757ca4c6aa0e44a6d55ef5e016bc7274d6"},
+    {file = "pygame-2.1.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:97a74ba186deee68318a52637012ef6abf5be6282c659e1d1ba6ad08cf35ec85"},
+    {file = "pygame-2.1.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0e97d38308c441942577fea7fcd1326308bc56d6be6c024218e94d075d322e0f"},
+    {file = "pygame-2.1.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:ea36f4f93524554a35cac2359df63b50af6556ed866830aa1f07f0d8580280ea"},
+    {file = "pygame-2.1.2-cp38-cp38-win32.whl", hash = "sha256:4aa3ae32320cc704d63e185864e44f6265c2a6e52c9384afe152cc3d51b3a2ef"},
+    {file = "pygame-2.1.2-cp38-cp38-win_amd64.whl", hash = "sha256:9d7b021b8dde5d528363e474bc18bd6f79a9666eef89fb4859bcb8f0a536c9de"},
+    {file = "pygame-2.1.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:660c80c0b2e80f1f801715583b759fb4c7bc0c11eb3b534e89c9fc4bfbc38acd"},
+    {file = "pygame-2.1.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:dad6bf3fdd3752d7519422f3732be779b98fe7c87d32c3efe2fdffdcbeebb6ca"},
+    {file = "pygame-2.1.2-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:119dee20c372c85dc47b717119534d15a60c64ceab8b0eb09278866d10486afe"},
+    {file = "pygame-2.1.2-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:fc2e5db54491e8f27785fc5204c96f540d3557dcf5b0a9a857b6594d6b32561b"},
+    {file = "pygame-2.1.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d2d3c50ee9847b743db6cd7b1bb17a94c2c2abc16679d70f5e745cabdf19e655"},
+    {file = "pygame-2.1.2-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ecda8dd4583982bb65f9c682f244a5e94524dcf628379766227e9ed97201a49"},
+    {file = "pygame-2.1.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e06ae8e1c830f1b9c36a2bc6bb11de840232e95b78e2c349c6ed803a303be19"},
+    {file = "pygame-2.1.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c5ea87da5fe4b6164c3854f3b0c9146811dbad0dd7fa74297683dfacc485ae1c"},
+    {file = "pygame-2.1.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:0427c103f741234336e5606d2fad86f5403c1a3d1dc55c309fbff3c984f0c9ae"},
+    {file = "pygame-2.1.2-cp39-cp39-win32.whl", hash = "sha256:5e88b0d4338b94960686f59396f23f7f684fed4859fcc3b9f40286d72c1c61af"},
+    {file = "pygame-2.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:5d0c14152d0ca8ef5fbcc5ed9981462bdf59a9ae85a291e62d8a8d0b7e5cbe43"},
+    {file = "pygame-2.1.2-pp36-pypy36_pp73-win32.whl", hash = "sha256:636f51f56615d67459b11918206bb4da30cd7d7042027bf997c218ccd6c77902"},
+    {file = "pygame-2.1.2-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:ff961c3280d6ee5f4163f4772f963d7a4dbe42e36c6dd54b79ad436c1f046e5d"},
+    {file = "pygame-2.1.2-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:fc30e834f65b893d1b4c230070183bf98e6b70c41c1511687e8436a33d5ce49d"},
+    {file = "pygame-2.1.2-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5c7600bf307de1ca1dca0cc7840e34604d5b0b0a5a5dad345c3fa62b054b886d"},
+    {file = "pygame-2.1.2-pp37-pypy37_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7fdb93b4282962c9a2ebf1af994ee698be823dd913218ed97a5f2fb372b10b66"},
+    {file = "pygame-2.1.2-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1fddec8829e96424800c806582d73a5173b7d48946cccf7d035839ca09850db8"},
+    {file = "pygame-2.1.2.tar.gz", hash = "sha256:d6d0eca28f886f0477cd0721ac688189155a587f2bb8eae740e52ca56c3ad23c"},
 ]
 pyglet = [
     {file = "pyglet-1.5.21-py3-none-any.whl", hash = "sha256:11f11ddda4ee456284f2ddd1fe5c62fe29ba8c42074d3d9ae52d094abc2e1b7c"},
     {file = "pyglet-1.5.21.zip", hash = "sha256:5aaaddb06dc4b6f9ba08254d8d806a2bd2406925a9caf3a51fdffbd5d09728e2"},
 ]
 pygments = [
-    {file = "Pygments-2.10.0-py3-none-any.whl", hash = "sha256:b8e67fe6af78f492b3c4b3e2970c0624cbf08beb1e493b2c99b9fa1b67a20380"},
-    {file = "Pygments-2.10.0.tar.gz", hash = "sha256:f398865f7eb6874156579fdf36bc840a03cab64d1cde9e93d68f46a425ec52c6"},
+    {file = "Pygments-2.11.2-py3-none-any.whl", hash = "sha256:44238f1b60a76d78fc8ca0528ee429702aae011c265fe6a8dd8b63049ae41c65"},
+    {file = "Pygments-2.11.2.tar.gz", hash = "sha256:4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a"},
 ]
 pylint = [
     {file = "pylint-2.9.6-py3-none-any.whl", hash = "sha256:2e1a0eb2e8ab41d6b5dbada87f066492bb1557b12b76c47c2ee8aa8a11186594"},
@@ -5645,8 +5776,8 @@ pyls-spyder = [
     {file = "pyls_spyder-0.4.0-py3-none-any.whl", hash = "sha256:1505d975f866a343d0554b6dab41b53717f4b4bc6df450dfd7d48f889fe450b9"},
 ]
 pymdown-extensions = [
-    {file = "pymdown-extensions-9.0.tar.gz", hash = "sha256:01e4bec7f4b16beaba0087a74496401cf11afd69e3a11fe95cb593e5c698ef40"},
-    {file = "pymdown_extensions-9.0-py3-none-any.whl", hash = "sha256:430cc2fbb30cef2df70edac0b4f62614a6a4d2b06462e32da4ca96098b7c1dfb"},
+    {file = "pymdown-extensions-9.1.tar.gz", hash = "sha256:74247f2c80f1d9e3c7242abe1c16317da36c6f26c7ad4b8a7f457f0ec20f0365"},
+    {file = "pymdown_extensions-9.1-py3-none-any.whl", hash = "sha256:b03e66f91f33af4a6e7a0e20c740313522995f69a03d86316b1449766c473d0e"},
 ]
 pymunk = [
     {file = "pymunk-6.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:21c683995c7c9763070ef501cb90817e0158f1aacc95fe316338e02754f3a4bf"},
@@ -5694,668 +5825,776 @@ pymunk = [
     {file = "pymunk-6.2.1.zip", hash = "sha256:18ae0f83ec2dc20892b98c84127ce9149ab40fa3c3120097377e1506884b27b8"},
 ]
 pynacl = [
-    {file = "PyNaCl-1.4.0-cp27-cp27m-macosx_10_10_x86_64.whl", hash = "sha256:ea6841bc3a76fa4942ce00f3bda7d436fda21e2d91602b9e21b7ca9ecab8f3ff"},
-    {file = "PyNaCl-1.4.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:d452a6746f0a7e11121e64625109bc4468fc3100452817001dbe018bb8b08514"},
-    {file = "PyNaCl-1.4.0-cp27-cp27m-win32.whl", hash = "sha256:2fe0fc5a2480361dcaf4e6e7cea00e078fcda07ba45f811b167e3f99e8cff574"},
-    {file = "PyNaCl-1.4.0-cp27-cp27m-win_amd64.whl", hash = "sha256:f8851ab9041756003119368c1e6cd0b9c631f46d686b3904b18c0139f4419f80"},
-    {file = "PyNaCl-1.4.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:7757ae33dae81c300487591c68790dfb5145c7d03324000433d9a2c141f82af7"},
-    {file = "PyNaCl-1.4.0-cp35-abi3-macosx_10_10_x86_64.whl", hash = "sha256:757250ddb3bff1eecd7e41e65f7f833a8405fede0194319f87899690624f2122"},
-    {file = "PyNaCl-1.4.0-cp35-abi3-manylinux1_x86_64.whl", hash = "sha256:30f9b96db44e09b3304f9ea95079b1b7316b2b4f3744fe3aaecccd95d547063d"},
-    {file = "PyNaCl-1.4.0-cp35-abi3-win32.whl", hash = "sha256:4e10569f8cbed81cb7526ae137049759d2a8d57726d52c1a000a3ce366779634"},
-    {file = "PyNaCl-1.4.0-cp35-abi3-win_amd64.whl", hash = "sha256:c914f78da4953b33d4685e3cdc7ce63401247a21425c16a39760e282075ac4a6"},
-    {file = "PyNaCl-1.4.0-cp35-cp35m-win32.whl", hash = "sha256:06cbb4d9b2c4bd3c8dc0d267416aaed79906e7b33f114ddbf0911969794b1cc4"},
-    {file = "PyNaCl-1.4.0-cp35-cp35m-win_amd64.whl", hash = "sha256:511d269ee845037b95c9781aa702f90ccc36036f95d0f31373a6a79bd8242e25"},
-    {file = "PyNaCl-1.4.0-cp36-cp36m-win32.whl", hash = "sha256:11335f09060af52c97137d4ac54285bcb7df0cef29014a1a4efe64ac065434c4"},
-    {file = "PyNaCl-1.4.0-cp36-cp36m-win_amd64.whl", hash = "sha256:cd401ccbc2a249a47a3a1724c2918fcd04be1f7b54eb2a5a71ff915db0ac51c6"},
-    {file = "PyNaCl-1.4.0-cp37-cp37m-win32.whl", hash = "sha256:8122ba5f2a2169ca5da936b2e5a511740ffb73979381b4229d9188f6dcb22f1f"},
-    {file = "PyNaCl-1.4.0-cp37-cp37m-win_amd64.whl", hash = "sha256:537a7ccbea22905a0ab36ea58577b39d1fa9b1884869d173b5cf111f006f689f"},
-    {file = "PyNaCl-1.4.0-cp38-cp38-win32.whl", hash = "sha256:9c4a7ea4fb81536c1b1f5cc44d54a296f96ae78c1ebd2311bd0b60be45a48d96"},
-    {file = "PyNaCl-1.4.0-cp38-cp38-win_amd64.whl", hash = "sha256:7c6092102219f59ff29788860ccb021e80fffd953920c4a8653889c029b2d420"},
-    {file = "PyNaCl-1.4.0.tar.gz", hash = "sha256:54e9a2c849c742006516ad56a88f5c74bf2ce92c9f67435187c3c5953b346505"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:401002a4aaa07c9414132aaed7f6836ff98f59277a234704ff66878c2ee4a0d1"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:52cb72a79269189d4e0dc537556f4740f7f0a9ec41c1322598799b0bdad4ef92"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a36d4a9dda1f19ce6e03c9a784a2921a4b726b02e1c736600ca9c22029474394"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:0c84947a22519e013607c9be43706dd42513f9e6ae5d39d3613ca1e142fba44d"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06b8f6fa7f5de8d5d2f7573fe8c863c051225a27b61e6860fd047b1775807858"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:a422368fc821589c228f4c49438a368831cb5bbc0eab5ebe1d7fac9dded6567b"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:61f642bf2378713e2c2e1de73444a3778e5f0a38be6fee0fe532fe30060282ff"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-win32.whl", hash = "sha256:e46dae94e34b085175f8abb3b0aaa7da40767865ac82c928eeb9e57e1ea8a543"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-win_amd64.whl", hash = "sha256:20f42270d27e1b6a29f54032090b972d97f0a1b0948cc52392041ef7831fee93"},
+    {file = "PyNaCl-1.5.0.tar.gz", hash = "sha256:8ac7448f09ab85811607bdd21ec2464495ac8b7c66d146bf545b0f08fb9220ba"},
 ]
 pyobjc = [
-    {file = "pyobjc-7.3-py3-none-any.whl", hash = "sha256:8a42710a73e6a7e4c332619aa3ea6d9981edadefafe4492f295c10fb7f14c4d2"},
-    {file = "pyobjc-7.3.tar.gz", hash = "sha256:322b07420f91b2dd7f624823e53046b922cab4aad28baab01a62463728b7e0c5"},
+    {file = "pyobjc-8.2-py3-none-any.whl", hash = "sha256:ebf0a986e8f26e2e0f597fc0be9801f2404c81befc3bee81f665de65ce412e0b"},
+    {file = "pyobjc-8.2.tar.gz", hash = "sha256:20c8dda07debf6f2ac20fb0eaada82b938aa25ae87e481b047e27b14ee854a04"},
 ]
 pyobjc-core = [
-    {file = "pyobjc-core-7.3.tar.gz", hash = "sha256:5081aedf8bb40aac1a8ad95adac9e44e148a882686ded614adf46bb67fd67574"},
-    {file = "pyobjc_core-7.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:4e93ad769a20b908778fe950f62a843a6d8f0fa71996e5f3cc9fab5ae7d17771"},
-    {file = "pyobjc_core-7.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:9f63fd37bbf3785af4ddb2f86cad5ca81c62cfc7d1c0099637ca18343c3656c1"},
-    {file = "pyobjc_core-7.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e9b1311f72f2e170742a7ee3a8149f52c35158dc024a21e88d6f1e52ba5d718b"},
-    {file = "pyobjc_core-7.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:8d5e12a0729dfd1d998a861998b422d0a3e41923d75ea229bacf31372c831d7b"},
-    {file = "pyobjc_core-7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:efdee8c4884405e0c0186c57f87d7bfaa0abc1f50b18e865db3caea3a1f329b9"},
+    {file = "pyobjc-core-8.2.tar.gz", hash = "sha256:6afb8ee1dd0647cbfaaf99906eca3b43ce045b27e3d4510462d04e7e5361c89b"},
+    {file = "pyobjc_core-8.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:311e45556c3afa8831713b89017e0204562f51f35661d76c07ffe04985f44e1d"},
+    {file = "pyobjc_core-8.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:711f361e83382e405e4273ff085178b0cf730901ccf6801f834e7037e50278f9"},
+    {file = "pyobjc_core-8.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:bdd2e2960ec73214bcfe2d86bb4ca94f5f5119db86d129fa32d3c003b6532c50"},
+    {file = "pyobjc_core-8.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b879f91fc614c399aafa1d08cf5e279c267510e904bad5c336c3a6064c0eb3aa"},
+    {file = "pyobjc_core-8.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:b4ef4bdb99a330f5e15cc6273098964276fccbc432453cdba3c2963292bc066c"},
+    {file = "pyobjc_core-8.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:fd8e5be0955790ff8f9d17a0f356b6eb7eb1ce4995e0c94355c462dd52d22d6d"},
 ]
 pyobjc-framework-accessibility = [
-    {file = "pyobjc-framework-Accessibility-7.3.tar.gz", hash = "sha256:75f11e49a5fdb871da7b86f2363aef9d4ce01975549b3ad70d67bdc53c94c365"},
-    {file = "pyobjc_framework_Accessibility-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:d91afc44bff2a29fd33ff1269317e0c8e6413864d1a8a5f5c60d24ca859b8a45"},
-    {file = "pyobjc_framework_Accessibility-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:bc23152da5ddff4c60a316effcdba43ed664db07f7c4713cb7342a5620cfa04d"},
+    {file = "pyobjc-framework-Accessibility-8.2.tar.gz", hash = "sha256:ee3fff7b893501c89dcc1239a56d45e531c3536b0a4ae375cd5dcc31c849e75e"},
+    {file = "pyobjc_framework_Accessibility-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:9cba3a1c5afa2b1ef8ea9b3c733385a50ac29d850cfc3307493600529a187967"},
+    {file = "pyobjc_framework_Accessibility-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:8cffa2fc8e01a8d3bbd5c4756742e75db551a9e9a3145b49bbcea727a02a1743"},
+    {file = "pyobjc_framework_Accessibility-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:d44252d8d742b658edddf9cca7314f2d570f4dc6c46b846d5143ff84ee5f85cb"},
 ]
 pyobjc-framework-accounts = [
-    {file = "pyobjc-framework-Accounts-7.3.tar.gz", hash = "sha256:f35634b7f334a2ce11f8838af1045ec4bf0374000c9296a0f7bbf1b315d81afc"},
-    {file = "pyobjc_framework_Accounts-7.3-py2.py3-none-any.whl", hash = "sha256:8c706252c2c01882277555d7e8b53762895dbb41b76501d33ded1c8a16f1902e"},
+    {file = "pyobjc-framework-Accounts-8.2.tar.gz", hash = "sha256:f42faf6b175939afd3336774ec1db80cef486dbca764b91c19cf71e93d4b4841"},
+    {file = "pyobjc_framework_Accounts-8.2-py2.py3-none-any.whl", hash = "sha256:c5fcc25ffa094df1b4212547ea531fa524492820e24ee844fc3b452cccd1501b"},
 ]
 pyobjc-framework-addressbook = [
-    {file = "pyobjc-framework-AddressBook-7.3.tar.gz", hash = "sha256:2c5036369ee78b68337c6524b6a35060891f94d5ef24beacd8abb9c034f6f201"},
-    {file = "pyobjc_framework_AddressBook-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:3e84749937c58776d9157aebbe4599c304f8e5f7e8aa31937c25ba5c0704dd81"},
-    {file = "pyobjc_framework_AddressBook-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:bcf0386a2d26069fe49f5ed1364d9d4c67abe5ae338e91255f713c83c253da16"},
+    {file = "pyobjc-framework-AddressBook-8.2.tar.gz", hash = "sha256:262b4657f5c31f48df248429dba1236e3e7927964338a4cf4e75feb19ef81bb5"},
+    {file = "pyobjc_framework_AddressBook-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:052ce2a98db8cfbb52fc0aa82bb353fbffa889596d2357bec4c26922d3c0032a"},
+    {file = "pyobjc_framework_AddressBook-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b0bc5c185980d1633fff5e62e3bde6aafbabb094e22bf05adb582d2832fa8ce4"},
+    {file = "pyobjc_framework_AddressBook-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:0e99fcbcd2b637e205dce645d12f17475a8873e3bcc6ada68a668b216d81af10"},
 ]
 pyobjc-framework-adservices = [
-    {file = "pyobjc-framework-AdServices-7.3.tar.gz", hash = "sha256:2506d71835258bf52605a8e1f93a1f33d6293c3fe864b3eaa020267860125188"},
-    {file = "pyobjc_framework_AdServices-7.3-py2.py3-none-any.whl", hash = "sha256:a17ff248bbe8da5bc0afa63d00dddbb4e7ed09daf417aa66f5d41236d6879234"},
+    {file = "pyobjc-framework-AdServices-8.2.tar.gz", hash = "sha256:2138f76f6d7b90df9c8d7d33a476754eb65050a7f8aae5ce541610e2008c1535"},
+    {file = "pyobjc_framework_AdServices-8.2-py2.py3-none-any.whl", hash = "sha256:974c7e8b2c86668768df888d684514434c6a391d6db3b005bdee5ec70102f70a"},
 ]
 pyobjc-framework-adsupport = [
-    {file = "pyobjc-framework-AdSupport-7.3.tar.gz", hash = "sha256:c668c66d4ca0565279a2e8d0c496f63110be8dd6b7fc888438aebd7921e9c773"},
-    {file = "pyobjc_framework_AdSupport-7.3-py2.py3-none-any.whl", hash = "sha256:3db51bbd09d0b2c77b810765aa3588ca88e7be5aa2a716697d04fc5bcdca4235"},
+    {file = "pyobjc-framework-AdSupport-8.2.tar.gz", hash = "sha256:50a2d490b0f3ca4a6e8e19f6329b60c850d0289360a4397bc237a977993e0f92"},
+    {file = "pyobjc_framework_AdSupport-8.2-py2.py3-none-any.whl", hash = "sha256:acca36aa44c840e7a15899691bc54cc237fcdcda1ed766a2f75a3da3565c122b"},
 ]
 pyobjc-framework-applescriptkit = [
-    {file = "pyobjc-framework-AppleScriptKit-7.3.tar.gz", hash = "sha256:7c9adfc047222ce4c56dab7182b8408da48ec08c03a57463334f2a122a300aaf"},
-    {file = "pyobjc_framework_AppleScriptKit-7.3-py2.py3-none-any.whl", hash = "sha256:2862cc29e5c2141ba8b35ff85508e0f1616572080dc57732f96eb85b3e8c803b"},
+    {file = "pyobjc-framework-AppleScriptKit-8.2.tar.gz", hash = "sha256:31464e59178617d0477bb001de2d7e0c2d776322a945639e2b39cebb88401c6a"},
+    {file = "pyobjc_framework_AppleScriptKit-8.2-py2.py3-none-any.whl", hash = "sha256:1f577813c213dc14748cba9d60f5a99c62eeb734b95162f2b4ca96aba739e289"},
 ]
 pyobjc-framework-applescriptobjc = [
-    {file = "pyobjc-framework-AppleScriptObjC-7.3.tar.gz", hash = "sha256:ac6dc66ae55c627182c3e873e58ed6ea1aecf4fc837ffc9321b7d70f9514c193"},
-    {file = "pyobjc_framework_AppleScriptObjC-7.3-py2.py3-none-any.whl", hash = "sha256:e3cfe17d43eb4a8a8c07c9a77fadbf16540c189c99351484d6a189564fda3bc4"},
+    {file = "pyobjc-framework-AppleScriptObjC-8.2.tar.gz", hash = "sha256:913cf86c6bf2df508529a9865de04d05196612af4416a511ca1eaa395185321b"},
+    {file = "pyobjc_framework_AppleScriptObjC-8.2-py2.py3-none-any.whl", hash = "sha256:b1d15269179f284a03be73745cb2b784f43656bb7c1f18facb82fff336f384da"},
 ]
 pyobjc-framework-applicationservices = [
-    {file = "pyobjc-framework-ApplicationServices-7.3.tar.gz", hash = "sha256:1925ac30a817e557d1c08450005103bbf76ebd3ff473631fe9875070377b0b4d"},
-    {file = "pyobjc_framework_ApplicationServices-7.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:daa4a9c51a927630fdd3d3f627e03ebc370aee3c397305db85a0a8ba4c28ae93"},
-    {file = "pyobjc_framework_ApplicationServices-7.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:167aa21ee47b0ee6e4e399915371d183ae84880dc3813c27519e759acb9d20c9"},
-    {file = "pyobjc_framework_ApplicationServices-7.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7a98f0f1e21465868f9dd32588ae71e5e6a4cb5c434d4158c9e12273fd7b8f27"},
-    {file = "pyobjc_framework_ApplicationServices-7.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2d55796610e6293e83cc40183347e7f75a7c0682775cc19e5986945efa9cac1b"},
-    {file = "pyobjc_framework_ApplicationServices-7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:afd1ef147447fe7b06a271458eabb37ece6436705abf86265d7fb57310eca45f"},
+    {file = "pyobjc-framework-ApplicationServices-8.2.tar.gz", hash = "sha256:f901b2ebb278b7d00033b45cf9ee9d43f651e096ff4c4defa261509238138da8"},
+    {file = "pyobjc_framework_ApplicationServices-8.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b5be1757a8df944a58449c628ed68fc76dd746fcd1e96ebb6db0f734e94cdfc8"},
+    {file = "pyobjc_framework_ApplicationServices-8.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:32657c4b89983a98fbe831a14884954710719e763197968a20ac07e1daa21f1e"},
+    {file = "pyobjc_framework_ApplicationServices-8.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6ce2c9701590f752a75151b2fe1e462e7a7ad67dec3119a796711ea93ea01031"},
+    {file = "pyobjc_framework_ApplicationServices-8.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:28124bc892045222305cf8953b163495bf662c401e54f48905dafb1104d9c1d1"},
+    {file = "pyobjc_framework_ApplicationServices-8.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:d5c60d66c6ed2569cb042a6c14dd5b9f4d01e182a464b893cd6002ce445b4ddf"},
+    {file = "pyobjc_framework_ApplicationServices-8.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e1727fccc1d48922fa28a4cebf4a6d287d633f451cb03779968df60de8cb1bd0"},
 ]
 pyobjc-framework-apptrackingtransparency = [
-    {file = "pyobjc-framework-AppTrackingTransparency-7.3.tar.gz", hash = "sha256:e29f193ca3b302394d8d1305daf592fefca290e521d6b0150abb83a7e5ac059c"},
-    {file = "pyobjc_framework_AppTrackingTransparency-7.3-py2.py3-none-any.whl", hash = "sha256:3623e3f81b3a1e140e82ba86376d50cf25e781d3eca64b0b63b35a7dc03d0870"},
+    {file = "pyobjc-framework-AppTrackingTransparency-8.2.tar.gz", hash = "sha256:4bfb73ca5f2d15c34e1d19d36818467950efc7400159bb50169c3e8ffa291d5f"},
+    {file = "pyobjc_framework_AppTrackingTransparency-8.2-py2.py3-none-any.whl", hash = "sha256:b75cfa6b215a31d0898cc8e2eacdaaac09b87a5162d978949d52ea4ee765987d"},
+]
+pyobjc-framework-audiovideobridging = [
+    {file = "pyobjc-framework-AudioVideoBridging-8.2.tar.gz", hash = "sha256:dba4f1671d9af4a6c282da92cf19359f7bbf6dd0423226ccc48bd28423fbc24d"},
+    {file = "pyobjc_framework_AudioVideoBridging-8.2-py2.py3-none-any.whl", hash = "sha256:e207af1a1ba3dc09b6a09af09d59a1b123c5b96762820b357e8457f03d29bfce"},
 ]
 pyobjc-framework-authenticationservices = [
-    {file = "pyobjc-framework-AuthenticationServices-7.3.tar.gz", hash = "sha256:610b2e02a6a9027e85bb7f0e232fbfb93348cff2ce3528e4c35bd4834c9ce164"},
-    {file = "pyobjc_framework_AuthenticationServices-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:8b6de4109e7cd825cb1016e5d826af63dd37ed2d0331e8bcad7c7d1f26185a0e"},
-    {file = "pyobjc_framework_AuthenticationServices-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c238cb2cfe0c8d5d2d606804aba47d9cecb0f78994072ab419bd5ac823bd3e78"},
+    {file = "pyobjc-framework-AuthenticationServices-8.2.tar.gz", hash = "sha256:62774d1f4dd891ebabc12838d4ee59fcf24ccff49dc46ecf9328c6cbf6a17974"},
+    {file = "pyobjc_framework_AuthenticationServices-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:87abe9c4fcb5c737cd5be46b1413ec8ad3a0b516686ceeb66822401687a1a6d8"},
+    {file = "pyobjc_framework_AuthenticationServices-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2596ef3a4314e9cfa26eff11e41a33f8cd1a760fe36c168c00080b571d1f59fd"},
+    {file = "pyobjc_framework_AuthenticationServices-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:8bd18b40fc3e8160216e3b0e0a84f9f485543ebc384ccd56ea03156ba61f9f43"},
 ]
 pyobjc-framework-automaticassessmentconfiguration = [
-    {file = "pyobjc-framework-AutomaticAssessmentConfiguration-7.3.tar.gz", hash = "sha256:c932b31d3620c391e68a16afad85216cf9cc84e8efd938ff285563236890c09a"},
-    {file = "pyobjc_framework_AutomaticAssessmentConfiguration-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:7a43f01bcf83f0959359394dba4844ac4c1ba4be3ef8599358bb50fb79963c79"},
-    {file = "pyobjc_framework_AutomaticAssessmentConfiguration-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:e31272d8b344f4ce192e99d620d074e554948f8cacb6eaef3514baea6cad8c2c"},
+    {file = "pyobjc-framework-AutomaticAssessmentConfiguration-8.2.tar.gz", hash = "sha256:635da4a6a997925d07fdc58bc92c35775431a7c7064415b77ea03c2471f4f9a1"},
+    {file = "pyobjc_framework_AutomaticAssessmentConfiguration-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:b99aa4eb931b8427314a80da07f6d4197769f7534a2c70bbe1ba00d52c44e4da"},
+    {file = "pyobjc_framework_AutomaticAssessmentConfiguration-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b53379fff78afac6c875835fc3f1d8ee3e1726ee216d26b32255d24694eadffd"},
+    {file = "pyobjc_framework_AutomaticAssessmentConfiguration-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:8447cd07800e2535e446a4928924ce02bc940a0f2af3f60ec63e4c2f4ad901e5"},
 ]
 pyobjc-framework-automator = [
-    {file = "pyobjc-framework-Automator-7.3.tar.gz", hash = "sha256:37b9ba85dcb138fd2e6a0ff373e88dd33cab3a3137b11bf15dfb40c67f4934d0"},
-    {file = "pyobjc_framework_Automator-7.3-py2.py3-none-any.whl", hash = "sha256:c793a740649253c9d1bc70fc757fd95a946004ae386dbf937b9f4290c47b43ac"},
+    {file = "pyobjc-framework-Automator-8.2.tar.gz", hash = "sha256:5793a4baf48cdad51d1537315f67a86f9e26ee0f9238895a16886b4478f86335"},
+    {file = "pyobjc_framework_Automator-8.2-py2.py3-none-any.whl", hash = "sha256:5fb59b21cc5b3469d3431b89c673cf7ad666c4e21af80edcc1103682f2c20bd0"},
 ]
 pyobjc-framework-avfoundation = [
-    {file = "pyobjc-framework-AVFoundation-7.3.tar.gz", hash = "sha256:e187591b31c2b053d65aef8b8e3de3cd9ad53496b1ec9144e712dbfb2cded20b"},
-    {file = "pyobjc_framework_AVFoundation-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:12b642df505240d6bb493cd10ca34e7785782eda6aba7e361cb1128b29866092"},
-    {file = "pyobjc_framework_AVFoundation-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:8b7e0e1413f3e627a4668c738a308b54324a781b437d064733c71713977b299f"},
+    {file = "pyobjc-framework-AVFoundation-8.2.tar.gz", hash = "sha256:fdc3415fc54040556e320e2dd5bcb17b811ea1ede2a91540640abfe6cdfb0baa"},
+    {file = "pyobjc_framework_AVFoundation-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:fe866d0b5534f9ad402d4a569bcfa2d6fff30d092b358461adc2e77a8c940fd9"},
+    {file = "pyobjc_framework_AVFoundation-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:a3173b8d687cb9ec7909f6e7104987f2b4f6776ed9154aa726ee2bf60e5184fa"},
+    {file = "pyobjc_framework_AVFoundation-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:a103b8428393d2d96c3b9ed6e8cd27037234a0c15c8707ad5ecd8068a589661e"},
 ]
 pyobjc-framework-avkit = [
-    {file = "pyobjc-framework-AVKit-7.3.tar.gz", hash = "sha256:00aa57ebe7068dccf53e571870bfffe8e9b0857f99f5225795dbe224b412d22f"},
-    {file = "pyobjc_framework_AVKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:59030a44d79533c096bbff5dd6a82c51f4c0730878d58d4eb9ec2cb57f828d7f"},
-    {file = "pyobjc_framework_AVKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:a07645592759ecc438beb37bc9b6e3c527647423e7327d325f84380e198e34d2"},
+    {file = "pyobjc-framework-AVKit-8.2.tar.gz", hash = "sha256:6762149bd0471bb32cd0d446b4869a4c944e7ab21caaf82ac97f1cbf79679d51"},
+    {file = "pyobjc_framework_AVKit-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:e31407dee0d8be33087cb71326e434611c4826e889874b7ffbe2e6379e6010e4"},
+    {file = "pyobjc_framework_AVKit-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:1c083e829965fcd0950fe53d773f531a4db9432166bc74cae5bbac86f1f87595"},
+    {file = "pyobjc_framework_AVKit-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:00fa1b7675dcad8d98e16ad3ba761492bc531be6e905f386ec182f7477500cce"},
 ]
 pyobjc-framework-businesschat = [
-    {file = "pyobjc-framework-BusinessChat-7.3.tar.gz", hash = "sha256:d1e3b16fe25deee3ba39fda17948d98c327523914eef7d16e30582f072442b79"},
-    {file = "pyobjc_framework_BusinessChat-7.3-py2.py3-none-any.whl", hash = "sha256:a0a777c1b6404d7e15a8fdc856178be71a6ad89138dba833f76bf267ba83653e"},
+    {file = "pyobjc-framework-BusinessChat-8.2.tar.gz", hash = "sha256:4edf9d6910925534f18e7fa1f98e0fc9f0abca4b4123a221f739801b43143b17"},
+    {file = "pyobjc_framework_BusinessChat-8.2-py2.py3-none-any.whl", hash = "sha256:b98b4585b0a6b3dabf202e2dbe20f469ade91ded4eaf427e577121785d30bf0c"},
 ]
 pyobjc-framework-calendarstore = [
-    {file = "pyobjc-framework-CalendarStore-7.3.tar.gz", hash = "sha256:fb19a8bb059fb84505ff427cea69df604ab4755ed3fee08278c7d94c34dc3cf2"},
-    {file = "pyobjc_framework_CalendarStore-7.3-py2.py3-none-any.whl", hash = "sha256:a1371e0e9137c9d566836e63f8a927ad2fd0a2b076c722c8fff6d48a73a94382"},
+    {file = "pyobjc-framework-CalendarStore-8.2.tar.gz", hash = "sha256:3d3771e4f685448d670fd4e06e0ab40a0fa7159e7a17b2a828e50b6ab71283c0"},
+    {file = "pyobjc_framework_CalendarStore-8.2-py2.py3-none-any.whl", hash = "sha256:1beaa7c0445e69b074b0f2c5393b3fff9ae15be88c661a08aedd89c85de255d0"},
 ]
 pyobjc-framework-callkit = [
-    {file = "pyobjc-framework-CallKit-7.3.tar.gz", hash = "sha256:5167f17b90ac765774213826af6ce025864ea1643c27ff2f91c76201ada886c3"},
-    {file = "pyobjc_framework_CallKit-7.3-py2.py3-none-any.whl", hash = "sha256:b0ba781bdd02966810b7106f889bd5838d60ac4b25df6fe21d08ece4f6503a8c"},
+    {file = "pyobjc-framework-CallKit-8.2.tar.gz", hash = "sha256:f000b595f522777e2273c46dac6fef8116c72f55a540de014ec767239dcb193e"},
+    {file = "pyobjc_framework_CallKit-8.2-py2.py3-none-any.whl", hash = "sha256:d47bdeed56ea31c76db2ab42879ae23f6ae9d7ccda2d65d8513deccc12c033ac"},
 ]
 pyobjc-framework-cfnetwork = [
-    {file = "pyobjc-framework-CFNetwork-7.3.tar.gz", hash = "sha256:50f0041ee9803857a57827e1995794f8824a4bb7c685d736e1337853c64e741d"},
-    {file = "pyobjc_framework_CFNetwork-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:018e4a4eabc58ded583fe8ea250ad0533ed2c57fd8bfa9a658c867b1826867de"},
-    {file = "pyobjc_framework_CFNetwork-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:24392f6505c243eba7bd2399730bfb39631401796f9f82508c726e723016865e"},
+    {file = "pyobjc-framework-CFNetwork-8.2.tar.gz", hash = "sha256:ad08cfecfb0140674cb9ee7d1d33b701ba9fbd73b34d7c5f4fb5fd5cdfd9de67"},
+    {file = "pyobjc_framework_CFNetwork-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:e85c3414ca5880bc85f1f2a214c139ecacec8046d074738d730a521bd10ac548"},
+    {file = "pyobjc_framework_CFNetwork-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ea2e5500db7e7ff9b0311fa1eece8f1073cca5313c26ed284636217575f54e40"},
+    {file = "pyobjc_framework_CFNetwork-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:29ab77a5f746137f5b611cdf9bf08f5841f8dfef25bd8f6dee482c549a5ee51a"},
 ]
 pyobjc-framework-classkit = [
-    {file = "pyobjc-framework-ClassKit-7.3.tar.gz", hash = "sha256:7da8a38f9a939738092145c3455d1e8917b0e98e9140bdd5ac70dec87e7965c7"},
-    {file = "pyobjc_framework_ClassKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:e1c014caeb6d675dfe606a6c77ccd93df7ffca3be0fd6697bb86e6703d66717c"},
-    {file = "pyobjc_framework_ClassKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2b3b1d3d1da7f5a752bb7d32a09c283db49e9281f4702517c10bf66b3bf226be"},
+    {file = "pyobjc-framework-ClassKit-8.2.tar.gz", hash = "sha256:ee5690e9b59c56e19601583b8a729e72b1c8905288b3b6944ff7eace67b5fcbd"},
+    {file = "pyobjc_framework_ClassKit-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:066f8f33af636943b88b35f0b6e404f9a8e8e7b638fc5004529e10312cf9cf19"},
+    {file = "pyobjc_framework_ClassKit-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:50f499c2237973850f11af9be592d0a1c3506555d18a748b361b4bbea27dba36"},
+    {file = "pyobjc_framework_ClassKit-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:baae9e437094880ea2f94b0cc1e96677b60f71eea0a1698ea08536ba2fefaef4"},
 ]
 pyobjc-framework-cloudkit = [
-    {file = "pyobjc-framework-CloudKit-7.3.tar.gz", hash = "sha256:76efef08830d83c44bdaa9e20dfc652c065f2f8d6c7d1f10ee8dd29cba301869"},
-    {file = "pyobjc_framework_CloudKit-7.3-py2.py3-none-any.whl", hash = "sha256:137c605a288a14f4b10bd2cce69b6897e5b2978b621e334ca83b407831084700"},
+    {file = "pyobjc-framework-CloudKit-8.2.tar.gz", hash = "sha256:3f6f4563063cfe2cb6da979b4cac46fed6fa0d48c1bae6ff12aa3b0f4174cc84"},
+    {file = "pyobjc_framework_CloudKit-8.2-py2.py3-none-any.whl", hash = "sha256:d9930948da0f44c8335b19b252ac4b8e420c6a7b3e1404d09a55de0932f5de48"},
 ]
 pyobjc-framework-cocoa = [
-    {file = "pyobjc-framework-Cocoa-7.3.tar.gz", hash = "sha256:b18d05e7a795a3455ad191c3e43d6bfa673c2a4fd480bb1ccf57191051b80b7e"},
-    {file = "pyobjc_framework_Cocoa-7.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9edffdfa6dd1f71f21b531c3e61fdd3e4d5d3bf6c5a528c98e88828cd60bac11"},
-    {file = "pyobjc_framework_Cocoa-7.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:35a6340437a4e0109a302150b7d1f6baf57004ccf74834f9e6062fcafe2fd8d7"},
-    {file = "pyobjc_framework_Cocoa-7.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7c3886f2608ab3ed02482f8b2ebf9f782b324c559e84b52cfd92dba8a1109872"},
-    {file = "pyobjc_framework_Cocoa-7.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2e8e7a1a82cca21d9bfac9115baf065305f3da577bf240085964dfb9c9fff337"},
-    {file = "pyobjc_framework_Cocoa-7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6c15f43077c9a2ba1853eb402ff7a9515df9e584315bc2fcb779d4c95ef46dc5"},
+    {file = "pyobjc-framework-Cocoa-8.2.tar.gz", hash = "sha256:f0901998e2f18415ef6d1f8a12b083f69fc93bd56b3e88040002e3c09bd8c304"},
+    {file = "pyobjc_framework_Cocoa-8.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:5af73f150e242542735e0663bb5504f88aabaec2a54c60e856cfca3ff6dd9712"},
+    {file = "pyobjc_framework_Cocoa-8.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d1de3763ee01850c311da74de5c82c85ec199120e85ab45acaf203accc37a470"},
+    {file = "pyobjc_framework_Cocoa-8.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:86d69bf667f99f3c43184d8830567195fff94c675fe7f60f899dd90553d9b265"},
+    {file = "pyobjc_framework_Cocoa-8.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9dbadb22826392c48b00087359f66579f8404a4f4f77498f31f9869c54bb0fa9"},
+    {file = "pyobjc_framework_Cocoa-8.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:7adf8b57da1c1292c24375b8e74b6dd45f99a4d3c10ba925a9b38f63a97ba782"},
+    {file = "pyobjc_framework_Cocoa-8.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:bc8279c8c1544087d46a7e99324f093029df89b8c527c5da2a682bad4cb3197e"},
 ]
 pyobjc-framework-collaboration = [
-    {file = "pyobjc-framework-Collaboration-7.3.tar.gz", hash = "sha256:43a1d85e5d418265f18a4c5d77f33eea6d7ad701482a7796f1986e0ef6f39d9d"},
-    {file = "pyobjc_framework_Collaboration-7.3-py2.py3-none-any.whl", hash = "sha256:86724cb8776c5b9045c80307c0a196432515098a9a4a648f7efca0054fdada1b"},
+    {file = "pyobjc-framework-Collaboration-8.2.tar.gz", hash = "sha256:e2ae8ad4dac47eb3fda225971b013a7cc32b9a99544aa9ef653b95c97005674f"},
+    {file = "pyobjc_framework_Collaboration-8.2-py2.py3-none-any.whl", hash = "sha256:8671ecbb126f808ce057194e1c2eb6c7e782cfd249b79848bc7652a4f110c6ce"},
 ]
 pyobjc-framework-colorsync = [
-    {file = "pyobjc-framework-ColorSync-7.3.tar.gz", hash = "sha256:7f95964f1290739642da32a40a6668e5b32d1477635435f3b6eb86689751c80f"},
-    {file = "pyobjc_framework_ColorSync-7.3-py2.py3-none-any.whl", hash = "sha256:23cafb502ac251e363f0128ece1d1fe7df92c2e8ca2545cd502c0030e0da36f6"},
+    {file = "pyobjc-framework-ColorSync-8.2.tar.gz", hash = "sha256:07220b7a78cbec18bda6be46e288a883b98c7f07ba62d676c45edee20f54bf36"},
+    {file = "pyobjc_framework_ColorSync-8.2-py2.py3-none-any.whl", hash = "sha256:243ec6064aa4c3ed6e826f6dafad99bf071c42148b9b6c710ee58daa616665b3"},
 ]
 pyobjc-framework-contacts = [
-    {file = "pyobjc-framework-Contacts-7.3.tar.gz", hash = "sha256:912fccc3b44b9d3b53043df433729344a71ff7652bf18d22c8da4d41c11e444e"},
-    {file = "pyobjc_framework_Contacts-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:7ae50f3eb2d241bca80c0ab52a99ce0eda5e29b4f6a1ec1432cd1d24d1df7209"},
-    {file = "pyobjc_framework_Contacts-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:8504649f8fedaf0d319fd0dfe42214ed060299e080fbe8e8c9111168640d6cfd"},
+    {file = "pyobjc-framework-Contacts-8.2.tar.gz", hash = "sha256:232b527b2d05032b0df2ccfc758ae5cddcc8f8f4e835094ba5a10355be0b5a66"},
+    {file = "pyobjc_framework_Contacts-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:52564693987e0c0a020b1ebd9a0b6f31aa9e5fea594496d94b26f98bf70b287b"},
+    {file = "pyobjc_framework_Contacts-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:d34dc25498a5c4a26cb7426ee3047bb2a4da9cbdd689a354f54c8e367ce737a5"},
+    {file = "pyobjc_framework_Contacts-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:780a9b7b4eaa4787cf70c33db8fc5006cdf7ce3f9a134a7c856eb77fbdc7e0a6"},
 ]
 pyobjc-framework-contactsui = [
-    {file = "pyobjc-framework-ContactsUI-7.3.tar.gz", hash = "sha256:c35b9f10395ef822bcb418541cca4d972fd4f54d064d29b247702e5deee77f0c"},
-    {file = "pyobjc_framework_ContactsUI-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:ee9c704f1738a291c114c72815c17af1a150c6124b84b23fdef7f09e4f6d5d51"},
-    {file = "pyobjc_framework_ContactsUI-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:e623da9b07c03a2869d9d2d921a4debe5649cde41474fbbea57e32641beae8eb"},
+    {file = "pyobjc-framework-ContactsUI-8.2.tar.gz", hash = "sha256:3df4523ec8ad1aeca00700d98671e08fb42add925560b94d3b5433433d9d46f0"},
+    {file = "pyobjc_framework_ContactsUI-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:429055c16bf7c92745d0c65d2fbdc03bcf7fdbc421a3658e9de6fabf837f7588"},
+    {file = "pyobjc_framework_ContactsUI-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:3ded4140f81f92bf500d9887032e29e2dbab8801f195f2010b176e4f6a164ebb"},
+    {file = "pyobjc_framework_ContactsUI-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:06979786ca5fe412ce196f63093c75f34db4597461ce7581fb4bacf3ecf16a79"},
 ]
 pyobjc-framework-coreaudio = [
-    {file = "pyobjc-framework-CoreAudio-7.3.tar.gz", hash = "sha256:37d161dc459ba309fa5f46655662cd63ff850b5edddde463c58594bdf4b4dee4"},
-    {file = "pyobjc_framework_CoreAudio-7.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:11876f4eb434a492674f8b61a5e9ebd6d9f5bc5ba49a2dd56e5e8dcfee92138f"},
-    {file = "pyobjc_framework_CoreAudio-7.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b4fec7d9be1c094caefea862782960d7ee4e33526e31896fee5838b8fe95d01f"},
-    {file = "pyobjc_framework_CoreAudio-7.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f2ef8d2b1a2aab20f12fe978adcdcc21f5c83f5c0374e0cc908e13c49d3a2d69"},
-    {file = "pyobjc_framework_CoreAudio-7.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2c6a6641d4c6bf0464db014b9406566cebad86ae59401e356e09552b2cd478fc"},
-    {file = "pyobjc_framework_CoreAudio-7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6eb67ccecdf488e9369706727f8b90623dea35159f8193a59c04d2cd4d752067"},
+    {file = "pyobjc-framework-CoreAudio-8.2.tar.gz", hash = "sha256:91415ff2c31d5c9c275f54a2ab0e6b746c3b03947a3670e1bcaa19aedd693ed1"},
+    {file = "pyobjc_framework_CoreAudio-8.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:12dc279e27fbc7a3d5618e8a7d4fce30611bb3adc3550b3afec97f63039f6bfa"},
+    {file = "pyobjc_framework_CoreAudio-8.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:9f0475d559d795a0b07de660a93416e628fd6157740d90e220d330adeb7f0e0f"},
+    {file = "pyobjc_framework_CoreAudio-8.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:07e79b452df8f668e83ad7670806574d76cbe20b72c23b59ae279dafbcf80a9b"},
+    {file = "pyobjc_framework_CoreAudio-8.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e034c7e3e8843410042128fcddd0a2b04e4dabdf3e16fa54d693030eac65119e"},
+    {file = "pyobjc_framework_CoreAudio-8.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:4d0e738c991af9327e1723bc0bd9fff603120e987ea58a53a2f2b73f3b1cb814"},
+    {file = "pyobjc_framework_CoreAudio-8.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a139e79c866e179617377b6eba4dff25832f173ca4787a34b28cf912a22d4433"},
 ]
 pyobjc-framework-coreaudiokit = [
-    {file = "pyobjc-framework-CoreAudioKit-7.3.tar.gz", hash = "sha256:9f0ad55dedbff8539c89990a74bb57c452273ac32a5676acbc22becae677b683"},
-    {file = "pyobjc_framework_CoreAudioKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:355ac0a26b896c2d024ed8ae92092a17a39b862fc48e58af3f9a27763f8e4a08"},
-    {file = "pyobjc_framework_CoreAudioKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:8c8853478f12521750f2c1251c51b5094b8c00970f8337a674f3006fb32e777f"},
+    {file = "pyobjc-framework-CoreAudioKit-8.2.tar.gz", hash = "sha256:736311ca39876dbb4373c6706a9ce3b197fed2e5a521bdadac725abe53c451c8"},
+    {file = "pyobjc_framework_CoreAudioKit-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:b52ace56ae9fdbd2ee2ea751fb75e7db24a821dd6b5c542133d164c0dd4845db"},
+    {file = "pyobjc_framework_CoreAudioKit-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:48beb541c956e5a9579d4b0b27d0786d93fc5342cb50c2ee1b6aaa82a06721f0"},
+    {file = "pyobjc_framework_CoreAudioKit-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:112bb1075bbf47c7f929bb9a1203c7d7cd7ec42f193ebbce752892bf5172df72"},
 ]
 pyobjc-framework-corebluetooth = [
-    {file = "pyobjc-framework-CoreBluetooth-7.3.tar.gz", hash = "sha256:86537978052481023cd378714c5e01a337794435aa1981db60c75517f7dc7fca"},
-    {file = "pyobjc_framework_CoreBluetooth-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:f197fd9c13815c1f41997b7eaadee704a54e9f0bd8a0a2ba75bf549d0889caca"},
-    {file = "pyobjc_framework_CoreBluetooth-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:f9f4e9ce79d1933ca7c046348319ec332bf8e95383bc7af70f26accd9167b5c4"},
+    {file = "pyobjc-framework-CoreBluetooth-8.2.tar.gz", hash = "sha256:473662009cd0780d172947f8fd58489e9d95c85a48d143bed7c8a013f48534a4"},
+    {file = "pyobjc_framework_CoreBluetooth-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:7968e913f95a606d563b9214362ace2dac19057f47bbf071c37b29d69babef13"},
+    {file = "pyobjc_framework_CoreBluetooth-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b7a8caf97a8e648297685f07c70b98e5d3de9dde3b5e0114affb5b14f63a2fda"},
+    {file = "pyobjc_framework_CoreBluetooth-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:00ce3b3497d9be48a24ce556dfa12a71aaf7925c7b82a64db2c7edb21aac3887"},
 ]
 pyobjc-framework-coredata = [
-    {file = "pyobjc-framework-CoreData-7.3.tar.gz", hash = "sha256:e7bb263a38ab0acfb931d8a116bde6d928a17a284d1ffa78eebb2d87f62da9b5"},
-    {file = "pyobjc_framework_CoreData-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:e30504bb316e836b0b7ed49035e4443cd95e04af91745a3f6d5656ccb68c0964"},
-    {file = "pyobjc_framework_CoreData-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:20fd74440c777f57f4f58ea21a8bd14112d853f4b210c1dd6e2c7d0b93d89e1c"},
+    {file = "pyobjc-framework-CoreData-8.2.tar.gz", hash = "sha256:a54897f563e849372bb9d0be4ef191eec20b471f1492d1f3c4d8221eaa979523"},
+    {file = "pyobjc_framework_CoreData-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:c126ac81e929d9393208f662f803324c64903663284365051a27446afb3d67de"},
+    {file = "pyobjc_framework_CoreData-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:efbd3b1143c8c8c2f111ba79a087d64538358704ccba01aa842188e4114e2f32"},
+    {file = "pyobjc_framework_CoreData-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:614f5a4531575c400fafe367104f0d89a692dee731504dc4ee40ad3727bdd697"},
 ]
 pyobjc-framework-corehaptics = [
-    {file = "pyobjc-framework-CoreHaptics-7.3.tar.gz", hash = "sha256:e0ff9800e2ffe93c42583bb4f9cb29ebddd6c36f8c93aa12d5ffcf3ad942d788"},
-    {file = "pyobjc_framework_CoreHaptics-7.3-py2.py3-none-any.whl", hash = "sha256:8263ce87459038e4e6c648dcd127abb55811dd532abfa1d3526f12f52defbc64"},
+    {file = "pyobjc-framework-CoreHaptics-8.2.tar.gz", hash = "sha256:3d0498734add4ed8136787098bffad26bff9ca577c03600cab64adaae437f45d"},
+    {file = "pyobjc_framework_CoreHaptics-8.2-py2.py3-none-any.whl", hash = "sha256:eca504ddfa2a02d49b56b4b3f66964a1293f33de7fe0e9ffc44ada39ab6dde86"},
 ]
 pyobjc-framework-corelocation = [
-    {file = "pyobjc-framework-CoreLocation-7.3.tar.gz", hash = "sha256:30060bf97e6cd858192e3cf6ad2725496838062b1750392d6f3c227a8b39bdf8"},
-    {file = "pyobjc_framework_CoreLocation-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:489df752c94d2e51af4881d0a1a5d87ebc1561df17d26ba3a9b177caf90f824d"},
-    {file = "pyobjc_framework_CoreLocation-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:f537af08363281b12ecf1aeed77a2928474a978209ee827cd00d4b3346f411a3"},
+    {file = "pyobjc-framework-CoreLocation-8.2.tar.gz", hash = "sha256:02dccf6ab2621e72e3ed24f952c1b315cb686b5fcce1733c653ee24fefe3f308"},
+    {file = "pyobjc_framework_CoreLocation-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:a3455bf117f51dca3318c5461980eb79accf7bca96ea7d1de521b28778573ab2"},
+    {file = "pyobjc_framework_CoreLocation-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:5c67d58407f7c6b4787c0c4089aa53128fae93da4044c35fb95d4404e106fcb4"},
+    {file = "pyobjc_framework_CoreLocation-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:d566fe46f9f8654bf97bf385ae0176d5f21370ca3b3817c37ec3bd34f275eb9e"},
 ]
 pyobjc-framework-coremedia = [
-    {file = "pyobjc-framework-CoreMedia-7.3.tar.gz", hash = "sha256:c95a09979709241e50a2b000f6772751fed99850f1aaa2cacafd039f3a6b3e99"},
-    {file = "pyobjc_framework_CoreMedia-7.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:38a86c24e337b895fa4832323085f2cc84fb5bffaf1c6c4f54173e9774d4017d"},
-    {file = "pyobjc_framework_CoreMedia-7.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:53e874af4c5cedcbb21a52b6482f98afb402798062326efef0f08de37f7af002"},
-    {file = "pyobjc_framework_CoreMedia-7.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2b911875f1630da6d918c02ca5617e8b5692cc2c8a222874befea19c453fcad7"},
-    {file = "pyobjc_framework_CoreMedia-7.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:b6a05656db2dbfb9e27b2a0ee354528a46cf9d2791a398e60db14c93d6f1c089"},
-    {file = "pyobjc_framework_CoreMedia-7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:089c2cd1eddd9d8a6b3cd624cd44c9f0b222127280d13daacd45ccb0afcda6db"},
+    {file = "pyobjc-framework-CoreMedia-8.2.tar.gz", hash = "sha256:6546aa18a3a0aecae0aadaff6b340a3197bda04d860b9408e31f8fb53bd8ab37"},
+    {file = "pyobjc_framework_CoreMedia-8.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d09dcfa6e4e79ffdfa9b8d4c5424b18f8db9d2648c9308f710a204db225afa5f"},
+    {file = "pyobjc_framework_CoreMedia-8.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:ed55fb2dff5bcadd83db14d0c1687966e6fa1d81229c72a78b23631f6b914e65"},
+    {file = "pyobjc_framework_CoreMedia-8.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:ef8c2d4294a4c03d61b2ef67a01cbaa7429eff8e1fbeaf5af4ee20a8e05e2f15"},
+    {file = "pyobjc_framework_CoreMedia-8.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6af1c90074ed2331982692bd9a96b0ea8b26b8694cc8f839659ac8b4f5865ba4"},
+    {file = "pyobjc_framework_CoreMedia-8.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:18c25376f85f61ae2ef506585248fb9dc29ef71dafeb3638c6300570d7554f75"},
+    {file = "pyobjc_framework_CoreMedia-8.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:58cccc929e3e20dec13b15f0b7e193e58fe62a737c98c890ff6469ef51ce75da"},
 ]
 pyobjc-framework-coremediaio = [
-    {file = "pyobjc-framework-CoreMediaIO-7.3.tar.gz", hash = "sha256:4d2b6106456219d8e74a0dcd9fd4ed1c9be50220b559a266f1048bfe0250a5df"},
-    {file = "pyobjc_framework_CoreMediaIO-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:ffa8e5b48bc3b5dfcacd5f8b7f89fe3f02e888f1fcf8597ef41f4767499ee071"},
-    {file = "pyobjc_framework_CoreMediaIO-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2723c2d994fa1604e2d44719adcc3dda938867aadba565ffecc613b5606e608b"},
+    {file = "pyobjc-framework-CoreMediaIO-8.2.tar.gz", hash = "sha256:a58fab8acfed91e75acfe5b1679696280dda6421c017a70458d7ae9c7ec2dda7"},
+    {file = "pyobjc_framework_CoreMediaIO-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:eca5340f447dc3692305e6124b398cb01e3d27bc833b9e5090bda7dc5d793b13"},
+    {file = "pyobjc_framework_CoreMediaIO-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:3848ac651d57937235843d2c6878893a9225b917eb30243d4197d4ebb9c4b61f"},
+    {file = "pyobjc_framework_CoreMediaIO-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:ccf7f4d87b8b7a771d3800621f7a3271da61fcbb8eb0b70a8f7cadba8601f1ae"},
 ]
 pyobjc-framework-coremidi = [
-    {file = "pyobjc-framework-CoreMIDI-7.3.tar.gz", hash = "sha256:6e333eeddb136579128c8e61476eb638d1db5b7a3bcf2f79ac6f32b00c39ad16"},
-    {file = "pyobjc_framework_CoreMIDI-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:60e99c2a18becad80864801394afc5755c982ebc2877e6c71a95e799de1467be"},
-    {file = "pyobjc_framework_CoreMIDI-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:0ffc7eeb7f3295baa40f477dd2de955dc7b02512ed963dbe6256d0d32250ec16"},
+    {file = "pyobjc-framework-CoreMIDI-8.2.tar.gz", hash = "sha256:051079acabcdce365d4beb6667bdb2e64ca40c8e6c6d14396c183f6de36d0964"},
+    {file = "pyobjc_framework_CoreMIDI-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:1aed05b33198a124424a1750e6935f0d09d3f84cba037a4474c607242268f9d2"},
+    {file = "pyobjc_framework_CoreMIDI-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:7b7cc432ef92cf1fd69dc5927a1cf7af044a20505a5466c5925d3d6105d55fb6"},
+    {file = "pyobjc_framework_CoreMIDI-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:1f5fef983bcf9b3d36589ee1e68f95fa7252ffa413c211fd3dc77bf7d17667a3"},
 ]
 pyobjc-framework-coreml = [
-    {file = "pyobjc-framework-CoreML-7.3.tar.gz", hash = "sha256:dd6810f920e4b6aba14d3e9a471ea3e6cd36b315e324b76a92c46d7ca8ef7700"},
-    {file = "pyobjc_framework_CoreML-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:3b4e1848fbe7d765946a385dc1bdece6c79aed8f59fd426ecc6a32c1f0d8562d"},
-    {file = "pyobjc_framework_CoreML-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:3f40f91a32769cb9e5550498f95eb272b06a90a0467f528adbf4db9e1273eebb"},
+    {file = "pyobjc-framework-CoreML-8.2.tar.gz", hash = "sha256:ff97d77c6aff13df92a394c0903d0bebdc6de3fe29a32097dca036ff991096cf"},
+    {file = "pyobjc_framework_CoreML-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:0ceed56e295f1467f988565dbec873094e76aac0449e1adbb058d18d30ee424e"},
+    {file = "pyobjc_framework_CoreML-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9ee5995776ac909542f29ba174e020831e74e10731b3eaa2d73dac0b2383c124"},
+    {file = "pyobjc_framework_CoreML-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:1c7fcd6dc994f2af6e576ee5a90687250e72eb6b9f1e46cc35cc857017131894"},
 ]
 pyobjc-framework-coremotion = [
-    {file = "pyobjc-framework-CoreMotion-7.3.tar.gz", hash = "sha256:4338c0f24d99d6dac0555a4df1a9265da5164e8603af37eb8345a7e1785624e3"},
-    {file = "pyobjc_framework_CoreMotion-7.3-py2.py3-none-any.whl", hash = "sha256:78afc91a500472ee7a7b9b16a7035aa45ddb83e11339675303d8b86900f3f727"},
+    {file = "pyobjc-framework-CoreMotion-8.2.tar.gz", hash = "sha256:31d8f6855915c55ebe43faec1e2de9478639ce4836577e801684da7bdec7990a"},
+    {file = "pyobjc_framework_CoreMotion-8.2-py2.py3-none-any.whl", hash = "sha256:7b12a8471b09fadced19956db1974f9b3a81b2693d170050c510f73b72b0e16a"},
 ]
 pyobjc-framework-coreservices = [
-    {file = "pyobjc-framework-CoreServices-7.3.tar.gz", hash = "sha256:68240e0314e144e8cccef52c5db112bc4098cb0841c36e747b2f35eeee739e96"},
-    {file = "pyobjc_framework_CoreServices-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:08cac5b662640772e02c8bc62e4a1e21a39794a21826ffe257b48cfe587083f7"},
-    {file = "pyobjc_framework_CoreServices-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:148cc460d9f94ad200d22151c35bf985422790b0cbf1f147f9c1127c5fea23e0"},
+    {file = "pyobjc-framework-CoreServices-8.2.tar.gz", hash = "sha256:4a2b9e9f9a8a962260a445b397b9c9ae221c61e31fb5fcd0813b45dc8e257347"},
+    {file = "pyobjc_framework_CoreServices-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:3e526991d39202641cfcfd2e02ce7aef9056ee0ce7606f0b753314fab4ca4fa2"},
+    {file = "pyobjc_framework_CoreServices-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:da98c40266b34f2187e2e8149c8969d9d76df731a0999cf75be27dca1d941a78"},
+    {file = "pyobjc_framework_CoreServices-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:c4830cb8254115ead9e8f479b3872db95c261de35ecad1c711c5c2c1068216d8"},
 ]
 pyobjc-framework-corespotlight = [
-    {file = "pyobjc-framework-CoreSpotlight-7.3.tar.gz", hash = "sha256:5cb0f25f3c48753a355e1f90c7bd94ea5549d03fa33edf92053fb69d8cb0a9de"},
-    {file = "pyobjc_framework_CoreSpotlight-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:0cf4dc2091a75efbdce804a2b3e1e5eb2fe98daaa4ce495f93db47f94ea47eb7"},
-    {file = "pyobjc_framework_CoreSpotlight-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:90a14bd7f1083b9f237d88a22eda22f043f86671416273dc70c73480fe1febc5"},
+    {file = "pyobjc-framework-CoreSpotlight-8.2.tar.gz", hash = "sha256:77c1139031e2e2133c79f4750e50a9117cec03d8afce861631a581ffe3661163"},
+    {file = "pyobjc_framework_CoreSpotlight-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:50100a501e5ffe68e4c2e7010e5d4f4b886e04795279f1b1a76c02c582698a82"},
+    {file = "pyobjc_framework_CoreSpotlight-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:1881a7737a77b4281d4b51a3549c67f0143eb0bbe124d4d43c90308851617324"},
+    {file = "pyobjc_framework_CoreSpotlight-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:7b73b7fb143597e422887a690579c05cb8420074266a78744f57a720ff8ebbbe"},
 ]
 pyobjc-framework-coretext = [
-    {file = "pyobjc-framework-CoreText-7.3.tar.gz", hash = "sha256:5b5fc91bcbd2fe5199f6b65971d62bea02f942c76d6acb59168c041c7af435d9"},
-    {file = "pyobjc_framework_CoreText-7.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a3ae27d5756b9d62d113e7c4f12022f8812bc95bc277f920f0fe2ca45b5272be"},
-    {file = "pyobjc_framework_CoreText-7.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fd3f11b3358cbf5a56d4a01e736322daa5b6ce6e3701d41cc9eafcede0267faa"},
-    {file = "pyobjc_framework_CoreText-7.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d290880894256497425a1abd116076e7a74c8b92a2b1b27d899ede16f52e5f20"},
-    {file = "pyobjc_framework_CoreText-7.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:b172b22f51625a0f92c9730b9d9a193f12bd5e56552d77b6841dfaac0d16bab0"},
-    {file = "pyobjc_framework_CoreText-7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:862e5c2c1bd6f5d276321c9a2d557dd8fb62ab1da55722a582b9e6621b05c1bd"},
+    {file = "pyobjc-framework-CoreText-8.2.tar.gz", hash = "sha256:833e6090e24c00fffcfef8d759bd6dd3f968b92d20b62edd64ab714269614f84"},
+    {file = "pyobjc_framework_CoreText-8.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ba9e7335c8f3e9f5ab0c6bab1d05b95dd945fbbb801411f5f63474511ec8cb31"},
+    {file = "pyobjc_framework_CoreText-8.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:473d150276116c2b3e91353b8c0cc0b134e2a0edb999b2e7ac97b2d02920c9fd"},
+    {file = "pyobjc_framework_CoreText-8.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:397975fc5a71f75b7b908438faf8fd06b4cc49233ae64d27955c0a8b48970a91"},
+    {file = "pyobjc_framework_CoreText-8.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:3f9c0188447fee508267274603f00baa6cc92dbf23e5f8e84f33253d625d4af3"},
+    {file = "pyobjc_framework_CoreText-8.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:20d44c833e1fbdc53e56caf168fa207330754acfe011239f6e0977ae58696737"},
+    {file = "pyobjc_framework_CoreText-8.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:641a456506c7b21420977a3ecbe6ae1786be74fc770d2440dc290906b820d465"},
 ]
 pyobjc-framework-corewlan = [
-    {file = "pyobjc-framework-CoreWLAN-7.3.tar.gz", hash = "sha256:63ab61cd28cd1d61619150e1eff85e3c953f28b4240ec4011229100bb4749657"},
-    {file = "pyobjc_framework_CoreWLAN-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:f102cdc76b1715b85376f80b11d27034458083cd589a161926904dabbe04a41b"},
-    {file = "pyobjc_framework_CoreWLAN-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:8bb19b278c56f9d5dc52ebe7a0f45565a26dcaea24f127e06234c8d75e66a6b1"},
+    {file = "pyobjc-framework-CoreWLAN-8.2.tar.gz", hash = "sha256:0542560213be5df51cd33aca8bbf3cb5b4750d429ab8d4d8ef17afcb78c8cf9f"},
+    {file = "pyobjc_framework_CoreWLAN-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:87a56f7e57a47c1c869e912b2bdaf295f1fe67732bf2bc41a24f7d2d0a4198be"},
+    {file = "pyobjc_framework_CoreWLAN-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:48975dd33a73cf14a62ef84985df83ac31f2d08eaccf45b5ea7b0ac985ce3462"},
+    {file = "pyobjc_framework_CoreWLAN-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:0c80e615400cb7435db7f948fbfb061e19f6ceecedae469179f0ee8d7e091ef5"},
 ]
 pyobjc-framework-cryptotokenkit = [
-    {file = "pyobjc-framework-CryptoTokenKit-7.3.tar.gz", hash = "sha256:904ea3ee27135a2fa4b139ed8aed0a50f0c2ce7d3633c7e1e79d317aa5c4e9f8"},
-    {file = "pyobjc_framework_CryptoTokenKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:bab35918d7d29bf8264c99b6eba3bfaacaef52f7be28039e8fda955e6b6540f2"},
-    {file = "pyobjc_framework_CryptoTokenKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c2cfbdbb424a8fee16ed76ab558d121e681bb32ea33d4361c5d4fe618ad66c6f"},
+    {file = "pyobjc-framework-CryptoTokenKit-8.2.tar.gz", hash = "sha256:dd0cc1253a6f8a7823a958f3e8fc7c3595eb5117f972894883da23e8e1a34d33"},
+    {file = "pyobjc_framework_CryptoTokenKit-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:13deccf82e4e6aba6ad213ab2b265533b4b8db0d644a4d25c41bc6ed603ae2ad"},
+    {file = "pyobjc_framework_CryptoTokenKit-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:8fafff37635b1f12d1209ea721d60ceeef024f92dcc01f0e247f2bc8803094f4"},
+    {file = "pyobjc_framework_CryptoTokenKit-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:88650ccd365c0bfd9b7c9932884c686d0b5678a8aa5377c0b4e93b345d6e6d98"},
+]
+pyobjc-framework-datadetection = [
+    {file = "pyobjc-framework-DataDetection-8.2.tar.gz", hash = "sha256:6bddc36392e18a20ffadc07fa11d8577a4140ef0ceb18cc44d7d1de802f08045"},
+    {file = "pyobjc_framework_DataDetection-8.2-py2.py3-none-any.whl", hash = "sha256:818cf371c8b83e4e47103c81f7c8b9423adf5cd7aea8bf908589b204b671bff2"},
 ]
 pyobjc-framework-devicecheck = [
-    {file = "pyobjc-framework-DeviceCheck-7.3.tar.gz", hash = "sha256:9f65aa882367a367d8f05bbed52ad822f883970bc0afd7ae0bfb9941e16f13bc"},
-    {file = "pyobjc_framework_DeviceCheck-7.3-py2.py3-none-any.whl", hash = "sha256:12eceb3f9bffa9bdd0a8948bfd9e27ff6be34a8f72a4d72dbe117efbcf13870c"},
+    {file = "pyobjc-framework-DeviceCheck-8.2.tar.gz", hash = "sha256:2d82521edcb394ffbca9c4e9bca52f55abf414df4c639463a941a6a77156b5c8"},
+    {file = "pyobjc_framework_DeviceCheck-8.2-py2.py3-none-any.whl", hash = "sha256:2460e240f1b4b0df599881d0b135f40e85330015220c805c959bad58baa6993e"},
 ]
 pyobjc-framework-dictionaryservices = [
-    {file = "pyobjc-framework-DictionaryServices-7.3.tar.gz", hash = "sha256:3187b7c24f3fb8e6f5aea89eefacf3657a4bd4fa0f589a69836fb5aeafe2733b"},
-    {file = "pyobjc_framework_DictionaryServices-7.3-py2.py3-none-any.whl", hash = "sha256:c3bc44a4383add1505b348d3a1a99c49708eb8360f44655ba726312d76451421"},
+    {file = "pyobjc-framework-DictionaryServices-8.2.tar.gz", hash = "sha256:0a1eefd7dc3977d0082130b237a3039c9c2eaf5defac52edabf19910bf684542"},
+    {file = "pyobjc_framework_DictionaryServices-8.2-py2.py3-none-any.whl", hash = "sha256:b76d8c15b0b0287c76e8a056b73afc80f31ecacb5ef5a7d8945ae8805fa296ee"},
 ]
 pyobjc-framework-discrecording = [
-    {file = "pyobjc-framework-DiscRecording-7.3.tar.gz", hash = "sha256:9a1dc83f44227e1522643ec3c0fa774dee9e42b501fce7e1e39ba1e4907e1e22"},
-    {file = "pyobjc_framework_DiscRecording-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:e531c82e35986eb984e2613ef5fc37c1cb0e3b3174c60cbe2e34860052423259"},
-    {file = "pyobjc_framework_DiscRecording-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:690621c0bc25ff2b8c6e227e6294cd9469e8208179d79a7fcf79e580159f582e"},
+    {file = "pyobjc-framework-DiscRecording-8.2.tar.gz", hash = "sha256:46bebb0f4a81f7bd0c56bd90cda00ec763c151f16e2d02d00390d03aa4047c55"},
+    {file = "pyobjc_framework_DiscRecording-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:03a140efa401cb9993ad7d2b41276d155000a0a155f8b959584dea537430cbdf"},
+    {file = "pyobjc_framework_DiscRecording-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:6e832b74dd7d1dc2b684033e966cf390fd772af592b3a9b5c457dd6401891156"},
+    {file = "pyobjc_framework_DiscRecording-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:8a387063a019963a495f1b9dea17b067b7c3260c6d13e1c119af9aa888e2b140"},
 ]
 pyobjc-framework-discrecordingui = [
-    {file = "pyobjc-framework-DiscRecordingUI-7.3.tar.gz", hash = "sha256:5db083a92bc9513a818d1bc4574a3313f9b967f2aa8dce888ebe436b9a948673"},
-    {file = "pyobjc_framework_DiscRecordingUI-7.3-py2.py3-none-any.whl", hash = "sha256:c30d3000885be80aded9f4517946fed3ab6c43dce89923ad62ebadb7f5135ebc"},
+    {file = "pyobjc-framework-DiscRecordingUI-8.2.tar.gz", hash = "sha256:a923d13af629c4badf953fdeaecafa7a9271dab528b4b2aa873a5b3b7f2ea89e"},
+    {file = "pyobjc_framework_DiscRecordingUI-8.2-py2.py3-none-any.whl", hash = "sha256:5218c6138c047c0293a8f5e0479271ce640eba2ea4f05258351af691167e62fa"},
 ]
 pyobjc-framework-diskarbitration = [
-    {file = "pyobjc-framework-DiskArbitration-7.3.tar.gz", hash = "sha256:f34d28226760fdce865487b2ea6835e5256f0df00deb68154515e51dc36ea352"},
-    {file = "pyobjc_framework_DiskArbitration-7.3-py2.py3-none-any.whl", hash = "sha256:edac3e6a8daa20cd39d3295b253b0118d6fb1e757357f1fcb384b2abda12cca0"},
+    {file = "pyobjc-framework-DiskArbitration-8.2.tar.gz", hash = "sha256:c9fceb2e28a1e3fae279b44a329ea1c801d072a8610b6c5b2e2b8e47e136f5b1"},
+    {file = "pyobjc_framework_DiskArbitration-8.2-py2.py3-none-any.whl", hash = "sha256:53167155229837ff2e93f613147de3de39024e63d69bc0b32076573a82a9512a"},
 ]
 pyobjc-framework-dvdplayback = [
-    {file = "pyobjc-framework-DVDPlayback-7.3.tar.gz", hash = "sha256:4e71fafed5901652ad7540f1f25e9250c5c6522039bf74681e850c6241bfe497"},
-    {file = "pyobjc_framework_DVDPlayback-7.3-py2.py3-none-any.whl", hash = "sha256:523bb58d41b972514187ef0dddadc5033f739074e5a89002d677282575b1e777"},
+    {file = "pyobjc-framework-DVDPlayback-8.2.tar.gz", hash = "sha256:8ecb9f3d02ddf072bfac69ce6187cf71092f741326d079ec0d5041f7e080ae4d"},
+    {file = "pyobjc_framework_DVDPlayback-8.2-py2.py3-none-any.whl", hash = "sha256:a800044777fa60fa75b91fa80e1058b43529c6cf1c94fcd96d8a8dc53b44c4a4"},
 ]
 pyobjc-framework-eventkit = [
-    {file = "pyobjc-framework-EventKit-7.3.tar.gz", hash = "sha256:826e04c0211c781ce85b4efb0de4b72d833a66e8475e3f1728f318253fd9ffea"},
-    {file = "pyobjc_framework_EventKit-7.3-py2.py3-none-any.whl", hash = "sha256:08034245c385f31d93eddd181f48defefd9f97fcfff7d01ae47dc5dd3aacd424"},
+    {file = "pyobjc-framework-EventKit-8.2.tar.gz", hash = "sha256:017ea72b04be4f33ae62c15bed81f2d17de302b78331cbe25e838328710c4aef"},
+    {file = "pyobjc_framework_EventKit-8.2-py2.py3-none-any.whl", hash = "sha256:675b04a40dcf86434245d6b89bdc39d6c57eabfc2c825329dec3bfc93b1bfc66"},
 ]
 pyobjc-framework-exceptionhandling = [
-    {file = "pyobjc-framework-ExceptionHandling-7.3.tar.gz", hash = "sha256:1843f8e48d88c8518280c0daf23247a4f12897cb3b7b9b77ee014cf0b4a145bd"},
-    {file = "pyobjc_framework_ExceptionHandling-7.3-py2.py3-none-any.whl", hash = "sha256:f5c04dfb0178c983e60e6a19d1ff75ee74898d79d87916005a562bceb941d469"},
+    {file = "pyobjc-framework-ExceptionHandling-8.2.tar.gz", hash = "sha256:695af385adaf995a94966a6c60d74e9945727e727be68842a99bd8ddb65856e5"},
+    {file = "pyobjc_framework_ExceptionHandling-8.2-py2.py3-none-any.whl", hash = "sha256:efc9359f456373a0ffd66eb87f418f0b28d6078c6f8160014079af9ff0cc1841"},
 ]
 pyobjc-framework-executionpolicy = [
-    {file = "pyobjc-framework-ExecutionPolicy-7.3.tar.gz", hash = "sha256:27f1bd941320238eaebf933b30b401cf0af5b581af2d4197554ef6977125a2ef"},
-    {file = "pyobjc_framework_ExecutionPolicy-7.3-py2.py3-none-any.whl", hash = "sha256:b042788483b40178bfaabe7bde4a4db76e340877d1525074a2e3812cceafe9d0"},
+    {file = "pyobjc-framework-ExecutionPolicy-8.2.tar.gz", hash = "sha256:0130a1fd75aec0705f11041ed975aa0ac926e428582d49982d743bf86d0ffbb6"},
+    {file = "pyobjc_framework_ExecutionPolicy-8.2-py2.py3-none-any.whl", hash = "sha256:69bb637025573e9d46b0a07052e83eaac89708f3af54303c1a93d3bf100973e7"},
 ]
 pyobjc-framework-externalaccessory = [
-    {file = "pyobjc-framework-ExternalAccessory-7.3.tar.gz", hash = "sha256:74b5c2cce8f2a7a70c2e57e6ecf773ac5e083887e27b5acb86e97eb5c4f1d472"},
-    {file = "pyobjc_framework_ExternalAccessory-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:ff6727bc5b1d2894e7a8e350272a19be6d4b70621a22a488e9efe64971b01086"},
-    {file = "pyobjc_framework_ExternalAccessory-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b72bf6d62aaefb7ad5a7997b3ef8be4a270861edbb1c4546a82963c3d09ae5a0"},
+    {file = "pyobjc-framework-ExternalAccessory-8.2.tar.gz", hash = "sha256:a8e0bed6d457ac16d808662959fbe85baeee59099b66c4aa16926686ac95c8d5"},
+    {file = "pyobjc_framework_ExternalAccessory-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:88f627b5b38f314d8c48bac9575b126751d9d2eafdf403bad3e772fc88d87662"},
+    {file = "pyobjc_framework_ExternalAccessory-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:cf6c41c74fea1f86faa1595c7743d2ed806917ffa7a98a27a1ed6dcebed9931e"},
+    {file = "pyobjc_framework_ExternalAccessory-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:3d2809d408a73881fddcfc4392e8c12cc13009a368e8ffa737a616fa110ef8a9"},
 ]
 pyobjc-framework-fileprovider = [
-    {file = "pyobjc-framework-FileProvider-7.3.tar.gz", hash = "sha256:cec94c9e2eef09e624834a358da7c0827938eb0825c2804b09a2bf20858a6615"},
-    {file = "pyobjc_framework_FileProvider-7.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:55537492938356fb0d2034327d39e84c46b2e7340b923177ba249baf0ce43b38"},
-    {file = "pyobjc_framework_FileProvider-7.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a427f2f560b8568f7992467b4f8acde9dd9de716979a71484cea06ad9e3465ef"},
-    {file = "pyobjc_framework_FileProvider-7.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:370dfde069494818f077ff06ee02cdedc9c3733add6df5336800c5f14c6519ff"},
-    {file = "pyobjc_framework_FileProvider-7.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7b3649e1ddfa2c936a27d8d4c811d72786c911809909d0367ca08cae740d81f2"},
-    {file = "pyobjc_framework_FileProvider-7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:71170dd3fb5b9abfe59bf441568b31b8059284054501419c06c94871006cb5cb"},
+    {file = "pyobjc-framework-FileProvider-8.2.tar.gz", hash = "sha256:9ed03088638e1263df3c3d4243c2e0ad506848297b577f19d2e95ce2739160f5"},
+    {file = "pyobjc_framework_FileProvider-8.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:5d60a340c6dfd265c1043aa9c6f29b473b1fadbe59e3b89b3d8fbcccfb5af824"},
+    {file = "pyobjc_framework_FileProvider-8.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f289c20ba7de4d797be52ca8632eb768cd2a06babae84dc7c05a28c9632f7a90"},
+    {file = "pyobjc_framework_FileProvider-8.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:49e758bf1669c6c8af0ff6dd57202d568aff4ee185030b20f4b30de251047c5d"},
+    {file = "pyobjc_framework_FileProvider-8.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ad61f13731e2a18044181b9d486c01d4bf0e15249a6bedffa44d039833e24e24"},
+    {file = "pyobjc_framework_FileProvider-8.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:a74409296f1f0720b1065152d28571d2617065213500d5c49ce9d668e5a79812"},
+    {file = "pyobjc_framework_FileProvider-8.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:979a8e3e3583b067caf6c96d5edce4c094e41f4bca2df4d79fcad9fd6d94161c"},
 ]
 pyobjc-framework-fileproviderui = [
-    {file = "pyobjc-framework-FileProviderUI-7.3.tar.gz", hash = "sha256:2cf6f7182bde330ee018233014549f24ed89002f543364f55ca99fd5ee51051e"},
-    {file = "pyobjc_framework_FileProviderUI-7.3-py2.py3-none-any.whl", hash = "sha256:df4babeb6ca03575f8488a4bd999d6a62b2825706ef8438960fe299938c05d54"},
+    {file = "pyobjc-framework-FileProviderUI-8.2.tar.gz", hash = "sha256:de66e0f59900adf58bf6cdaf6153f2d27efd60e580c68b5de8c7bed4c8e509f0"},
+    {file = "pyobjc_framework_FileProviderUI-8.2-py2.py3-none-any.whl", hash = "sha256:9d5712df3909c247e665c3a9dc214b9ad115f697732ea7d99abc314d8da22431"},
 ]
 pyobjc-framework-findersync = [
-    {file = "pyobjc-framework-FinderSync-7.3.tar.gz", hash = "sha256:f68c6920a1a8445c170dfc6c345243e772e331ff01f5a2eef04b330ab5ae8c42"},
-    {file = "pyobjc_framework_FinderSync-7.3-py2.py3-none-any.whl", hash = "sha256:51ef8c0ae97575a9aa2c5abf9c9739bf40ec2482371fdf40baa13f58ad05fd79"},
+    {file = "pyobjc-framework-FinderSync-8.2.tar.gz", hash = "sha256:c86d3856017c81b452f0ae99c2b73170a40507bc2adcd237816e9cfaae3dec17"},
+    {file = "pyobjc_framework_FinderSync-8.2-py2.py3-none-any.whl", hash = "sha256:a8cffc5ead2fdad2892785399e00f5f5e6afbb2022e33eb2e71773698702cc71"},
 ]
 pyobjc-framework-fsevents = [
-    {file = "pyobjc-framework-FSEvents-7.3.tar.gz", hash = "sha256:3d12df35cc0b18c3f7c677d6bc870a7ea13a5d1c2f16456c1f445e0b894ddb55"},
-    {file = "pyobjc_framework_FSEvents-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:65d2fed30225c9de9678f68cf41e56f0e1afaaac6e3ae82075e874e93e42a823"},
-    {file = "pyobjc_framework_FSEvents-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:dc9e2b8ed3dc2f6acffacd52681ece8141711acd5e02d23638f6a48af9bcfc5a"},
+    {file = "pyobjc-framework-FSEvents-8.2.tar.gz", hash = "sha256:35e175f157c2906f2fdaa0ddaa20f2505840801449c54638512d6a0b2f1bcccf"},
+    {file = "pyobjc_framework_FSEvents-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:e0369b0dedfee5b06157b19b3978ecb1b3cb322276698005b60d089a95fd2fb8"},
+    {file = "pyobjc_framework_FSEvents-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:91d275b070105e410cd498d07a90e65a49e00a2482db43a22540b5f34ed60cfa"},
+    {file = "pyobjc_framework_FSEvents-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:32757268849abbba4dda39572a26c0bc2504d21fe396ed20ab4ef635c12fc27f"},
 ]
 pyobjc-framework-gamecenter = [
-    {file = "pyobjc-framework-GameCenter-7.3.tar.gz", hash = "sha256:1a13c35fa7f109d043e5d0d8cd5f808d061a4ce525580550dceca2697270beaf"},
-    {file = "pyobjc_framework_GameCenter-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:fee0d1bf927daefbf6dea6c980ffc04d54df03041f01e0895999c82be5cb27ea"},
-    {file = "pyobjc_framework_GameCenter-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:5f6a5d673b767372f60603a5f370d46ea3895168dd9efd501bb34d64a66844e9"},
+    {file = "pyobjc-framework-GameCenter-8.2.tar.gz", hash = "sha256:c5f3f8b91afc20fa3e9ebeb493fa01b9a4210a27dc5c856172648358b9eec956"},
+    {file = "pyobjc_framework_GameCenter-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:642aedce04afba5ef3f65ceac9981f1bdd2b1cfdae173db8a06c15c5cbd711f7"},
+    {file = "pyobjc_framework_GameCenter-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:5d8345c208f586826ad40f20bc66640eea70f87bb83f94862b56430313414628"},
+    {file = "pyobjc_framework_GameCenter-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:4df634fc3873d95516de18e8fdf3f6186e3068a92f66173634766937b3c18b29"},
 ]
 pyobjc-framework-gamecontroller = [
-    {file = "pyobjc-framework-GameController-7.3.tar.gz", hash = "sha256:745088df9c3d127e0949f5ee19d12c8c88f305c8406769f12da4299338320d91"},
-    {file = "pyobjc_framework_GameController-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:ae38efcce1dcba570fb97a377a2af8372e2dee5129466193b52a7ab3996306aa"},
-    {file = "pyobjc_framework_GameController-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:6d88715544ef6159ba5d10e6e9148cab1d7c94e572ee23e06d8d95262ac05425"},
+    {file = "pyobjc-framework-GameController-8.2.tar.gz", hash = "sha256:113d600da5c9b5b8cffbb1e64ce8de1d8df360aaaaec878c49a6190d57bc1193"},
+    {file = "pyobjc_framework_GameController-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:563a79c539eb2379140bafa5e28689d365be1cd9961f71682a63f09e80b4bfe9"},
+    {file = "pyobjc_framework_GameController-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:29bb17d761990548fcee50be3d7f5ef3dd4de83705cdd2d428326e2071bd1113"},
+    {file = "pyobjc_framework_GameController-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:bfde6d0d80f0746c66571e3222391e70f43b241096a5800b470b223ab8b5036f"},
 ]
 pyobjc-framework-gamekit = [
-    {file = "pyobjc-framework-GameKit-7.3.tar.gz", hash = "sha256:6bb7b60b638026c2c5dca0f2ed92e0710e83d7b2ac5393387cbe3b80f1f46c6b"},
-    {file = "pyobjc_framework_GameKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:899c5a98d1c86d918c2d4ff2928974d3f177a3bd1db2cdd1362ac1978c7746f9"},
-    {file = "pyobjc_framework_GameKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:eac5768f71e8d78edef9ac3d660bb55ccda911e42fd13a5ca157c10342848a5c"},
+    {file = "pyobjc-framework-GameKit-8.2.tar.gz", hash = "sha256:37a84ebcec557080ea995c500f95b5d8d7c75803f743bd7c5ad8358711181bd6"},
+    {file = "pyobjc_framework_GameKit-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:907939abcb589def608216502e07999c041760f6f5e113e48223ddba42aa52ce"},
+    {file = "pyobjc_framework_GameKit-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:8f70a7669be18339bbce6258e4f0c4417482327e3b7fa704a304cb961f8561ff"},
+    {file = "pyobjc_framework_GameKit-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:6e8f451f9860045ca279a6d267aedfee0a645ea9f2752337b1678bb524a34a82"},
 ]
 pyobjc-framework-gameplaykit = [
-    {file = "pyobjc-framework-GameplayKit-7.3.tar.gz", hash = "sha256:6138e5e7eb16c0f6dc1d9d9d570589f6dd19746be7a5a84ef69f3288e8f87cbb"},
-    {file = "pyobjc_framework_GameplayKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:2a93a9eaef10c693c37764d8b73702036f85ad733dfb84b7e2569e1d64efb4be"},
-    {file = "pyobjc_framework_GameplayKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:e90fa8213580990ff982664b71fbc414d3015d83b5819c2dbed967dca9352cf7"},
+    {file = "pyobjc-framework-GameplayKit-8.2.tar.gz", hash = "sha256:8dc8d214699bbad569de4eaae7a2ec9f01b635177a4970727078b46a0772dc26"},
+    {file = "pyobjc_framework_GameplayKit-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:5619daf15edc18c0981ae9e279f15d2437a36cd0cdfffa706e212b874ba0a331"},
+    {file = "pyobjc_framework_GameplayKit-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:4cb1bcd0adb35e83a02918e6668c72fe665810a426408154f07ce88c40befa56"},
+    {file = "pyobjc_framework_GameplayKit-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:461009288d7186428143bb3b90fa73752e0b9f640bd208b3f6fde79270222aa3"},
 ]
 pyobjc-framework-imagecapturecore = [
-    {file = "pyobjc-framework-ImageCaptureCore-7.3.tar.gz", hash = "sha256:e0143ae9d33d5dae5427b1823444a83f89fbdbcc5f0d42b3c3fe5e6dd17ec4e5"},
-    {file = "pyobjc_framework_ImageCaptureCore-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:a292eddc7db0bb57cd40ac32fe16c85be21e0dbad99f1f414d520456e0ae9f70"},
-    {file = "pyobjc_framework_ImageCaptureCore-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:adc2e0b6ac1a60adc778a56a0f5b6b53631f441f46c592e693c79b64b47bf229"},
+    {file = "pyobjc-framework-ImageCaptureCore-8.2.tar.gz", hash = "sha256:86685857a6818000a4282c85995d637dd70a0881265b70f54c020b865f6e3063"},
+    {file = "pyobjc_framework_ImageCaptureCore-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:638304a22347869a0996a9147e5777834c65173dd434ad0c71262528516a5473"},
+    {file = "pyobjc_framework_ImageCaptureCore-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:52dce4eef00aa8c25e7491d4a11fd52fdb61aa481e7ac2b15ebfc39c96893c62"},
+    {file = "pyobjc_framework_ImageCaptureCore-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:40c5bd84350c8a189fcc53b7ebdc1694ef9b37ed31255f28d6f0269dc807d148"},
 ]
 pyobjc-framework-imserviceplugin = [
-    {file = "pyobjc-framework-IMServicePlugIn-7.3.tar.gz", hash = "sha256:04faa56cdf2899bba8d7d397d9cd77a8bf12aa631d979b005365201611a0712f"},
-    {file = "pyobjc_framework_IMServicePlugIn-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:7d41664b7fe6059cf311d589d6b7ab35726b74d7e10fd0d61e270954818c39c6"},
-    {file = "pyobjc_framework_IMServicePlugIn-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b2b297f68891a3be1120767a6509ec3eba81cf74fc550974362140820c9def82"},
+    {file = "pyobjc-framework-IMServicePlugIn-8.2.tar.gz", hash = "sha256:1866cdc51642f4adba725ee7d96bb2ac0a67a99fb6d4e4fbb14522b766b058fd"},
+    {file = "pyobjc_framework_IMServicePlugIn-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:239ecbaef924fd802278e8e12509733aafd3e0eaaa154f14d3cd74212c64af98"},
+    {file = "pyobjc_framework_IMServicePlugIn-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9250b72cecfff8239a8c6403a406d6ba524d4e8cf3a61974e11463267f50e96b"},
+    {file = "pyobjc_framework_IMServicePlugIn-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:1be652816153b4b17d0af6ca025f89f949dcac6b451eb7279c84e5f51eb2b62b"},
 ]
 pyobjc-framework-inputmethodkit = [
-    {file = "pyobjc-framework-InputMethodKit-7.3.tar.gz", hash = "sha256:c96d51bdbdf55c05ca53ed50691c9e7258265c700126f25498f293d708dbb601"},
-    {file = "pyobjc_framework_InputMethodKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:fda4b2fc8fa989f5f59fe7abed42d42784a12b5731a93636609bd2d6014715bb"},
-    {file = "pyobjc_framework_InputMethodKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:5984ed9239ca8f5e8d29d76cc7a218570f8c6a29b0705b6853fa2eda65e3542e"},
+    {file = "pyobjc-framework-InputMethodKit-8.2.tar.gz", hash = "sha256:57974d6d433e40d68f0416dd6d07d9a893291250ae8d649f0491aaccd0c636d8"},
+    {file = "pyobjc_framework_InputMethodKit-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:1b011b223e1cc4ac33bfec532acc6152264c67a5eb113d39c6a4939f1887e7ce"},
+    {file = "pyobjc_framework_InputMethodKit-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9b616f38c37eab2760d24af99b09eb5ff418c7ad37db83064b86f617e69eb761"},
+    {file = "pyobjc_framework_InputMethodKit-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:62fbfb3add79a0592d6c235d46172db3c59f125146bb304c8661edf3a7d9c1fe"},
 ]
 pyobjc-framework-installerplugins = [
-    {file = "pyobjc-framework-InstallerPlugins-7.3.tar.gz", hash = "sha256:d1bd6b8df714a6f7dd7dc19e5a96c13434732ff6a17dcc3bb21f88ea7cd9cdf2"},
-    {file = "pyobjc_framework_InstallerPlugins-7.3-py2.py3-none-any.whl", hash = "sha256:8b770f0d5633cc04a5aea376766ed5d18aa75806275f3e9579e4b2093c29ca18"},
+    {file = "pyobjc-framework-InstallerPlugins-8.2.tar.gz", hash = "sha256:b79a29e0965f1999c9111654015c52c3ea44755d2ca2528cba6f0da4b7b92cfc"},
+    {file = "pyobjc_framework_InstallerPlugins-8.2-py2.py3-none-any.whl", hash = "sha256:60a62d6c4d8683b265af212eb57a12bf2cbc210ac98e4330b1acbe59d8024a9d"},
 ]
 pyobjc-framework-instantmessage = [
-    {file = "pyobjc-framework-InstantMessage-7.3.tar.gz", hash = "sha256:dbc907cbdd4ae0766f568c709460381846fb57852496177dafb323960e52f22f"},
-    {file = "pyobjc_framework_InstantMessage-7.3-py2.py3-none-any.whl", hash = "sha256:dfbed891b064bae5fa4cb6c205d9820e49002dac3b49021f526c9d0360c0bd14"},
+    {file = "pyobjc-framework-InstantMessage-8.2.tar.gz", hash = "sha256:45a0890cd52cfc49a28c1dc20f14ff508849ab36e6c748f842eed6badd5fcf2f"},
+    {file = "pyobjc_framework_InstantMessage-8.2-py2.py3-none-any.whl", hash = "sha256:d56e2931903851ff02c8c705a638f11d748f7ab7f366e0d675d69842cc5ea235"},
 ]
 pyobjc-framework-intents = [
-    {file = "pyobjc-framework-Intents-7.3.tar.gz", hash = "sha256:1220eeaad2849f7ba75f947c94343087f33495b678bf3bdb695a22ba23520a4d"},
-    {file = "pyobjc_framework_Intents-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:b6ac38cb878cce0caac161e2529ae79c82eac2a658e0323da52df8626fe94cbe"},
-    {file = "pyobjc_framework_Intents-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:e25038fbf70c1b3f55c17067601f28d06745e9fb6874e7a03672c5639ee0fd70"},
+    {file = "pyobjc-framework-Intents-8.2.tar.gz", hash = "sha256:d079853babcb4e35e6a077f6498f58d603fae5373763f245fc5ca61b55fd9439"},
+    {file = "pyobjc_framework_Intents-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:bae596bba41bf97ec2b030f2220f9dea3e5e0a31ce457fed3d2e4085a88815a5"},
+    {file = "pyobjc_framework_Intents-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:e8282d923871834b8e8b584e03001ae14b6264276f43b4089d4f8e2e0224347b"},
+    {file = "pyobjc_framework_Intents-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:24682d275f62525bbd99237abc99fe32d742d25800c3931cc783d5a833c7d922"},
 ]
-pyobjc-framework-interfacebuilderkit = [
-    {file = "pyobjc-framework-InterfaceBuilderKit-7.3.tar.gz", hash = "sha256:5b6ce97e92cfadff4a95ba87bf6c355026af9698f2aa87fbfa0396286511ab44"},
-    {file = "pyobjc_framework_InterfaceBuilderKit-7.3-py2.py3-none-any.whl", hash = "sha256:7f0c3a1a15e7b818062b814b4e360f30cab2b7500b029107457187e0e2e3424b"},
+pyobjc-framework-intentsui = [
+    {file = "pyobjc-framework-IntentsUI-8.2.tar.gz", hash = "sha256:a22fa1bc5ed935d88b0f2e58a41ffd5e4861361d70f83a6e500d92c59af3f42d"},
+    {file = "pyobjc_framework_IntentsUI-8.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8ee5ba425a4a97686faf04b3d80cbf8f63f22b39e825d7c75bf16ef8fbbc8456"},
+    {file = "pyobjc_framework_IntentsUI-8.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:825030c30dc43e52cde053c0f55c8b448e4adb98989531d9c2c66f6b52df34d0"},
+    {file = "pyobjc_framework_IntentsUI-8.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b0f353eb8f2ce71bf599e38c68216a575ea6593b1b9ed4e1dcdd648681670b92"},
+    {file = "pyobjc_framework_IntentsUI-8.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:15750e32e92889957fcc74ef4dcfa5aa21983ead5ccd2bc7a29653172f32ee7e"},
+    {file = "pyobjc_framework_IntentsUI-8.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:a4e59ec8b6882334b52a13128e051060aa70ab98c13ee983d6df007629f0d252"},
+    {file = "pyobjc_framework_IntentsUI-8.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:cf943961473891331bd9fc8e2db672a18fc0ca59e8def391aa717354cbeed68a"},
 ]
 pyobjc-framework-iosurface = [
-    {file = "pyobjc-framework-IOSurface-7.3.tar.gz", hash = "sha256:bbaa566eb2972cfd44531875aefb7c0622f31743b4d85bd957348edc7eab21d5"},
-    {file = "pyobjc_framework_IOSurface-7.3-py2.py3-none-any.whl", hash = "sha256:28a02d8ade66ab6c02c64e002c92f4b5ac2b0590d7b0b3a0dcb57d415f44f4a1"},
+    {file = "pyobjc-framework-IOSurface-8.2.tar.gz", hash = "sha256:2e1ee1fdee5fec5060fb8f2c26aed250b2e41924007d141ef20d57d171270d59"},
+    {file = "pyobjc_framework_IOSurface-8.2-py2.py3-none-any.whl", hash = "sha256:70f500bb16df8c30b5fe589242060b675a8e6746414eb2f37f4a1e7adbc20090"},
 ]
 pyobjc-framework-ituneslibrary = [
-    {file = "pyobjc-framework-iTunesLibrary-7.3.tar.gz", hash = "sha256:340c5aa952871aa34a7dcad677fb537252d4ecedde499d88f89de0093b117ac3"},
-    {file = "pyobjc_framework_iTunesLibrary-7.3-py2.py3-none-any.whl", hash = "sha256:cac84e32b338fcc68ab80befc51460e9adc5181e19c4d07b319b50dde93c3cbc"},
+    {file = "pyobjc-framework-iTunesLibrary-8.2.tar.gz", hash = "sha256:cfdc7565bab8107de2b8435921f7abafd38abe351a60d9ed20113bef07849dba"},
+    {file = "pyobjc_framework_iTunesLibrary-8.2-py2.py3-none-any.whl", hash = "sha256:4010c752be4ab01ff4e8c228ef3a430d9714abbc57023e514662b4cb41f74858"},
 ]
 pyobjc-framework-kernelmanagement = [
-    {file = "pyobjc-framework-KernelManagement-7.3.tar.gz", hash = "sha256:7f04f73ec4dbaab3402f5c45b716ce35d34a595f9cf87bcb62573ee9beb2a00b"},
-    {file = "pyobjc_framework_KernelManagement-7.3-py2.py3-none-any.whl", hash = "sha256:d5efc836aac83df2f71e3e20f0e5ab877640897f79f81a65bb5e0c9a82023280"},
+    {file = "pyobjc-framework-KernelManagement-8.2.tar.gz", hash = "sha256:ebb434f2852626271e9157d8b8b00631b6f870dd1ade49a3173c5161edb37f4c"},
+    {file = "pyobjc_framework_KernelManagement-8.2-py2.py3-none-any.whl", hash = "sha256:76dd46f92d405e5a61f670d346a38e202b9dadab07cd3ffd7801c79c55b6269d"},
 ]
 pyobjc-framework-latentsemanticmapping = [
-    {file = "pyobjc-framework-LatentSemanticMapping-7.3.tar.gz", hash = "sha256:67abdb884a5114887d10c7528711eef9501843c14188a150c915339d796defd0"},
-    {file = "pyobjc_framework_LatentSemanticMapping-7.3-py2.py3-none-any.whl", hash = "sha256:f252083f5321222726597938685c31e9b53b6e6cd3db9c84a9b54426291bb0c5"},
+    {file = "pyobjc-framework-LatentSemanticMapping-8.2.tar.gz", hash = "sha256:e9492616d918a8b84ba00bdf08c68cbd70402922ad8aa0dcf323420a5f6c3f10"},
+    {file = "pyobjc_framework_LatentSemanticMapping-8.2-py2.py3-none-any.whl", hash = "sha256:7df04bb19c5651abfbf63e9be95aa9e3cef1f516134115c1cb7aee6991c97ff3"},
 ]
 pyobjc-framework-launchservices = [
-    {file = "pyobjc-framework-LaunchServices-7.3.tar.gz", hash = "sha256:53cdb7c7566b169c6c373512b8e5a6b3ad8cdf540ad56eb36c9a424e5228fb1b"},
-    {file = "pyobjc_framework_LaunchServices-7.3-py2.py3-none-any.whl", hash = "sha256:95bd4a68f4a5d098e2e4619d7d392753fa0978acba482384aaa441a6c82c4f6d"},
+    {file = "pyobjc-framework-LaunchServices-8.2.tar.gz", hash = "sha256:f92413bde4ded6f143f8ba84ddfc6f8f6bc942420512170c1556fa74b6397731"},
+    {file = "pyobjc_framework_LaunchServices-8.2-py2.py3-none-any.whl", hash = "sha256:14ca0323432e1ceede602c39f2c0e0583cd57489ddebf3831ca0b8d50aaabc95"},
 ]
 pyobjc-framework-libdispatch = [
-    {file = "pyobjc-framework-libdispatch-7.3.tar.gz", hash = "sha256:c3e63ce294e50a36c17bc9e65ccf3e448995931fc10fc0c15f899d27c438e25f"},
-    {file = "pyobjc_framework_libdispatch-7.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2262ab83c6236d168c4e595ecdb1973c1f845dd0dc21840f4a8ce6f900d7e357"},
-    {file = "pyobjc_framework_libdispatch-7.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:57acf9136ad53794c2303dc0f055491270cf70b85f89cef79493c09b60f60f59"},
-    {file = "pyobjc_framework_libdispatch-7.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be032ce5d05ac23e82c18a6d25459b45ceac3f3073949a439584a99fc26582a5"},
-    {file = "pyobjc_framework_libdispatch-7.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:69137492b4564d739f9b4eb56f8823a32fab47d13e809ca401b0c66240be929c"},
-    {file = "pyobjc_framework_libdispatch-7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7bc56539ac0761519d6f68149a012ed9b4250781156dbeeeeb8920146125222a"},
+    {file = "pyobjc-framework-libdispatch-8.2.tar.gz", hash = "sha256:fdb009bcac3c9d39bb4158cc61e4a7b9bf24b7e1b58b0cc2ccd038d359be371f"},
+    {file = "pyobjc_framework_libdispatch-8.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0484f326f1dc81a783f787cc5de4d89e5eecf3e6f5ccd3768649749f6715411a"},
+    {file = "pyobjc_framework_libdispatch-8.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:a4edbadb3b30c6de1a28be8af1d21b38ee1cedcc2f87ef59cd03af67e7d70a5a"},
+    {file = "pyobjc_framework_libdispatch-8.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:bed96b2a5ba0b5ca38c41762ec313e17081d441b5a6281e351646b4553877c2b"},
+    {file = "pyobjc_framework_libdispatch-8.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:93550d6dc1bdb1125fc585a6e472283015dbe25e0670f41e562f8cf826284bf7"},
+    {file = "pyobjc_framework_libdispatch-8.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:5d64fa528d7b9f20a6641c0266291afa91fb0e70cfba610e2fc9001c84ece586"},
+    {file = "pyobjc_framework_libdispatch-8.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:dd42f4b0e7b29e0510213087b1e242032b895044ad87728664d373460e032609"},
 ]
 pyobjc-framework-linkpresentation = [
-    {file = "pyobjc-framework-LinkPresentation-7.3.tar.gz", hash = "sha256:ba06355eedbbd83b703171d53d7cda2ff2294c4eb8ececd431a10683bf09bdbe"},
-    {file = "pyobjc_framework_LinkPresentation-7.3-py2.py3-none-any.whl", hash = "sha256:b0c572fab75789b5775d5ce941e4e1a53ebe438846996f148b12e1ba2b585e02"},
+    {file = "pyobjc-framework-LinkPresentation-8.2.tar.gz", hash = "sha256:7ab7eee1b1a2aa599735c68689a3f527ab45a141e310ae7322dceb7deeb7ec75"},
+    {file = "pyobjc_framework_LinkPresentation-8.2-py2.py3-none-any.whl", hash = "sha256:164925b549968fe543e25ea2e17279e98a6ae3b2174e94ca9dce2ee1c765e84b"},
 ]
 pyobjc-framework-localauthentication = [
-    {file = "pyobjc-framework-LocalAuthentication-7.3.tar.gz", hash = "sha256:0c7ac94f90e3e5e1797980dca08548f5e7ce38ba1578d10b45dd2b611c41183a"},
-    {file = "pyobjc_framework_LocalAuthentication-7.3-py2.py3-none-any.whl", hash = "sha256:3d2c7d7b945ec6b635a61adcb493bc5130abfbb7bbf2dc779ec7b7edba4efc72"},
+    {file = "pyobjc-framework-LocalAuthentication-8.2.tar.gz", hash = "sha256:bb105d9fb3c842f534b799c826e0006b76328c39291f52494dcc738b78042cef"},
+    {file = "pyobjc_framework_LocalAuthentication-8.2-py2.py3-none-any.whl", hash = "sha256:a4c484c821769933d1351a59670555a3d6c54378d346adfb30ad7a12775d43d6"},
+]
+pyobjc-framework-localauthenticationembeddedui = [
+    {file = "pyobjc-framework-LocalAuthenticationEmbeddedUI-8.2.tar.gz", hash = "sha256:88104257dac79c2072a07ac6e7c4421d21a914e7df78b7b852ea8cb10cd63e89"},
+    {file = "pyobjc_framework_LocalAuthenticationEmbeddedUI-8.2-py2.py3-none-any.whl", hash = "sha256:1ad0202c580adda66666f7118c5f97e69994ca05cdf769d2949312e3b5c65c57"},
+]
+pyobjc-framework-mailkit = [
+    {file = "pyobjc-framework-MailKit-8.2.tar.gz", hash = "sha256:2ec5c8a91f568c93bf20ee5897f936b71a232a2b5182762a46d46f62c5a78d69"},
+    {file = "pyobjc_framework_MailKit-8.2-py2.py3-none-any.whl", hash = "sha256:cfa559fe4da3cf9fc38740b96bcc5a556d919d2ba5b9069d438950860f9431de"},
 ]
 pyobjc-framework-mapkit = [
-    {file = "pyobjc-framework-MapKit-7.3.tar.gz", hash = "sha256:efb836c7a9e97c971cec4549043bfdbf4088164f75b177ac3de67a3a98817d2f"},
-    {file = "pyobjc_framework_MapKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:8b946a4b204895dd380a09e8bd28f543475714c3a5bf63913cd2436986d07932"},
-    {file = "pyobjc_framework_MapKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:0f9a95f2d6edac843de545df8d00280ef222ed8508ef4ee940a34d56d7b11352"},
+    {file = "pyobjc-framework-MapKit-8.2.tar.gz", hash = "sha256:0c5b20eb3ad8905bba7a64791a201f28d7627fc9421684291e1f3db245c95310"},
+    {file = "pyobjc_framework_MapKit-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:8952a192cd7653f70b8d3d518570cf9afb42eb89050d0522639989fcdf958113"},
+    {file = "pyobjc_framework_MapKit-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2af23353266549a8e6110895b86c39a846356f1478e0f6c74528180d72a51921"},
+    {file = "pyobjc_framework_MapKit-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:77f9c8fa8ea55e1099f8822ec905d2450433d3c13fe41eb8efc393da86c3aa30"},
 ]
 pyobjc-framework-mediaaccessibility = [
-    {file = "pyobjc-framework-MediaAccessibility-7.3.tar.gz", hash = "sha256:687403801f89805710c8de0a3a41811614e772776f19c9e041c06eb4fb529c24"},
-    {file = "pyobjc_framework_MediaAccessibility-7.3-py2.py3-none-any.whl", hash = "sha256:91b61f99521fea516affae23b0a208204b3326d5ad90b8cf32dac786287cb84f"},
+    {file = "pyobjc-framework-MediaAccessibility-8.2.tar.gz", hash = "sha256:a6b9a2d51bf371fe9b0b68a6a8966c27e367217823ad0beacd6353c4a9c461a6"},
+    {file = "pyobjc_framework_MediaAccessibility-8.2-py2.py3-none-any.whl", hash = "sha256:c9e50d85d49091dc8ec0e0bad8450de979b52406f25dc5a5193bf7557c6857ee"},
 ]
 pyobjc-framework-medialibrary = [
-    {file = "pyobjc-framework-MediaLibrary-7.3.tar.gz", hash = "sha256:d23b9f80ca63cd8e2471e64794df30231e1b71eb9f0259c986225b1a58face22"},
-    {file = "pyobjc_framework_MediaLibrary-7.3-py2.py3-none-any.whl", hash = "sha256:63449f7109d292c4179f169cb5e9c114141683c2a95ab260f870339f616f38d8"},
+    {file = "pyobjc-framework-MediaLibrary-8.2.tar.gz", hash = "sha256:e6e0cdf2ff07b5db3ccf99806663d2d44fc45be6aa0f6ad1871bee27ab4cf2d3"},
+    {file = "pyobjc_framework_MediaLibrary-8.2-py2.py3-none-any.whl", hash = "sha256:834140154b452342f7e42b16e046190db52f0ec1e6090f995e6b20d833c44c5f"},
 ]
 pyobjc-framework-mediaplayer = [
-    {file = "pyobjc-framework-MediaPlayer-7.3.tar.gz", hash = "sha256:76e3746cad7c1f0fa2f08ae3ba922316c634fc85c4c7616b573e79bd781c30be"},
-    {file = "pyobjc_framework_MediaPlayer-7.3-py2.py3-none-any.whl", hash = "sha256:e6133a4cc293b98e6f0c9ffff3aa2becf3cccc6c89b79a04ab976459f62be5dd"},
+    {file = "pyobjc-framework-MediaPlayer-8.2.tar.gz", hash = "sha256:df821e392723ec0f26bbe499663e065298bf22874930d6bf3562221564ad82c5"},
+    {file = "pyobjc_framework_MediaPlayer-8.2-py2.py3-none-any.whl", hash = "sha256:505104c8071454a0dcad7af5e094937e3d4f9e2b9c1cd707139ab480c080db06"},
 ]
 pyobjc-framework-mediatoolbox = [
-    {file = "pyobjc-framework-MediaToolbox-7.3.tar.gz", hash = "sha256:52013a09fc7d1cab5613d2044f14016f7b6b504c5ed50cca80894f93de59008e"},
-    {file = "pyobjc_framework_MediaToolbox-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:92ab0d38fb9036499399f27091f123d73f28618a1cda0b2eb6745f798843366b"},
-    {file = "pyobjc_framework_MediaToolbox-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:8a17cdb1a8d69b6104ff901cb335f085f6549b03de30d40fba319bf6ec1b8257"},
+    {file = "pyobjc-framework-MediaToolbox-8.2.tar.gz", hash = "sha256:4b5b476382297b9989c907cee308a52eae7bc400e7f499230fd6ea8a99de6653"},
+    {file = "pyobjc_framework_MediaToolbox-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:266776bede3b00eadcedc5dd2f14eca287c7ad2845254217b0090d2c41279885"},
+    {file = "pyobjc_framework_MediaToolbox-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:1451acfcfd1a181e25f2422a6e96c227b60ccb76a7737b4255dd879e3c31a31d"},
+    {file = "pyobjc_framework_MediaToolbox-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:4967d49f84a92869c4f915607e4c52c7f42b12c23d4f967f3bfe036e3be362a2"},
 ]
 pyobjc-framework-message = [
-    {file = "pyobjc-framework-Message-7.3.tar.gz", hash = "sha256:3a713a19357ebe26b6476489d5ff0c6ef3d9c477c40595d13d218dcf6ea9cc38"},
-    {file = "pyobjc_framework_Message-7.3-py2.py3-none-any.whl", hash = "sha256:c36e2e28e91bce78123ad35dc0e84a841d455b5974cb891fff15accc7c0cb49d"},
+    {file = "pyobjc-framework-Message-8.2.tar.gz", hash = "sha256:c1dce3fb5a937d48a5bea011143ea43b246aca126bd5c220dfb68356e8ffea35"},
+    {file = "pyobjc_framework_Message-8.2-py2.py3-none-any.whl", hash = "sha256:fd84c1d9c865fa9c7b9668abdea9bf21bdcdd38940931f006f99bd3c87eaed7a"},
 ]
 pyobjc-framework-metal = [
-    {file = "pyobjc-framework-Metal-7.3.tar.gz", hash = "sha256:249d996476cee9e8762839b16d6fcfedd4acd3195fe1ef436aa6e3806177db37"},
-    {file = "pyobjc_framework_Metal-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:1ad907a5432809eb807ebda843ed44b07d389d09d0c29a678ac88fee06558d56"},
-    {file = "pyobjc_framework_Metal-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:e69a7780edeab17fee4662e62f0a62c70c613051b27d3ac2813b2fc445ebee38"},
+    {file = "pyobjc-framework-Metal-8.2.tar.gz", hash = "sha256:bddd0930bffa259c3134d24a9ef6f34edcf473306ed2179b050b2080bf0b32a1"},
+    {file = "pyobjc_framework_Metal-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:fa5cec1fd4e4d5ce6f768380e69601bdf178f764e51152992e9c31325bdf4d72"},
+    {file = "pyobjc_framework_Metal-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:30f2c65f9a4c579871ac9a7ad378a91df2475e3d382e52a03c5cff17c28d6b01"},
+    {file = "pyobjc_framework_Metal-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:31806d0366ff92e1ff575114ae0d6d89fafd4de39c29ba0bfccd95b608b0fa4b"},
 ]
 pyobjc-framework-metalkit = [
-    {file = "pyobjc-framework-MetalKit-7.3.tar.gz", hash = "sha256:a834a881fef2f4986384423a3393ebd934719ca436e2e9df76519ef424162278"},
-    {file = "pyobjc_framework_MetalKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:7e6ed417fccd1d2467fa65ebb57770f621cf05ea6075462425de33434a3262e7"},
-    {file = "pyobjc_framework_MetalKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:37644b9a27f6ea481eb2d6f1db71b603c49e3789d62fdccb7dfe9c18d4eb84ad"},
+    {file = "pyobjc-framework-MetalKit-8.2.tar.gz", hash = "sha256:4ead7c6e6649bd393646b8405995ce4fe2663552d1570c2effa54ede722db07c"},
+    {file = "pyobjc_framework_MetalKit-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:d5566cbf4288e62e2346033909d823ea63f50ec7dcb7416d3bf0ad1987e186db"},
+    {file = "pyobjc_framework_MetalKit-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:461ba034c5fbaddab7e9bca0b53cc99c7464b96a2491fbd3fc94fbbee3229f15"},
+    {file = "pyobjc_framework_MetalKit-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:8d4cb3f638b5fccb594edb5ca8304058d94e0bf6aada38a5fc3ff06f29682bb6"},
 ]
 pyobjc-framework-metalperformanceshaders = [
-    {file = "pyobjc-framework-MetalPerformanceShaders-7.3.tar.gz", hash = "sha256:aab31f039b4236a7799cf36ea9343c04065856f0257b874e8bfd653d35069007"},
-    {file = "pyobjc_framework_MetalPerformanceShaders-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:e73270a94b6ae4500eb56d9ce8a7dd0484195314ed96196aaf9c6c23b72b0442"},
-    {file = "pyobjc_framework_MetalPerformanceShaders-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:d1a2d86a679a8db75ca35bd8f614430b7d8aa4de8e73205327abb140da917db2"},
+    {file = "pyobjc-framework-MetalPerformanceShaders-8.2.tar.gz", hash = "sha256:98540ca629d8d3323ce8a832c6b392bcbd70a63c094c19d61495a59b4e347b9c"},
+    {file = "pyobjc_framework_MetalPerformanceShaders-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:8c998cdd067ce7680288574577b7f1422b352d2aa4025dd3e74d5a00342283bf"},
+    {file = "pyobjc_framework_MetalPerformanceShaders-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c990d1407cb7033c38b45f7e01c6b24772b7acbec0792a80758aab453b45e99c"},
+    {file = "pyobjc_framework_MetalPerformanceShaders-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:f0c16f614f256689add709cc0d1a0fd29caec78747b85f18ee4aca7109377d47"},
 ]
 pyobjc-framework-metalperformanceshadersgraph = [
-    {file = "pyobjc-framework-MetalPerformanceShadersGraph-7.3.tar.gz", hash = "sha256:a81d957f0cfb7901ef6698d892df1432bd9d84bc2ef814319e91faf0663e0586"},
-    {file = "pyobjc_framework_MetalPerformanceShadersGraph-7.3-py2.py3-none-any.whl", hash = "sha256:432f4a542c1037c7fd65041d21d2e51684bea0649b308d0054e45c3d7df4176b"},
+    {file = "pyobjc-framework-MetalPerformanceShadersGraph-8.2.tar.gz", hash = "sha256:d53a24a900c0ce6c324cd8ff6b293f439b507b4d98816a0c409bcb785c32df99"},
+    {file = "pyobjc_framework_MetalPerformanceShadersGraph-8.2-py2.py3-none-any.whl", hash = "sha256:1e4b737b66f07420766a730876cfa895e2bf29fd710dfcd179ab5beca0bb33c1"},
+]
+pyobjc-framework-metrickit = [
+    {file = "pyobjc-framework-MetricKit-8.2.tar.gz", hash = "sha256:81aa2e692d2ffe0291ec1dc98e66c7cfe87cff56a77d3432a255793819d5a715"},
+    {file = "pyobjc_framework_MetricKit-8.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c23cda6fd737503a73acee2deecd9c5560e56d0195ca95c9c2bc51991834e945"},
+    {file = "pyobjc_framework_MetricKit-8.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:12e6b6bf064b02b83f45d17181de373d808f8d6fcd73fd31423d96488c63be5e"},
+    {file = "pyobjc_framework_MetricKit-8.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:21dbd2def63187afc224a23c30ace9a93edd43d266290f351df61a0be0da43f5"},
+    {file = "pyobjc_framework_MetricKit-8.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:5ebb35e98a924eb97681efda3c72178f61565b038128f85bbd265edd68f4c169"},
+    {file = "pyobjc_framework_MetricKit-8.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:9b980bca66e2ee6524fa9d492a0cd58032f4b460e08996552b9e1b7993e58b2e"},
+    {file = "pyobjc_framework_MetricKit-8.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:91c7a460feb5cb473de843e1ea8697e02a21b3211e4fb0d22c938b4849a0d564"},
 ]
 pyobjc-framework-mlcompute = [
-    {file = "pyobjc-framework-MLCompute-7.3.tar.gz", hash = "sha256:113c78b4decb48e6c46a8e8037476b26869a7ac4439ed7e83e5a92224ee39beb"},
-    {file = "pyobjc_framework_MLCompute-7.3-py2.py3-none-any.whl", hash = "sha256:c1d68f402d70751a18cda5d5644cbf808e7b5f38a568002de50cfbbea4604ec3"},
+    {file = "pyobjc-framework-MLCompute-8.2.tar.gz", hash = "sha256:c870d5fe8ed18fed0b57dea432d68fd121abf6e6c16f0175bfe5ea5eaaa74546"},
+    {file = "pyobjc_framework_MLCompute-8.2-py2.py3-none-any.whl", hash = "sha256:c1819667bc848736d3dc2246da2d6005858752804e559e9b1d9d6c66db2b20c1"},
 ]
 pyobjc-framework-modelio = [
-    {file = "pyobjc-framework-ModelIO-7.3.tar.gz", hash = "sha256:d151e5888300d533e23939df79be04563925fe9620d2698173b5e05b9e721678"},
-    {file = "pyobjc_framework_ModelIO-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:fae27754371cb8c20939cdf2cbb792aaf995633804d1fb51101f9f8c737c5d10"},
-    {file = "pyobjc_framework_ModelIO-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:095d10162aeb8810576506b02a3891056fdc12d1deac478f57bb633bc4af67bd"},
+    {file = "pyobjc-framework-ModelIO-8.2.tar.gz", hash = "sha256:78f83d6ebb40d13a8f6ce52e0a9d6e8df8a09225e6e13b3131e059980e026627"},
+    {file = "pyobjc_framework_ModelIO-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:9fec67b34cc81260de5a71ea178b021042a07a7c3d904e6dbed0ee080aeb6578"},
+    {file = "pyobjc_framework_ModelIO-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:0469e19b6ce1c2ec597a5d20b95961ebdd09ff1e45abe36a835b3614c0c629d1"},
+    {file = "pyobjc_framework_ModelIO-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:40f892f888da4c2c1edf1af6dba2d2b7ecab3f643e413e62a3779fea5dbdaa0a"},
 ]
 pyobjc-framework-multipeerconnectivity = [
-    {file = "pyobjc-framework-MultipeerConnectivity-7.3.tar.gz", hash = "sha256:a5b42dede182ad3e42d0e5bc764d55d3b75741383508f88c914d9559b8a6cfae"},
-    {file = "pyobjc_framework_MultipeerConnectivity-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:e3298250a9ab97cb1dda6010311c4c7aee79ca5642e52025b468608f4b97ce0c"},
-    {file = "pyobjc_framework_MultipeerConnectivity-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:a63ad18c91cde6c447c84bbcadc31ea054d027af5312e462d267746ceb6acdc1"},
+    {file = "pyobjc-framework-MultipeerConnectivity-8.2.tar.gz", hash = "sha256:ce58b5d37f764d5c231be822dd4af7404a6754c91e189b4fcdbb123893a7c328"},
+    {file = "pyobjc_framework_MultipeerConnectivity-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:29f74b3b47ea9faa60712dabdd0cfbaf9d8711220051b6a2fe9ad4ae6a06e60d"},
+    {file = "pyobjc_framework_MultipeerConnectivity-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:af5b53242ccdabfc090bed07bd893c3a4e4508a4a6b5510be100e3fdd984ae88"},
+    {file = "pyobjc_framework_MultipeerConnectivity-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:538af6e904046955cf8e0cac77a3e66cd3bcaece687e94bb647b256a2759bb37"},
 ]
 pyobjc-framework-naturallanguage = [
-    {file = "pyobjc-framework-NaturalLanguage-7.3.tar.gz", hash = "sha256:b48390651b857f6ed3fb3eeeb843f77cac033c32ad2bc367d4aeed17b63b1527"},
-    {file = "pyobjc_framework_NaturalLanguage-7.3-py2.py3-none-any.whl", hash = "sha256:a69dfdb67a9385aa37877046d42660f7da040beb182fd082dac6c203442911eb"},
+    {file = "pyobjc-framework-NaturalLanguage-8.2.tar.gz", hash = "sha256:74ac8340f40ca74b0991d529dc043989b85cf01c6dac6f130ff0e0e150b214bf"},
+    {file = "pyobjc_framework_NaturalLanguage-8.2-py2.py3-none-any.whl", hash = "sha256:ed4f1612408c274a7370ca886dad25e9fbf82137fba298c0dfe6324bf4cd19ac"},
 ]
 pyobjc-framework-netfs = [
-    {file = "pyobjc-framework-NetFS-7.3.tar.gz", hash = "sha256:a5f6fb8ab739c9466ba9a81e3a742f92a8808e6716385aa15078630110f2ca6f"},
-    {file = "pyobjc_framework_NetFS-7.3-py2.py3-none-any.whl", hash = "sha256:b48377bf8490f0ce2f78c7f6dbc8e280d7c8a58d73e64c2a888d3f951a991a58"},
+    {file = "pyobjc-framework-NetFS-8.2.tar.gz", hash = "sha256:a3cab73675bc6e0ce2b0ea6b7bd749c7af89004e261ccdc4cfa6b8efbd1a907f"},
+    {file = "pyobjc_framework_NetFS-8.2-py2.py3-none-any.whl", hash = "sha256:1463bf7db0cbdfc3fd1413d890c6ab7ef89ec0d05c20aae71922fa0a4349762b"},
 ]
 pyobjc-framework-network = [
-    {file = "pyobjc-framework-Network-7.3.tar.gz", hash = "sha256:c40fe885fcfc9e35680d81eb5a3b0bfc07e51b68039e928884da770bb0e45a78"},
-    {file = "pyobjc_framework_Network-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:094b2c63fcf1d29684fc2a0ab9c629620775ce1ac89026dbaafb22144e78304f"},
-    {file = "pyobjc_framework_Network-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:565761bada95e0d7912d4b2e5d17a201bb57be73321031a388bb301487a41b7d"},
+    {file = "pyobjc-framework-Network-8.2.tar.gz", hash = "sha256:8175fb7f8c687a4648de78897a9acce961cdf5bce5d28f8d9f54503b73cabda9"},
+    {file = "pyobjc_framework_Network-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:66d0a2bda6775d22a33f226b686da835fb6d8d5d052cd65052aed7ecdeaadc85"},
+    {file = "pyobjc_framework_Network-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:231b319a723b652baced62ac6453663cb1d1f192bb58cdd492a61e6ddbcd5b08"},
+    {file = "pyobjc_framework_Network-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:eb18120958eda7e5a0cc5844706bbd3055dfd953a4f956d105cd0d4925d9e688"},
 ]
 pyobjc-framework-networkextension = [
-    {file = "pyobjc-framework-NetworkExtension-7.3.tar.gz", hash = "sha256:0bd2422628be9848297aa58c3b53af2da5c4dac8022d55684dae37e0264bfcf7"},
-    {file = "pyobjc_framework_NetworkExtension-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:099044b5846c5097c0b71b53511c6e6de9db68dfd2ddd62dc1d4253ea60ec76d"},
-    {file = "pyobjc_framework_NetworkExtension-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:f3b37e0cc7ff7d8adb10d85bacea1a3883379f01bb77de1e9155bd4395ddae09"},
+    {file = "pyobjc-framework-NetworkExtension-8.2.tar.gz", hash = "sha256:4d135dd19ce73ed787f13ecc7081067177e535a8cc5b119781b4ca0247ac356a"},
+    {file = "pyobjc_framework_NetworkExtension-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:8340acba2017b120124224817b839261e11c095cbd3ae943085c68ae551b8e2c"},
+    {file = "pyobjc_framework_NetworkExtension-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:d329232bada44e6c8860c91ff82eee07ed6654d1ae77aa5efc4c87ec81f136f2"},
+    {file = "pyobjc_framework_NetworkExtension-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:b8bf83599898e2eb56d858008a3c1c7d3564109499402fba8fec65afbdefbccd"},
 ]
 pyobjc-framework-notificationcenter = [
-    {file = "pyobjc-framework-NotificationCenter-7.3.tar.gz", hash = "sha256:64866915bf4c20429fe27c2ab5ab86cab74fa0e557b24382c77a6a6d3d8878ea"},
-    {file = "pyobjc_framework_NotificationCenter-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:2186d4dcd6f56b567e72abc009b2c69f9bcb0ba42d61a987c057a257953a90be"},
-    {file = "pyobjc_framework_NotificationCenter-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:5765d0afb9716643d15ce52c66f3460898994b13084508c778c73430c8d2816d"},
+    {file = "pyobjc-framework-NotificationCenter-8.2.tar.gz", hash = "sha256:b561299eae8f17ceebb953fa73596759960c0a6583a870b63ce4ba4147c68533"},
+    {file = "pyobjc_framework_NotificationCenter-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:bf1809979b206921702b740587e9dc1edf7ca489abef06264c1a5bbbad470adf"},
+    {file = "pyobjc_framework_NotificationCenter-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b58bf85527e02baff61c41d4e016d7a982264b65939be66e26cf8c6c92544734"},
+    {file = "pyobjc_framework_NotificationCenter-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:f2050ccbe9008b1aa8d8e667bb2e0154da4e8bc49600b34d776dd84b42aeb64b"},
 ]
 pyobjc-framework-opendirectory = [
-    {file = "pyobjc-framework-OpenDirectory-7.3.tar.gz", hash = "sha256:2e60807e4385a0c781f4535af733a0ff38fc2c4fd29cb0622c0829b0e4ae34ac"},
-    {file = "pyobjc_framework_OpenDirectory-7.3-py2.py3-none-any.whl", hash = "sha256:fc12ec43d0faa7e83c45870ad5e58062a7299571bede4463a790a6e4bedaa5c4"},
+    {file = "pyobjc-framework-OpenDirectory-8.2.tar.gz", hash = "sha256:a218ae75bae3c0b493f53d7dfafa891a8348b82d82baaa091084269d23c188f8"},
+    {file = "pyobjc_framework_OpenDirectory-8.2-py2.py3-none-any.whl", hash = "sha256:cfc04eac8df2456b11afdfff49754bd605e3e9811632507032d18e96993dd0fe"},
 ]
 pyobjc-framework-osakit = [
-    {file = "pyobjc-framework-OSAKit-7.3.tar.gz", hash = "sha256:eff377c2c5c8f498ee4522aff406dac17381fe88bf93bad474ba92f77cff6082"},
-    {file = "pyobjc_framework_OSAKit-7.3-py2.py3-none-any.whl", hash = "sha256:5e8ab0fb3c5ebd10cd1d2a1496e4517110f119e6947556546dc8121ba4d2f730"},
+    {file = "pyobjc-framework-OSAKit-8.2.tar.gz", hash = "sha256:29d8450c7fbc1884df41a1eca28d54baec9089d7d6a4dbfc07be281012678919"},
+    {file = "pyobjc_framework_OSAKit-8.2-py2.py3-none-any.whl", hash = "sha256:976a648f1e10b5df79faef526af845b92d4176627382f3df7d2eca9869226771"},
 ]
 pyobjc-framework-oslog = [
-    {file = "pyobjc-framework-OSLog-7.3.tar.gz", hash = "sha256:251afa4a571f03a73b48807e95972eda9016746c08d55dcffad72454db485f86"},
-    {file = "pyobjc_framework_OSLog-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:734d1662b781e69e6096d24d908c52211ba3a54f97a21e30e5f22737269e709e"},
-    {file = "pyobjc_framework_OSLog-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:102ac6b834fc5e28f9c81f9760389d8d431001ecd12942d4464c24680084c09f"},
+    {file = "pyobjc-framework-OSLog-8.2.tar.gz", hash = "sha256:a8143cb63ea0dae23586c32aa781c056756ee3774895fa1f78e9be218921868d"},
+    {file = "pyobjc_framework_OSLog-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:1d57c9f011427b5ae2aa5d756cc2a587abb795a054d95680de031ae41d67d9e8"},
+    {file = "pyobjc_framework_OSLog-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:d4144b90cb0e47b9c371efa5d8672c359c35997ab256968d82ddeb3d37b76aa9"},
+    {file = "pyobjc_framework_OSLog-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:86693021897a75e126f5423f9fe67ab1f8934bc808574de10aa1aed66ff1fac2"},
 ]
 pyobjc-framework-passkit = [
-    {file = "pyobjc-framework-PassKit-7.3.tar.gz", hash = "sha256:10548941a9139bdd4469aeece4bb0aad7c5c28f57a19c54d7d78af6e779c5016"},
-    {file = "pyobjc_framework_PassKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:15fd2f0675428a40b0a64d672d3f33b8c708e13217cb3473c48d969d39d47c8f"},
-    {file = "pyobjc_framework_PassKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:1e80b0b52d4fec532c5d3d9065a5a14f731a35270038058be4f45be915ab2759"},
+    {file = "pyobjc-framework-PassKit-8.2.tar.gz", hash = "sha256:6faad7f72b094e47645dc53afdabf6a43b969a45901c3636418fe6456277535c"},
+    {file = "pyobjc_framework_PassKit-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:ac2eb5e03c2aee81c45a834a44c927c381bc689f1c58d9b1d52d6866cca21934"},
+    {file = "pyobjc_framework_PassKit-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:56467d9f2d75cd849343ee6dfabc10baba0ad38c5279c111dcdc13d6301c067c"},
+    {file = "pyobjc_framework_PassKit-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:561b28232cd53049a9373ab604735ecc0725f8499f9f7e6df7a3c48b96ecb8a0"},
 ]
 pyobjc-framework-pencilkit = [
-    {file = "pyobjc-framework-PencilKit-7.3.tar.gz", hash = "sha256:b2c12217c742e5acbffeb8d8b27f8a684ddfdbd0ade617db0865ae3c1955368a"},
-    {file = "pyobjc_framework_PencilKit-7.3-py2.py3-none-any.whl", hash = "sha256:4a065cb1dcd9ca92818fd045fc861f841b3204fb8ead95d2dda003553dbc0a47"},
+    {file = "pyobjc-framework-PencilKit-8.2.tar.gz", hash = "sha256:e86fec5d6d56bf1c8367fd599f6ce7210e95cfd993969832db25fb163651580b"},
+    {file = "pyobjc_framework_PencilKit-8.2-py2.py3-none-any.whl", hash = "sha256:e47223838bd852be17ec6a267b54e0aea572816e5d865a073d4d4901fce7f17d"},
 ]
 pyobjc-framework-photos = [
-    {file = "pyobjc-framework-Photos-7.3.tar.gz", hash = "sha256:cf96b97b94f3f3c922966fa7637436adcfb72c24acd3a21bda327fd151e8b4f1"},
-    {file = "pyobjc_framework_Photos-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:835465b9be2c65afb13bad3b16056321b454c152426af1f3e05ec37165166c7f"},
-    {file = "pyobjc_framework_Photos-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:69d755187ec2e57a5005c49fb7f0aadbe4a6b1782c1a40c46a06762379deb51e"},
+    {file = "pyobjc-framework-Photos-8.2.tar.gz", hash = "sha256:198a182713e5b228b71dab1a23bb330db59eae8e221b182d1f53562efb4de225"},
+    {file = "pyobjc_framework_Photos-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:8166a1193a574a0c7ee2f307ae358f48706eae8ee922541dba5f4f1150c44f51"},
+    {file = "pyobjc_framework_Photos-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:e47c5e3edfbc4df4a31b034c9bfd00c6a80d14742e4549dc3875073137e6e466"},
+    {file = "pyobjc_framework_Photos-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:6cb84698a5e9cbb70be5d4c36f71ee2bbaeedf35bb586e70216a23dc2b15f477"},
 ]
 pyobjc-framework-photosui = [
-    {file = "pyobjc-framework-PhotosUI-7.3.tar.gz", hash = "sha256:34da58779d560949e9443ea79b26f36deb6e2a6ab17a8fc4f4d39d0190ba87a8"},
-    {file = "pyobjc_framework_PhotosUI-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:e2f879d61e81e281770a681e3f5e9c38b61a051400ca45b3cf4abc5680bf1e8b"},
-    {file = "pyobjc_framework_PhotosUI-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b8e0839b5907619cc4071b012bcc942372be0ce0e6bfa63e32537faa6b48a620"},
+    {file = "pyobjc-framework-PhotosUI-8.2.tar.gz", hash = "sha256:6dbf14ee360e2d2ab8bf6cfae2338411624010d2d62f79424cf4797445031cb5"},
+    {file = "pyobjc_framework_PhotosUI-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:7c14a0d901218a56f1fd088673a6febd51283713afd20d1d9dc4523758a061d3"},
+    {file = "pyobjc_framework_PhotosUI-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:1a1570197a3a66989952a23bdc3b67836b94879609785a7a309bfa392f04393d"},
+    {file = "pyobjc_framework_PhotosUI-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:303fe159494f54814b2e06f552540eaa309ce51541caa2683cdbdf575830203f"},
 ]
 pyobjc-framework-preferencepanes = [
-    {file = "pyobjc-framework-PreferencePanes-7.3.tar.gz", hash = "sha256:8aa2710d96d3d18f637ba53748225ed47ebc474fd0874cf8734c25d9c69f48f3"},
-    {file = "pyobjc_framework_PreferencePanes-7.3-py2.py3-none-any.whl", hash = "sha256:cf8cd47f615cce6b29da8ba4b44962b92aaebd27dcf20168e20999ababc25a81"},
+    {file = "pyobjc-framework-PreferencePanes-8.2.tar.gz", hash = "sha256:d8e50a059188bf85c47bc57aa0310a67d2f98b993e09740cc8afd9f1f04505f4"},
+    {file = "pyobjc_framework_PreferencePanes-8.2-py2.py3-none-any.whl", hash = "sha256:aabe1d2d5d09f0a385f0d6623506b27f8101b5f521fd5500d6dcbb4f5a3af802"},
 ]
 pyobjc-framework-pubsub = [
-    {file = "pyobjc-framework-PubSub-7.3.tar.gz", hash = "sha256:1499e884b9b1e3fc8ced0e33fe6a4619af00359622969c45263d4192478edada"},
-    {file = "pyobjc_framework_PubSub-7.3-py2.py3-none-any.whl", hash = "sha256:cb7d6aac043446d654268e8b04fb2c0eed5c0f2d1d7e146812dd9a9f60f962cc"},
+    {file = "pyobjc-framework-PubSub-8.2.tar.gz", hash = "sha256:3daa26df9cd01550ab63471e37c359ce759237331152bf89a966fcf77357b822"},
+    {file = "pyobjc_framework_PubSub-8.2-py2.py3-none-any.whl", hash = "sha256:10352ae5458533da54a5ff21d4a1850c549bf2e5e3b86ff409caded1dd9d1c39"},
 ]
 pyobjc-framework-pushkit = [
-    {file = "pyobjc-framework-PushKit-7.3.tar.gz", hash = "sha256:063579734da899a19fd0b67f75085c2b4c2295793889594a66dcdb2a5bd8fd9a"},
-    {file = "pyobjc_framework_PushKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:8cf280fc616dfc01072b774803b59ab2d444223f8fa53e8c3750bcff3f1fd63d"},
-    {file = "pyobjc_framework_PushKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:6dcf7c040727932ea68faf6509c06b7e505c1b4489114f3ba0d79267c9288ca4"},
+    {file = "pyobjc-framework-PushKit-8.2.tar.gz", hash = "sha256:a3a9ef31c1a679c5052c231bf01a2f293f1a067298f5761b0caa53848113160e"},
+    {file = "pyobjc_framework_PushKit-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:ee696b600db912fad31fd37988bd67cc7321674d398bfe12fa048e09d2f8eda8"},
+    {file = "pyobjc_framework_PushKit-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9ec89b9322bddd44984c78ebbb7eddb4359cec163e49e6c2c04826b77b07c3dc"},
+    {file = "pyobjc_framework_PushKit-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:07f33aa3af7c19b82c43e4fc084747af57048047b2df2a79ca84c2ed23caa594"},
 ]
 pyobjc-framework-quartz = [
-    {file = "pyobjc-framework-Quartz-7.3.tar.gz", hash = "sha256:98812844c34262def980bdf60923a875cd43428a8375b6fd53bd2cd800eccf0b"},
-    {file = "pyobjc_framework_Quartz-7.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1ef18f5a16511ded65980bf4f5983ea5d35c88224dbad1b3112abd29c60413ea"},
-    {file = "pyobjc_framework_Quartz-7.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3b41eec8d4b10c7c7e011e2f9051367f5499ef315ba52dfbae573c3a2e05469c"},
-    {file = "pyobjc_framework_Quartz-7.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2c65456ed045dfe1711d0298734e5a3ad670f8c770f7eb3b19979256c388bdd2"},
-    {file = "pyobjc_framework_Quartz-7.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:8ddbca6b466584c3dc0e5b701b1c2a9b5d97ddc1d79a949927499ebb1be1f210"},
-    {file = "pyobjc_framework_Quartz-7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7aba3cd966a0768dd58a35680742820f0c5ac596a9cd11014e2057818e65b0af"},
+    {file = "pyobjc-framework-Quartz-8.2.tar.gz", hash = "sha256:219d8797235bf071723f8b0f30a681de0b12875e2d04ae902a3a269f72de0b66"},
+    {file = "pyobjc_framework_Quartz-8.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e5ab3117201a494b11bb1b80febf5dd288111a196b35731815b656ae30ee6ce3"},
+    {file = "pyobjc_framework_Quartz-8.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:4941b3039ab7bcf89cb4255c381358de2383c1ab45c9e00c3b64655f271a3b32"},
+    {file = "pyobjc_framework_Quartz-8.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:ab75a50dea84ec794641522d9f035fc6c19ec4eb37a56c9186b9943575fbc7ab"},
+    {file = "pyobjc_framework_Quartz-8.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8cb687b20ebfc467034868b38945b573d1c50f237e379cf86c4f557c9766b759"},
+    {file = "pyobjc_framework_Quartz-8.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:8b5c3ca1fef900fa66aafe82fff07bc352c60ea7dceed2bb9b5b1db0957b4fea"},
+    {file = "pyobjc_framework_Quartz-8.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7bca7e649da77056348d71032def44e345043319d71b0c592197888d92e3eec1"},
 ]
 pyobjc-framework-quicklookthumbnailing = [
-    {file = "pyobjc-framework-QuickLookThumbnailing-7.3.tar.gz", hash = "sha256:2308898f9c94370a99ab17fde0b713da0c9449ac22163cdb15e51a539834c3c7"},
-    {file = "pyobjc_framework_QuickLookThumbnailing-7.3-py2.py3-none-any.whl", hash = "sha256:699962a6c10168e7d59ec8467ef63fc0d50342545eb899215823551e4845040f"},
+    {file = "pyobjc-framework-QuickLookThumbnailing-8.2.tar.gz", hash = "sha256:73c8b0158cec5c19afdefe450bad73204d8f24a4f9e8eb7a151a22779de0df26"},
+    {file = "pyobjc_framework_QuickLookThumbnailing-8.2-py2.py3-none-any.whl", hash = "sha256:91e4ba23cec0eb2b5150f84e79fad287f94fc2ddb7282e70c3b6f0ad32fd545c"},
 ]
 pyobjc-framework-replaykit = [
-    {file = "pyobjc-framework-ReplayKit-7.3.tar.gz", hash = "sha256:aec8f34fbbeb7aca9b4f1b285a4f2119035e4100249b8a64e84b144bb47a650d"},
-    {file = "pyobjc_framework_ReplayKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:4f85103fcbf10e09504405c58879637641d1112d165997e8c1a7825c7d90c75f"},
-    {file = "pyobjc_framework_ReplayKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:0457177b6bc5a2d88e7015a33835fea98d5d73e1c36e8fb78c8a88f6927058ff"},
+    {file = "pyobjc-framework-ReplayKit-8.2.tar.gz", hash = "sha256:6c2e32aa260caa2e79a62d8f3f06b1e87423bdb30cb4dfe794a22ed44a8e38ae"},
+    {file = "pyobjc_framework_ReplayKit-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:e3ec60c205821c7efc9c767f200465049fc39f0c77908e4573dad370ad7c1dd0"},
+    {file = "pyobjc_framework_ReplayKit-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9db07b0ba09d9a1ddcfe7ce2e91e7160852edab5cf3e82bb874dcce7722ac88c"},
+    {file = "pyobjc_framework_ReplayKit-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:98d8e9c0f9e73358e0271546596ffd01759666f24b39d297ea729edec2dcf8e9"},
 ]
 pyobjc-framework-safariservices = [
-    {file = "pyobjc-framework-SafariServices-7.3.tar.gz", hash = "sha256:fd3d6878f0fd80a03ff343f8379af8060e5f33058ce279047ecb6e12304216cb"},
-    {file = "pyobjc_framework_SafariServices-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:5544485ddb68aa617a16a42200f345be95ef209af1a82a2f89a9d281b327219e"},
-    {file = "pyobjc_framework_SafariServices-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ee66f939d96b853b70dda6e2b24b7b59dbc17ce10ffa225de3a1d124ba9fb784"},
+    {file = "pyobjc-framework-SafariServices-8.2.tar.gz", hash = "sha256:58e1986dfd7f4eb920f12d651453f00bf284bc8c614404477bd1bf78151060b2"},
+    {file = "pyobjc_framework_SafariServices-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:4b886a0f67b13fea14cd84cf4d7107a71755a0e8e33fc4a75e04b2009c3b6ba7"},
+    {file = "pyobjc_framework_SafariServices-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:59193a4ff543c90989c6f78e065eb5b9b9f5f66ad4b1ddb48ffb8b488177bc66"},
+    {file = "pyobjc_framework_SafariServices-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:3ac2e032792675fdff92eba59c47aceb9b12eacde64a3e9f36d565c80740a5b3"},
 ]
 pyobjc-framework-scenekit = [
-    {file = "pyobjc-framework-SceneKit-7.3.tar.gz", hash = "sha256:4adc7e82784f5277f24305c08761936a329020f664fb7da4dc9b9b7a64990b1a"},
-    {file = "pyobjc_framework_SceneKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:977fa65fcf5d8012b0d7c8f3d7a2bd9aa7c685a83b6850d74faddab04e6fdab3"},
-    {file = "pyobjc_framework_SceneKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:14d2c4af8324e34c71d1fdb5a1af4c85b644c7142d61ebb30b495e12edd068e1"},
+    {file = "pyobjc-framework-SceneKit-8.2.tar.gz", hash = "sha256:76c5ebc654d2da069a8e6bb3bb36b36cb3ae50858bca32b467eeda88b6cd2dc8"},
+    {file = "pyobjc_framework_SceneKit-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:d58da3b12c1ec2328c4fe8990b5857b102ba5bd64711b295d6c169322f675b79"},
+    {file = "pyobjc_framework_SceneKit-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2541708c48930c43b2542cb0c39d4168b9a4ed2e567b2b7c377eabcb87bfee5a"},
+    {file = "pyobjc_framework_SceneKit-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:eb14e13cfdee50ecc1de83dc693b4999dfd5770c24ca5ef4c3ac5f19046d428c"},
 ]
 pyobjc-framework-screensaver = [
-    {file = "pyobjc-framework-ScreenSaver-7.3.tar.gz", hash = "sha256:b4d13cc2d54675893aed6d2fa60cf8d134fa821e9cce7b224756fa3e260a548f"},
-    {file = "pyobjc_framework_ScreenSaver-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:9bbb9ef9db8c73bbdb92c5ddca21e64f2f414b2e50dab3f143539834b11982d0"},
-    {file = "pyobjc_framework_ScreenSaver-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed8968225a6a84249cd984baeb09b03ac372c03195f99114673400ec617ccb8e"},
+    {file = "pyobjc-framework-ScreenSaver-8.2.tar.gz", hash = "sha256:0029d46cc732809f23e9dda058484817bcf0d6bd658b0ba0e40e8fd7fedc7da2"},
+    {file = "pyobjc_framework_ScreenSaver-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:c6706b8bc59ee9d8e787ea0a9829dd50bd5d83d1c5614d4cd44e8bb64cef9e9d"},
+    {file = "pyobjc_framework_ScreenSaver-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9420eb1035fd5e989e4a33809287b5898cb60aa957d8d61744c5c1091d90d621"},
+    {file = "pyobjc_framework_ScreenSaver-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:b5acf41b1f2592a2267b9d377d521cc191c4fb290088f1544edf1992ff118d94"},
 ]
 pyobjc-framework-screentime = [
-    {file = "pyobjc-framework-ScreenTime-7.3.tar.gz", hash = "sha256:96f25c23321f92eb4da9a75e10d778484e5a99e74e14971783354a5047f765ea"},
-    {file = "pyobjc_framework_ScreenTime-7.3-py2.py3-none-any.whl", hash = "sha256:7dbb5225ccf97ef809a147ad1785b45aba3e76d7a8e0aceac92e7293ae680fc5"},
+    {file = "pyobjc-framework-ScreenTime-8.2.tar.gz", hash = "sha256:dc8606a9da79e59597a6949698e9c17e895a2b845497378c5d6b26175a9c5c7f"},
+    {file = "pyobjc_framework_ScreenTime-8.2-py2.py3-none-any.whl", hash = "sha256:66e7cf31acae440c6b5b051b73a3aa643e8aff5bbce1e5a628fe4ed2fbf37b3d"},
 ]
 pyobjc-framework-scriptingbridge = [
-    {file = "pyobjc-framework-ScriptingBridge-7.3.tar.gz", hash = "sha256:f09f4cad708d3c946bbcf7fdc5e623bbb512e4e0b085536fc22fe1131b517ca9"},
-    {file = "pyobjc_framework_ScriptingBridge-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:903d70ed128709e3be06c033cc6c421b26658f67dc628b92e6190b1fd1150e59"},
-    {file = "pyobjc_framework_ScriptingBridge-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b8f071751845253469d7a2cd8e2fae9c35ea0015789030e1ad1b958fb53dc82f"},
+    {file = "pyobjc-framework-ScriptingBridge-8.2.tar.gz", hash = "sha256:d895743d64aff255ac331151b7add8d38c1337e5cefb064e17de09fc06d54cb2"},
+    {file = "pyobjc_framework_ScriptingBridge-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:a2c9b71ac5ce8c1414a1c9214d17def03ff8e404b50bb029850fe19ca09e8a90"},
+    {file = "pyobjc_framework_ScriptingBridge-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:7e26ee6dee140b355f4e3ccaeda232e3de2893125ff3433c7c9f74286fa815de"},
+    {file = "pyobjc_framework_ScriptingBridge-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:0b75d7ba3e5ccd3a206d570a0a4c2ceda3cf8235e65b85f4c57d1fbb126a335b"},
 ]
 pyobjc-framework-searchkit = [
-    {file = "pyobjc-framework-SearchKit-7.3.tar.gz", hash = "sha256:80fc90c95cf14a0f4cc589764f329211e20e02f51840e880c802603c9dc41497"},
-    {file = "pyobjc_framework_SearchKit-7.3-py2.py3-none-any.whl", hash = "sha256:9619b301411b2d0f9436758691b8f4dae8bf8b95a85fd6c66a422cfd15750943"},
+    {file = "pyobjc-framework-SearchKit-8.2.tar.gz", hash = "sha256:1a66deadd30eaa7cd87f9f40803fbb9c046b7fa6a3b4f418685b9c0708188e84"},
+    {file = "pyobjc_framework_SearchKit-8.2-py2.py3-none-any.whl", hash = "sha256:b42d2b410a176a948f53cd14cdbd20e9a9d2e3e99eb727e98d2b180d7d1c62b1"},
 ]
 pyobjc-framework-security = [
-    {file = "pyobjc-framework-Security-7.3.tar.gz", hash = "sha256:4109ab15faf2dcf89646330a4f0a6584410d7134418fae0814858cab4ab76347"},
-    {file = "pyobjc_framework_Security-7.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1a048e42ddca426ac02838e8f4093f138b1fd88f9de8c3c5f087fbaa60cd1987"},
-    {file = "pyobjc_framework_Security-7.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:77d0c4b68d1409719f7bc023719b1f1a066e48f270bcfedb700b342523b191be"},
-    {file = "pyobjc_framework_Security-7.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:379287b0a01abc047bee7d2632fa34f038faa8f566c3de6978141bfcf3fc6128"},
-    {file = "pyobjc_framework_Security-7.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:966a59f59b57da0cbea0b9d0e59bae0d61e631b5cd0a336982e50705dfaf37a5"},
-    {file = "pyobjc_framework_Security-7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b6bd5ba1443f2c7d47fa9f4e1257e7e32e00f452a251b5955fa2ba03c032c11d"},
+    {file = "pyobjc-framework-Security-8.2.tar.gz", hash = "sha256:05224fef5c7d6cd25eccb8fba4a1552e07764ce6a1243e15a9974a72f5c9a190"},
+    {file = "pyobjc_framework_Security-8.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:417dbed30c609aee89c925cff97f5338b975478c67ddeb5071e56de044c3bbdb"},
+    {file = "pyobjc_framework_Security-8.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:a24062605b498c937dac77219963ad19557812db209ed36392d1ec04d8280129"},
+    {file = "pyobjc_framework_Security-8.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c80f66bcfd8f1552df89df4e91c50d1c9918effc516effa2334a599ddd4f2575"},
+    {file = "pyobjc_framework_Security-8.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c37ad5487357587bf82bafeecf87f744918951cd3440bb6e5522f8512c98c5e1"},
+    {file = "pyobjc_framework_Security-8.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:6090d842ca0f375d73c055374438b5af0d4903905a9699578d2b3472b6ac964e"},
+    {file = "pyobjc_framework_Security-8.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:8afd84fcb60bc6ca7647620d1f1b17d1a832cba18419f9d491b728c305ecade3"},
 ]
 pyobjc-framework-securityfoundation = [
-    {file = "pyobjc-framework-SecurityFoundation-7.3.tar.gz", hash = "sha256:b37b2ebc737cf79dece2afadaeb1a93a2a1346280f38ffe4baa7681a9c3298ce"},
-    {file = "pyobjc_framework_SecurityFoundation-7.3-py2.py3-none-any.whl", hash = "sha256:f7518fa4be99e4dac5c967fcf190777fc54f6c9f1e1917222f7d3f073ad19d7f"},
+    {file = "pyobjc-framework-SecurityFoundation-8.2.tar.gz", hash = "sha256:a3c5f1a5065e806ac692feeb568d247fab7163e4cf13906073f1d2c6a763fbd3"},
+    {file = "pyobjc_framework_SecurityFoundation-8.2-py2.py3-none-any.whl", hash = "sha256:77d7745b7c2a251bd7e54ba79db01a761804d4a12689493c4790faa8b37de9ae"},
 ]
 pyobjc-framework-securityinterface = [
-    {file = "pyobjc-framework-SecurityInterface-7.3.tar.gz", hash = "sha256:e240be5bd5de8783bd98a36018a51a104a267459ce527af8b28b22f66ee299ce"},
-    {file = "pyobjc_framework_SecurityInterface-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:da76ffd44a26cf56a194cbc02bf28ef71753ad8ce2beb69a1281fa71d6f6e246"},
-    {file = "pyobjc_framework_SecurityInterface-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:7aae7ca82bad629ef620f99b5c696bd011bec5354d29c933715dc49e9a19536b"},
+    {file = "pyobjc-framework-SecurityInterface-8.2.tar.gz", hash = "sha256:57109525bd2800645be48a857b022c4780a64410a8a323c5b0ecdffebe3ac37b"},
+    {file = "pyobjc_framework_SecurityInterface-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:3eadc9c478a30f382d83fdf4d75633d1ceb2b15d9beb95c70165fe78f7629464"},
+    {file = "pyobjc_framework_SecurityInterface-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:6e10bf2269f041df63d3bf7bf95dec99d555f83f6f064c599abdf3bd5dbfbc94"},
+    {file = "pyobjc_framework_SecurityInterface-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:4984ce7ecff886bd42869307ed7cb58d0195c93f08d6b7c32af3aed218e3a604"},
 ]
 pyobjc-framework-servernotification = [
-    {file = "pyobjc-framework-ServerNotification-7.3.tar.gz", hash = "sha256:aa8ba576a020a567016d36c6ce5fd9f6f8bd0f93c2bfb2b07420eb54ba514cd8"},
-    {file = "pyobjc_framework_ServerNotification-7.3-py2.py3-none-any.whl", hash = "sha256:40e0ec87d69b0c27d9be07ee0265eca9a4a9fad5b7ffa2e66bdcf189f86b4561"},
+    {file = "pyobjc-framework-ServerNotification-8.2.tar.gz", hash = "sha256:2ef559453ff5502f6e0a9c9f3467814a1d261c07465eef4f2abc4a26fb86b6ca"},
+    {file = "pyobjc_framework_ServerNotification-8.2-py2.py3-none-any.whl", hash = "sha256:9c38c74e8c707b5c0ac5f974666545804ef60b00846fddeb3ba864c97787cbfa"},
 ]
 pyobjc-framework-servicemanagement = [
-    {file = "pyobjc-framework-ServiceManagement-7.3.tar.gz", hash = "sha256:f3106b96347c7bf60045ffaee917235442cd1d9254a03e10f9bc648ccbbc3b55"},
-    {file = "pyobjc_framework_ServiceManagement-7.3-py2.py3-none-any.whl", hash = "sha256:9fff8afbcb69c5509485c9df457b79ee7c79850e9099964458f5fc921a4f3b8f"},
+    {file = "pyobjc-framework-ServiceManagement-8.2.tar.gz", hash = "sha256:4a7aaff29a6f5bff5c08164fd66988da50730f344ac38c366a7dc3262d94c92e"},
+    {file = "pyobjc_framework_ServiceManagement-8.2-py2.py3-none-any.whl", hash = "sha256:ee984fc6a832f10e394856370d2bcd05a2385165b382f1b832310497bf41112f"},
+]
+pyobjc-framework-shazamkit = [
+    {file = "pyobjc-framework-ShazamKit-8.2.tar.gz", hash = "sha256:d68aa40ba309c05c474462732bc717b4a98ea0c37adb0f5c5121c98f666d12fd"},
+    {file = "pyobjc_framework_ShazamKit-8.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7bc02e25f867ff8b36b112b8c11552e8cd25b781992ef937ac0915d4756670ce"},
+    {file = "pyobjc_framework_ShazamKit-8.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:651532c931352c10f810b7bb11e2d300a021274f21fe2e300f76de15c84762d3"},
+    {file = "pyobjc_framework_ShazamKit-8.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:ecbbd5d159fc02aa68701c3b949729872ddc0cd1c0061606d218648fdfa2b827"},
+    {file = "pyobjc_framework_ShazamKit-8.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d45626d4963c71d7407a7b58f3a79e1e16e91b6f3bc81fb707112cff9fc88c83"},
+    {file = "pyobjc_framework_ShazamKit-8.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:55e7c25bcf3e7f3bf7298a5d7bc9473e4f634900990675290cd12f47ce450073"},
+    {file = "pyobjc_framework_ShazamKit-8.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2598aaa48250c22a8e92c1b0e6eea819f9786b519436b7451dcb02223eacb3c4"},
 ]
 pyobjc-framework-social = [
-    {file = "pyobjc-framework-Social-7.3.tar.gz", hash = "sha256:bc6f5e1566ae47d2083d9dc9d0903210b934e5abdc81a211f10ff0fa05df1e0d"},
-    {file = "pyobjc_framework_Social-7.3-py2.py3-none-any.whl", hash = "sha256:ba03559d4e6837e3454440011b1310b4f9f127faf7bb111f00b6572db8325770"},
+    {file = "pyobjc-framework-Social-8.2.tar.gz", hash = "sha256:f7ce4a94a6a55a8891b3a7ad4fd9971a368ea51bf5406e07cf0a5ea7131cfd46"},
+    {file = "pyobjc_framework_Social-8.2-py2.py3-none-any.whl", hash = "sha256:5cdca24110acf7c68bf0a30d1207351f20df9fe36ae831ac4568c988a80ac0ba"},
 ]
 pyobjc-framework-soundanalysis = [
-    {file = "pyobjc-framework-SoundAnalysis-7.3.tar.gz", hash = "sha256:702cd6a3ff022370421182244161310551fe4927aea20b89f66615c7abc859eb"},
-    {file = "pyobjc_framework_SoundAnalysis-7.3-py2.py3-none-any.whl", hash = "sha256:8c29f61010a53b2da7a9f394fc52618be1c3f30e4a2359958a574fbd4705ab31"},
+    {file = "pyobjc-framework-SoundAnalysis-8.2.tar.gz", hash = "sha256:0454f42f2bbff5dae637687a8485964b144832a05a1cb654e1c44b050fdc0857"},
+    {file = "pyobjc_framework_SoundAnalysis-8.2-py2.py3-none-any.whl", hash = "sha256:af3524cc409b66d5b1260713e0f73f05f30732bdce615bde79854748dea4b961"},
 ]
 pyobjc-framework-speech = [
-    {file = "pyobjc-framework-Speech-7.3.tar.gz", hash = "sha256:9c6ef27d8381a065e43c23101c24d23d4f2a3d1ae62ee8afd5d36de1781f3e64"},
-    {file = "pyobjc_framework_Speech-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:467320a7dd6e2eb3328c61c106bc41971e256feeed523d42895eee69a08f3fa0"},
-    {file = "pyobjc_framework_Speech-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:da52b8860375108807604ca947ede123123a07b70cf0ee063728233ba57cfb77"},
+    {file = "pyobjc-framework-Speech-8.2.tar.gz", hash = "sha256:e9c54ae5171feaca25e9b8fd0360d78d3c346a836e13a69ecc3eee4339fbf6ef"},
+    {file = "pyobjc_framework_Speech-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:a21063b3e0634fc7c4bad7a58b95d25c9fce22de48b0cded0a0f3cd25d1fdca7"},
+    {file = "pyobjc_framework_Speech-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:0dd10919219a7ff85b952256c5663d2fc3bd97f9901cdf06693a2c7e96b9fae0"},
+    {file = "pyobjc_framework_Speech-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:99790fbc0e75d0230b50dea6ca44a851b980a6fba3df9107486b761dab73a076"},
 ]
 pyobjc-framework-spritekit = [
-    {file = "pyobjc-framework-SpriteKit-7.3.tar.gz", hash = "sha256:0a6a6a0821e8eacf56f847a1b68c62db6484b37588a84677aca44e2a41c39c67"},
-    {file = "pyobjc_framework_SpriteKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:b47beedfd4f15a517b0f162ccf752d1367c24190e89239da961e8681a6f8a35c"},
-    {file = "pyobjc_framework_SpriteKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:1d0d7afa295d8926b2b8bd69f700b9039c35ac95323c1b3cc5023d312d60ec6f"},
+    {file = "pyobjc-framework-SpriteKit-8.2.tar.gz", hash = "sha256:00a5bc1e95d71c30c63b528e917b3e686fc2fca91f3aeffac974efd7d546272a"},
+    {file = "pyobjc_framework_SpriteKit-8.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c9aabd2885ab10a6e13dbd3a623b5524a6f2d8f8cf1c1004fa6c760d7f247495"},
+    {file = "pyobjc_framework_SpriteKit-8.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:48d0a5e6c23cb71f8d94d3f7a71c348ad41113e72871a2b84d26267ded2a9c83"},
+    {file = "pyobjc_framework_SpriteKit-8.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e29a2ec8f17bce26c09413804a40518913ca2be02832a3e6a809101cca2a2ab1"},
+    {file = "pyobjc_framework_SpriteKit-8.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2d960042d7207db7c50f1fd9b558d9653b84243ba0268bb5e00d40a570ea597c"},
+    {file = "pyobjc_framework_SpriteKit-8.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:86557886659c9b359fdc655c10d7af1f82571a0ac572dd257fc493273f273b63"},
+    {file = "pyobjc_framework_SpriteKit-8.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:30d4bd7e672c22d206749d82624f8169b987d09d9184d1ed6d06ad1b04b01198"},
 ]
 pyobjc-framework-storekit = [
-    {file = "pyobjc-framework-StoreKit-7.3.tar.gz", hash = "sha256:b9542b8a2a3ef7feb27ef6de7819b0657ec51db78235a5004f7d1444c0f19f56"},
-    {file = "pyobjc_framework_StoreKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:4e77ef9da46a12bc43294a053853b53c3dd026f68b2df6e779bca13ca80a2b13"},
-    {file = "pyobjc_framework_StoreKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:1980195a5f4ab6277eb4a52e7ad0995af613c0cd4e13e43f1435f567c1a3ec37"},
+    {file = "pyobjc-framework-StoreKit-8.2.tar.gz", hash = "sha256:080f461015ed23e03defe991e508abfadaf848916a75681e192c8a3b21456e30"},
+    {file = "pyobjc_framework_StoreKit-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:d1ff72339349b292e0d693e7291c446dd3bf6be15f61690ea094e2003d8e3f51"},
+    {file = "pyobjc_framework_StoreKit-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:8673636d0118d0f925fbdd042211aa389cc99b44e207fe615890bb4aa22c0a90"},
+    {file = "pyobjc_framework_StoreKit-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:748dd9f9b7ae0526631fac581d6cb4074fd65cae030952835f0a818f5a060a2c"},
 ]
 pyobjc-framework-syncservices = [
-    {file = "pyobjc-framework-SyncServices-7.3.tar.gz", hash = "sha256:e63bba4e855d1683d249017fbbbb09a8699f9258f3214014aa3ba4341506e165"},
-    {file = "pyobjc_framework_SyncServices-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:efef2c69b1dc0c9d558ee04e161dc937e02329a2451f002d3455b21ea1da11d3"},
-    {file = "pyobjc_framework_SyncServices-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:85d7519646d0faaee9b188d7f733d7629f292043eb1e37a840b1e3f785e13884"},
+    {file = "pyobjc-framework-SyncServices-8.2.tar.gz", hash = "sha256:0b112a56f9838ba4c6ad53ab88299f84fe4b151feed025923b862fdb1b92c9e5"},
+    {file = "pyobjc_framework_SyncServices-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:170a976f6cdd84425afe035d0b27a889649dd6ac5bb0524b6f371896fb764c44"},
+    {file = "pyobjc_framework_SyncServices-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:f80cc71b86ab83622d6b0e3e8952578a448d844f51e5d1bb05dd9ad3157a5659"},
+    {file = "pyobjc_framework_SyncServices-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:180620be36d5d84a3290c9f0998c376952a4f30a38959aa3cbeec43e4e0e805f"},
 ]
 pyobjc-framework-systemconfiguration = [
-    {file = "pyobjc-framework-SystemConfiguration-7.3.tar.gz", hash = "sha256:92cbe14d9efcf1c52328ab1ba4cc359879c22e2f390179ec4713af176bc19dc6"},
-    {file = "pyobjc_framework_SystemConfiguration-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:c5b5e9d852a15165507a46b8c8974e6d99aff3d1edda4d77443530b604adb520"},
-    {file = "pyobjc_framework_SystemConfiguration-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:05293ef0a358fbefd41d4470a98c7c08f70ace3d09245b7c7370228d8068b328"},
+    {file = "pyobjc-framework-SystemConfiguration-8.2.tar.gz", hash = "sha256:e1151ced500d5e528ba0924e85b003441326927201c10e415f7070a9ec8e355c"},
+    {file = "pyobjc_framework_SystemConfiguration-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:9898ea2afc92657a15f699bff5fcd4d5e49aefd62e3dab9ac42b5cd4f45fae73"},
+    {file = "pyobjc_framework_SystemConfiguration-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9102bfe477f4b4be9a0241cf07b55e5b0f211aa7ef902015f3e667bf3cbce937"},
+    {file = "pyobjc_framework_SystemConfiguration-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:21ef7d0e06a8c1c0a3bbdb94a8987d33be5d91af1021ad91330af3b0f18e6fa4"},
 ]
 pyobjc-framework-systemextensions = [
-    {file = "pyobjc-framework-SystemExtensions-7.3.tar.gz", hash = "sha256:d175f0fba9a571af78c333285f5b1cd310e83453dc018ae5663adcd53aef4d0d"},
-    {file = "pyobjc_framework_SystemExtensions-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:85810b03a7b1a4034bb0cd39eac5d0d38be7e602aa5805759944972bd50ce44d"},
-    {file = "pyobjc_framework_SystemExtensions-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:d45297f24cf411d62367c706d080b594620359195eb623bd3f9ea523dfb79b54"},
+    {file = "pyobjc-framework-SystemExtensions-8.2.tar.gz", hash = "sha256:a097894029b529752f8a4bdc99e207728eea7c091d8282c980deb8ccb4133b6e"},
+    {file = "pyobjc_framework_SystemExtensions-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:a482a85986b2e96438112366969dce7ce0b78cf9907ba1c2c22f4d1087af3f80"},
+    {file = "pyobjc_framework_SystemExtensions-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:3b6df6c46f8f1ba8c1fb81b1eb37b0e31da3b532e2fc38045f9ac458ac1b8526"},
+    {file = "pyobjc_framework_SystemExtensions-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:11d8dde86671540416c4c8c716ff26f89e256ba95a14cc4e8183d49000233a5c"},
 ]
 pyobjc-framework-uniformtypeidentifiers = [
-    {file = "pyobjc-framework-UniformTypeIdentifiers-7.3.tar.gz", hash = "sha256:f827ca61d5dcd82343178d1d6a6a5e9be8f721f51a4feba4c3a3a39afaa674d5"},
-    {file = "pyobjc_framework_UniformTypeIdentifiers-7.3-py2.py3-none-any.whl", hash = "sha256:62f043d566b3bf37b8324c98a6ae4b449b523cb3027d17eb5d2d8c4ce119f99c"},
+    {file = "pyobjc-framework-UniformTypeIdentifiers-8.2.tar.gz", hash = "sha256:074a4b5df1c411041ef38d2fe6443c9d565c46c456ffbf3a02d27729707b74f8"},
+    {file = "pyobjc_framework_UniformTypeIdentifiers-8.2-py2.py3-none-any.whl", hash = "sha256:156f52d97df3595686cf8423f6f5048c74aac12476a72c2f39cd0024b7dbe9fe"},
 ]
 pyobjc-framework-usernotifications = [
-    {file = "pyobjc-framework-UserNotifications-7.3.tar.gz", hash = "sha256:40f60d4d0eb575e5d23d3d0bb5fcbdf444cf80ce91f5235c634e336416f91934"},
-    {file = "pyobjc_framework_UserNotifications-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:814891723e45c380fa4d619bc77b23f8d3b846ddf4059488b2424d8b085e9105"},
-    {file = "pyobjc_framework_UserNotifications-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:88a74333013bd921af44d11211c1a6198f66add2ac506e6ce4b5c09991f3f024"},
+    {file = "pyobjc-framework-UserNotifications-8.2.tar.gz", hash = "sha256:417c619fc1eb448a778281dc847213af507287076af42a7210ae4e76f664df6e"},
+    {file = "pyobjc_framework_UserNotifications-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:fae60db5b2cb33fc047620a2d28211d5a8ce6e65ec82a2cf7098d5a1e7ed98c6"},
+    {file = "pyobjc_framework_UserNotifications-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:e1df4950265661fc2076fa346b02a6f7601470de25da30a93496be29b00c4014"},
+    {file = "pyobjc_framework_UserNotifications-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:83792d59bd4d6948f47297a9dfec0fc405201617fdbf6e65fd1bb0b21715a564"},
 ]
 pyobjc-framework-usernotificationsui = [
-    {file = "pyobjc-framework-UserNotificationsUI-7.3.tar.gz", hash = "sha256:02b639f06d0a394b4fd45068c6b74250f1033049d74f1a2b2533822aa114605b"},
-    {file = "pyobjc_framework_UserNotificationsUI-7.3-py2.py3-none-any.whl", hash = "sha256:36b17214c55bd38988c9f039029a4faf49c15071ffc586664474a2c8190c1f2c"},
+    {file = "pyobjc-framework-UserNotificationsUI-8.2.tar.gz", hash = "sha256:519b53b5dbfe46be57436491a9a423e496a55d5555902bdd16c494c00919ed49"},
+    {file = "pyobjc_framework_UserNotificationsUI-8.2-py2.py3-none-any.whl", hash = "sha256:64b27189ede12e54a8d00ab37672eefbe3823e01dbb74c4ed44d1c5303a6cd94"},
 ]
 pyobjc-framework-videosubscriberaccount = [
-    {file = "pyobjc-framework-VideoSubscriberAccount-7.3.tar.gz", hash = "sha256:0dddf8bbfe70e1fd1e5ef4d29fff097c00f33357807a958676d3b52944eaebfa"},
-    {file = "pyobjc_framework_VideoSubscriberAccount-7.3-py2.py3-none-any.whl", hash = "sha256:deef5975537cce391915f93434b5d67b4788f08e3e91de802c48966b22643a52"},
+    {file = "pyobjc-framework-VideoSubscriberAccount-8.2.tar.gz", hash = "sha256:ce3de9763b824f9325c2ab5b95f72d1e79dcab32ca65b20babbf9f7755e66a9c"},
+    {file = "pyobjc_framework_VideoSubscriberAccount-8.2-py2.py3-none-any.whl", hash = "sha256:2f0637c4e61bfdabb768be1e9cd663997fce12126c7f0af6a1baa201163a8713"},
 ]
 pyobjc-framework-videotoolbox = [
-    {file = "pyobjc-framework-VideoToolbox-7.3.tar.gz", hash = "sha256:e32eb1374dd42f4dc8d8bddb7f7f48dde0d7e1fde7181effdf15df8144b85c8e"},
-    {file = "pyobjc_framework_VideoToolbox-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:8dd4dae4c34085ea8bbcf65ea63358859f5621c55ac7db9ab37d6c45719d117d"},
-    {file = "pyobjc_framework_VideoToolbox-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:326fe057c65ec8df3198488e4e5250e0f6a9ab7fa2b0a5378ab6137f4377a47e"},
+    {file = "pyobjc-framework-VideoToolbox-8.2.tar.gz", hash = "sha256:f0d76352a4cd9386cfffec38a085848e7f45937ab4c5e990a7251ef3e5688ef4"},
+    {file = "pyobjc_framework_VideoToolbox-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:bc753f47606ecb321b5525f6e82bdf05217bbd2f904d760904cea472fb0e05ec"},
+    {file = "pyobjc_framework_VideoToolbox-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:e297918a1451e1ed83307f899f34dbc5aed7b946a9be7c647c31fa09f223594f"},
+    {file = "pyobjc_framework_VideoToolbox-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:ae05c21c6c0cbb8466acea77af4ba4fb2e74bc73727462dc751fd89fac5203f0"},
 ]
 pyobjc-framework-virtualization = [
-    {file = "pyobjc-framework-Virtualization-7.3.tar.gz", hash = "sha256:57f8ec5386f063d281a2c235cf1f1ef5181f2376cd53bd484018e50b4dcf2eb8"},
-    {file = "pyobjc_framework_Virtualization-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:5e7b183ee22c914fc203def08abcab74daab0bebbd6f0cfc53251321dffc2f07"},
-    {file = "pyobjc_framework_Virtualization-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:195fda568a0eebac87aa515232f2db765845c74daf903774616acbe8cb61263e"},
+    {file = "pyobjc-framework-Virtualization-8.2.tar.gz", hash = "sha256:157d6b92899134df2ac50895cc3626c32d4d49b484f4d98eb1ac3e626449c22e"},
+    {file = "pyobjc_framework_Virtualization-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:e4731c4405d75df36c62c438d20294dea219acf728a31e556e32e17a28a83583"},
+    {file = "pyobjc_framework_Virtualization-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:5cdaae5a22a5254de6ad0b150f263939b3b6846e06bd26a20cc636781241d79b"},
+    {file = "pyobjc_framework_Virtualization-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:db07eca632a08d16fa34d73abb6f576945d3306e9245e9cf478fcc4e03959b1c"},
 ]
 pyobjc-framework-vision = [
-    {file = "pyobjc-framework-Vision-7.3.tar.gz", hash = "sha256:cab1fdf6b02a1767646cf6353a118c0fa5d420fca4ab3904ce5054332f59f424"},
-    {file = "pyobjc_framework_Vision-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:09b1f55b731aaf3cad68a27b47c3bd93d2c88d8cf16d0c0157dd51151f5f0bbd"},
-    {file = "pyobjc_framework_Vision-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:a81ac37e5f4c89d56046b9c551d16d16d0fcfe077678d0f2bd5bf62f418d00f0"},
+    {file = "pyobjc-framework-Vision-8.2.tar.gz", hash = "sha256:0f1cf9d85fa0de56215ef499bb9226a11c388542fa5d0342e7cd8591739df099"},
+    {file = "pyobjc_framework_Vision-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:20eb0d0f7236ef579496453330e76bb702f5cdcf0620b8b2a6110175ab62faac"},
+    {file = "pyobjc_framework_Vision-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:4f7b4006721226bdd67689afa1b2770072f6869d5d1925d891533b59aa55f9b8"},
+    {file = "pyobjc_framework_Vision-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:492ba906a2adf40206da088ca4c26f3e2f62837260e90b237dec93a0f3877d10"},
 ]
 pyobjc-framework-webkit = [
-    {file = "pyobjc-framework-WebKit-7.3.tar.gz", hash = "sha256:bec3a985c0f5e4263d6e28e2c551c1b5ec7b63950e0e3cb5409abdbf61f11f01"},
-    {file = "pyobjc_framework_WebKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:cd388df8fde96db724a42745395998b6d5a98740fb29bac95f76884e2fa6bf27"},
-    {file = "pyobjc_framework_WebKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:89e0fcc10eb09e4203b1ace02808ae9b1882b6c8a55bbfaff20213e2a62ce974"},
+    {file = "pyobjc-framework-WebKit-8.2.tar.gz", hash = "sha256:9ec7640540a621498880b81b6e27a99523cec69efee4e6d718ea70db573f9869"},
+    {file = "pyobjc_framework_WebKit-8.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:c6e7aece1799740b5896e13360de6b0875942f6c2d612663f8863b892e95b0ba"},
+    {file = "pyobjc_framework_WebKit-8.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c137213f0cff9c689fbf32aeeabe76cfe199a8c2fea4edf23097f356d3b81eb9"},
+    {file = "pyobjc_framework_WebKit-8.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:213b08345685fe7b85267a96f4f4fd02b841084c752dc5154b5cc20189dd1ee0"},
 ]
 pyparsing = [
-    {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
-    {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
+    {file = "pyparsing-3.0.7-py3-none-any.whl", hash = "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"},
+    {file = "pyparsing-3.0.7.tar.gz", hash = "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea"},
 ]
 pyqt5 = [
     {file = "PyQt5-5.12.3-5.12.10-cp35.cp36.cp37.cp38.cp39-abi3-macosx_10_6_intel.whl", hash = "sha256:eb2e872a6f240459bc4a508aa53eb7df53e6406af95c2115f37abbe07d6b470b"},
@@ -6389,27 +6628,27 @@ pyqtwebengine = [
     {file = "PyQtWebEngine-5.12.1-5.12.10-cp35.cp36.cp37.cp38.cp39-none-win_amd64.whl", hash = "sha256:dd0d5d2736daf81957707b73e2589db7650a7891b804a885410738ddff04f7ef"},
 ]
 pyrsistent = [
-    {file = "pyrsistent-0.18.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f4c8cabb46ff8e5d61f56a037974228e978f26bfefce4f61a4b1ac0ba7a2ab72"},
-    {file = "pyrsistent-0.18.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:da6e5e818d18459fa46fac0a4a4e543507fe1110e808101277c5a2b5bab0cd2d"},
-    {file = "pyrsistent-0.18.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5e4395bbf841693eaebaa5bb5c8f5cdbb1d139e07c975c682ec4e4f8126e03d2"},
-    {file = "pyrsistent-0.18.0-cp36-cp36m-win32.whl", hash = "sha256:527be2bfa8dc80f6f8ddd65242ba476a6c4fb4e3aedbf281dfbac1b1ed4165b1"},
-    {file = "pyrsistent-0.18.0-cp36-cp36m-win_amd64.whl", hash = "sha256:2aaf19dc8ce517a8653746d98e962ef480ff34b6bc563fc067be6401ffb457c7"},
-    {file = "pyrsistent-0.18.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:58a70d93fb79dc585b21f9d72487b929a6fe58da0754fa4cb9f279bb92369396"},
-    {file = "pyrsistent-0.18.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:4916c10896721e472ee12c95cdc2891ce5890898d2f9907b1b4ae0f53588b710"},
-    {file = "pyrsistent-0.18.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:73ff61b1411e3fb0ba144b8f08d6749749775fe89688093e1efef9839d2dcc35"},
-    {file = "pyrsistent-0.18.0-cp37-cp37m-win32.whl", hash = "sha256:b29b869cf58412ca5738d23691e96d8aff535e17390128a1a52717c9a109da4f"},
-    {file = "pyrsistent-0.18.0-cp37-cp37m-win_amd64.whl", hash = "sha256:097b96f129dd36a8c9e33594e7ebb151b1515eb52cceb08474c10a5479e799f2"},
-    {file = "pyrsistent-0.18.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:772e94c2c6864f2cd2ffbe58bb3bdefbe2a32afa0acb1a77e472aac831f83427"},
-    {file = "pyrsistent-0.18.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:c1a9ff320fa699337e05edcaae79ef8c2880b52720bc031b219e5b5008ebbdef"},
-    {file = "pyrsistent-0.18.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:cd3caef37a415fd0dae6148a1b6957a8c5f275a62cca02e18474608cb263640c"},
-    {file = "pyrsistent-0.18.0-cp38-cp38-win32.whl", hash = "sha256:e79d94ca58fcafef6395f6352383fa1a76922268fa02caa2272fff501c2fdc78"},
-    {file = "pyrsistent-0.18.0-cp38-cp38-win_amd64.whl", hash = "sha256:a0c772d791c38bbc77be659af29bb14c38ced151433592e326361610250c605b"},
-    {file = "pyrsistent-0.18.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d5ec194c9c573aafaceebf05fc400656722793dac57f254cd4741f3c27ae57b4"},
-    {file = "pyrsistent-0.18.0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:6b5eed00e597b5b5773b4ca30bd48a5774ef1e96f2a45d105db5b4ebb4bca680"},
-    {file = "pyrsistent-0.18.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:48578680353f41dca1ca3dc48629fb77dfc745128b56fc01096b2530c13fd426"},
-    {file = "pyrsistent-0.18.0-cp39-cp39-win32.whl", hash = "sha256:f3ef98d7b76da5eb19c37fda834d50262ff9167c65658d1d8f974d2e4d90676b"},
-    {file = "pyrsistent-0.18.0-cp39-cp39-win_amd64.whl", hash = "sha256:404e1f1d254d314d55adb8d87f4f465c8693d6f902f67eb6ef5b4526dc58e6ea"},
-    {file = "pyrsistent-0.18.0.tar.gz", hash = "sha256:773c781216f8c2900b42a7b638d5b517bb134ae1acbebe4d1e8f1f41ea60eb4b"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:df46c854f490f81210870e509818b729db4488e1f30f2a1ce1698b2295a878d1"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d45866ececf4a5fff8742c25722da6d4c9e180daa7b405dc0a2a2790d668c26"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4ed6784ceac462a7d6fcb7e9b663e93b9a6fb373b7f43594f9ff68875788e01e"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-win32.whl", hash = "sha256:e4f3149fd5eb9b285d6bfb54d2e5173f6a116fe19172686797c056672689daf6"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-win_amd64.whl", hash = "sha256:636ce2dc235046ccd3d8c56a7ad54e99d5c1cd0ef07d9ae847306c91d11b5fec"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e92a52c166426efbe0d1ec1332ee9119b6d32fc1f0bbfd55d5c1088070e7fc1b"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7a096646eab884bf8bed965bad63ea327e0d0c38989fc83c5ea7b8a87037bfc"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cdfd2c361b8a8e5d9499b9082b501c452ade8bbf42aef97ea04854f4a3f43b22"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-win32.whl", hash = "sha256:7ec335fc998faa4febe75cc5268a9eac0478b3f681602c1f27befaf2a1abe1d8"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-win_amd64.whl", hash = "sha256:6455fc599df93d1f60e1c5c4fe471499f08d190d57eca040c0ea182301321286"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:fd8da6d0124efa2f67d86fa70c851022f87c98e205f0594e1fae044e7119a5a6"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bfe2388663fd18bd8ce7db2c91c7400bf3e1a9e8bd7d63bf7e77d39051b85ec"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e3e1fcc45199df76053026a51cc59ab2ea3fc7c094c6627e93b7b44cdae2c8c"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-win32.whl", hash = "sha256:b568f35ad53a7b07ed9b1b2bae09eb15cdd671a5ba5d2c66caee40dbf91c68ca"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-win_amd64.whl", hash = "sha256:d1b96547410f76078eaf66d282ddca2e4baae8964364abb4f4dcdde855cd123a"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:f87cc2863ef33c709e237d4b5f4502a62a00fab450c9e020892e8e2ede5847f5"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bc66318fb7ee012071b2792024564973ecc80e9522842eb4e17743604b5e045"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:914474c9f1d93080338ace89cb2acee74f4f666fb0424896fcfb8d86058bf17c"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-win32.whl", hash = "sha256:1b34eedd6812bf4d33814fca1b66005805d3640ce53140ab8bbb1e2651b0d9bc"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-win_amd64.whl", hash = "sha256:e24a828f57e0c337c8d8bb9f6b12f09dfdf0273da25fda9e314f0b684b415a07"},
+    {file = "pyrsistent-0.18.1.tar.gz", hash = "sha256:d4d61f8b993a7255ba714df3aca52700f8125289f84f704cf80916517c46eb96"},
 ]
 pytest = [
     {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
@@ -6420,8 +6659,8 @@ python-dateutil = [
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
 ]
 python-lsp-black = [
-    {file = "python-lsp-black-1.0.0.tar.gz", hash = "sha256:0d7dd5f440a53b6f676fa8c097979e0ff611065b8f4ffd248b43228b0df2efee"},
-    {file = "python_lsp_black-1.0.0-py3-none-any.whl", hash = "sha256:2a5fd9e37d27432fa003d01d88339889ee6090c04de5f80b588b50c9dc9f472b"},
+    {file = "python-lsp-black-1.0.1.tar.gz", hash = "sha256:c751fb30609260c89641ba749c4fe0e21fff9fd65fb34c00d380f953c9293b83"},
+    {file = "python_lsp_black-1.0.1-py3-none-any.whl", hash = "sha256:62a5f2f5dd1fcaead9e3ba9407cdb00024c50c461903a23c7bc7c01ee123d248"},
 ]
 python-lsp-jsonrpc = [
     {file = "python-lsp-jsonrpc-1.0.0.tar.gz", hash = "sha256:7bec170733db628d3506ea3a5288ff76aa33c70215ed223abdb0d95e957660bd"},
@@ -6440,16 +6679,18 @@ pytz = [
     {file = "pytz-2021.3.tar.gz", hash = "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"},
 ]
 pywin32 = [
-    {file = "pywin32-302-cp310-cp310-win32.whl", hash = "sha256:251b7a9367355ccd1a4cd69cd8dd24bd57b29ad83edb2957cfa30f7ed9941efa"},
-    {file = "pywin32-302-cp310-cp310-win_amd64.whl", hash = "sha256:79cf7e6ddaaf1cd47a9e50cc74b5d770801a9db6594464137b1b86aa91edafcc"},
-    {file = "pywin32-302-cp36-cp36m-win32.whl", hash = "sha256:fe21c2fb332d03dac29de070f191bdbf14095167f8f2165fdc57db59b1ecc006"},
-    {file = "pywin32-302-cp36-cp36m-win_amd64.whl", hash = "sha256:d3761ab4e8c5c2dbc156e2c9ccf38dd51f936dc77e58deb940ffbc4b82a30528"},
-    {file = "pywin32-302-cp37-cp37m-win32.whl", hash = "sha256:48dd4e348f1ee9538dd4440bf201ea8c110ea6d9f3a5010d79452e9fa80480d9"},
-    {file = "pywin32-302-cp37-cp37m-win_amd64.whl", hash = "sha256:496df89f10c054c9285cc99f9d509e243f4e14ec8dfc6d78c9f0bf147a893ab1"},
-    {file = "pywin32-302-cp38-cp38-win32.whl", hash = "sha256:e372e477d938a49266136bff78279ed14445e00718b6c75543334351bf535259"},
-    {file = "pywin32-302-cp38-cp38-win_amd64.whl", hash = "sha256:543552e66936378bd2d673c5a0a3d9903dba0b0a87235ef0c584f058ceef5872"},
-    {file = "pywin32-302-cp39-cp39-win32.whl", hash = "sha256:2393c1a40dc4497fd6161b76801b8acd727c5610167762b7c3e9fd058ef4a6ab"},
-    {file = "pywin32-302-cp39-cp39-win_amd64.whl", hash = "sha256:af5aea18167a31efcacc9f98a2ca932c6b6a6d91ebe31f007509e293dea12580"},
+    {file = "pywin32-303-cp310-cp310-win32.whl", hash = "sha256:6fed4af057039f309263fd3285d7b8042d41507343cd5fa781d98fcc5b90e8bb"},
+    {file = "pywin32-303-cp310-cp310-win_amd64.whl", hash = "sha256:51cb52c5ec6709f96c3f26e7795b0bf169ee0d8395b2c1d7eb2c029a5008ed51"},
+    {file = "pywin32-303-cp311-cp311-win32.whl", hash = "sha256:d9b5d87ca944eb3aa4cd45516203ead4b37ab06b8b777c54aedc35975dec0dee"},
+    {file = "pywin32-303-cp311-cp311-win_amd64.whl", hash = "sha256:fcf44032f5b14fcda86028cdf49b6ebdaea091230eb0a757282aa656e4732439"},
+    {file = "pywin32-303-cp36-cp36m-win32.whl", hash = "sha256:aad484d52ec58008ca36bd4ad14a71d7dd0a99db1a4ca71072213f63bf49c7d9"},
+    {file = "pywin32-303-cp36-cp36m-win_amd64.whl", hash = "sha256:2a09632916b6bb231ba49983fe989f2f625cea237219530e81a69239cd0c4559"},
+    {file = "pywin32-303-cp37-cp37m-win32.whl", hash = "sha256:b1675d82bcf6dbc96363fca747bac8bff6f6e4a447a4287ac652aa4b9adc796e"},
+    {file = "pywin32-303-cp37-cp37m-win_amd64.whl", hash = "sha256:c268040769b48a13367221fced6d4232ed52f044ffafeda247bd9d2c6bdc29ca"},
+    {file = "pywin32-303-cp38-cp38-win32.whl", hash = "sha256:5f9ec054f5a46a0f4dfd72af2ce1372f3d5a6e4052af20b858aa7df2df7d355b"},
+    {file = "pywin32-303-cp38-cp38-win_amd64.whl", hash = "sha256:793bf74fce164bcffd9d57bb13c2c15d56e43c9542a7b9687b4fccf8f8a41aba"},
+    {file = "pywin32-303-cp39-cp39-win32.whl", hash = "sha256:7d3271c98434617a11921c5ccf74615794d97b079e22ed7773790822735cc352"},
+    {file = "pywin32-303-cp39-cp39-win_amd64.whl", hash = "sha256:79cbb862c11b9af19bcb682891c1b91942ec2ff7de8151e2aea2e175899cda34"},
 ]
 pywin32-ctypes = [
     {file = "pywin32-ctypes-0.2.0.tar.gz", hash = "sha256:24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942"},
@@ -6541,71 +6782,20 @@ qstylizer = [
     {file = "qstylizer-0.2.1-py2.py3-none-any.whl", hash = "sha256:d54cacce04635548e41818e1c32872cc3c92d7eb41e8b77921f20adaee564394"},
 ]
 qtawesome = [
-    {file = "QtAwesome-1.1.0-py3-none-any.whl", hash = "sha256:b74cdb5d6c7eab3f6bac2a90f3fa70295455a20457c21c760cf67d6caa98eeaf"},
-    {file = "QtAwesome-1.1.0.tar.gz", hash = "sha256:3fc6eb9327f96ded8e0d291dad4f7a543394c53bff8f9f4badd7433181581a8b"},
+    {file = "QtAwesome-1.1.1-py3-none-any.whl", hash = "sha256:27d2e2bcb34cb5c9a7f61c29f34b24bf89ef50c79ffff7a76effe59bf781fcee"},
+    {file = "QtAwesome-1.1.1.tar.gz", hash = "sha256:ec02e200231fa68a146a93845890aa0432a7edcba14bf811ff6975cf9acdab5d"},
 ]
 qtconsole = [
-    {file = "qtconsole-5.1.1-py3-none-any.whl", hash = "sha256:73994105b0369bb99f4164df4a131010f3c7b33a7b5169c37366358d8744675b"},
-    {file = "qtconsole-5.1.1.tar.gz", hash = "sha256:bbc34bca14f65535afcb401bc74b752bac955e5313001ba640383f7e5857dc49"},
+    {file = "qtconsole-5.2.2-py3-none-any.whl", hash = "sha256:4aa6a3e600e0c8cf16853f2378311bc2371f57cb0f22ecfc28994f4cf409ee2e"},
+    {file = "qtconsole-5.2.2.tar.gz", hash = "sha256:8f9db97b27782184efd0a0f2d57ea3bd852d053747a2e442a9011329c082976d"},
 ]
 qtpy = [
-    {file = "QtPy-1.11.2-py2.py3-none-any.whl", hash = "sha256:83c502973e9fdd7b648d8267a421229ea3d9a0651c22e4c65a4d9228479c39b6"},
-    {file = "QtPy-1.11.2.tar.gz", hash = "sha256:d6e4ae3a41f1fcb19762b58f35ad6dd443b4bdc867a4cb81ef10ccd85403c92b"},
-]
-regex = [
-    {file = "regex-2021.11.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:897c539f0f3b2c3a715be651322bef2167de1cdc276b3f370ae81a3bda62df71"},
-    {file = "regex-2021.11.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:886f459db10c0f9d17c87d6594e77be915f18d343ee138e68d259eb385f044a8"},
-    {file = "regex-2021.11.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:075b0fdbaea81afcac5a39a0d1bb91de887dd0d93bf692a5dd69c430e7fc58cb"},
-    {file = "regex-2021.11.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c6238d30dcff141de076344cf7f52468de61729c2f70d776fce12f55fe8df790"},
-    {file = "regex-2021.11.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7fab29411d75c2eb48070020a40f80255936d7c31357b086e5931c107d48306e"},
-    {file = "regex-2021.11.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f0148988af0182a0a4e5020e7c168014f2c55a16d11179610f7883dd48ac0ebe"},
-    {file = "regex-2021.11.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:be30cd315db0168063a1755fa20a31119da91afa51da2907553493516e165640"},
-    {file = "regex-2021.11.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e9cec3a62d146e8e122d159ab93ac32c988e2ec0dcb1e18e9e53ff2da4fbd30c"},
-    {file = "regex-2021.11.2-cp310-cp310-win32.whl", hash = "sha256:41c66bd6750237a8ed23028a6c9173dc0c92dc24c473e771d3bfb9ee817700c3"},
-    {file = "regex-2021.11.2-cp310-cp310-win_amd64.whl", hash = "sha256:0075fe4e2c2720a685fef0f863edd67740ff78c342cf20b2a79bc19388edf5db"},
-    {file = "regex-2021.11.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:0ed3465acf8c7c10aa2e0f3d9671da410ead63b38a77283ef464cbb64275df58"},
-    {file = "regex-2021.11.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab1fea8832976ad0bebb11f652b692c328043057d35e9ebc78ab0a7a30cf9a70"},
-    {file = "regex-2021.11.2-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cb1e44d860345ab5d4f533b6c37565a22f403277f44c4d2d5e06c325da959883"},
-    {file = "regex-2021.11.2-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9486ebda015913909bc28763c6b92fcc3b5e5a67dee4674bceed112109f5dfb8"},
-    {file = "regex-2021.11.2-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:20605bfad484e1341b2cbfea0708e4b211d233716604846baa54b94821f487cb"},
-    {file = "regex-2021.11.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f20f9f430c33597887ba9bd76635476928e76cad2981643ca8be277b8e97aa96"},
-    {file = "regex-2021.11.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1d85ca137756d62c8138c971453cafe64741adad1f6a7e63a22a5a8abdbd19fa"},
-    {file = "regex-2021.11.2-cp36-cp36m-win32.whl", hash = "sha256:af23b9ca9a874ef0ec20e44467b8edd556c37b0f46f93abfa93752ea7c0e8d1e"},
-    {file = "regex-2021.11.2-cp36-cp36m-win_amd64.whl", hash = "sha256:070336382ca92c16c45b4066c4ba9fa83fb0bd13d5553a82e07d344df8d58a84"},
-    {file = "regex-2021.11.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:ef4e53e2fdc997d91f5b682f81f7dc9661db9a437acce28745d765d251902d85"},
-    {file = "regex-2021.11.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:35ed5714467fc606551db26f80ee5d6aa1f01185586a7bccd96f179c4b974a11"},
-    {file = "regex-2021.11.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7ee36d5113b6506b97f45f2e8447cb9af146e60e3f527d93013d19f6d0405f3b"},
-    {file = "regex-2021.11.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4fba661a4966adbd2c3c08d3caad6822ecb6878f5456588e2475ae23a6e47929"},
-    {file = "regex-2021.11.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77f9d16f7970791f17ecce7e7f101548314ed1ee2583d4268601f30af3170856"},
-    {file = "regex-2021.11.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f6a28e87ba69f3a4f30d775b179aac55be1ce59f55799328a0d9b6df8f16b39d"},
-    {file = "regex-2021.11.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:9267e4fba27e6dd1008c4f2983cc548c98b4be4444e3e342db11296c0f45512f"},
-    {file = "regex-2021.11.2-cp37-cp37m-win32.whl", hash = "sha256:d4bfe3bc3976ccaeb4ae32f51e631964e2f0e85b2b752721b7a02de5ce3b7f27"},
-    {file = "regex-2021.11.2-cp37-cp37m-win_amd64.whl", hash = "sha256:2bb7cae741de1aa03e3dd3a7d98c304871eb155921ca1f0d7cc11f5aade913fd"},
-    {file = "regex-2021.11.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:23f93e74409c210de4de270d4bf88fb8ab736a7400f74210df63a93728cf70d6"},
-    {file = "regex-2021.11.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:d8ee91e1c295beb5c132ebd78616814de26fedba6aa8687ea460c7f5eb289b72"},
-    {file = "regex-2021.11.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2e3ff69ab203b54ce5c480c3ccbe959394ea5beef6bd5ad1785457df7acea92e"},
-    {file = "regex-2021.11.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e3c00cb5c71da655e1e5161481455479b613d500dd1bd252aa01df4f037c641f"},
-    {file = "regex-2021.11.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4abf35e16f4b639daaf05a2602c1b1d47370e01babf9821306aa138924e3fe92"},
-    {file = "regex-2021.11.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb11c982a849dc22782210b01d0c1b98eb3696ce655d58a54180774e4880ac66"},
-    {file = "regex-2021.11.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:07e3755e0f070bc31567dfe447a02011bfa8444239b3e9e5cca6773a22133839"},
-    {file = "regex-2021.11.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0621c90f28d17260b41838b22c81a79ff436141b322960eb49c7b3f91d1cbab6"},
-    {file = "regex-2021.11.2-cp38-cp38-win32.whl", hash = "sha256:8fbe1768feafd3d0156556677b8ff234c7bf94a8110e906b2d73506f577a3269"},
-    {file = "regex-2021.11.2-cp38-cp38-win_amd64.whl", hash = "sha256:f9ee98d658a146cb6507be720a0ce1b44f2abef8fb43c2859791d91aace17cd5"},
-    {file = "regex-2021.11.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b3794cea825f101fe0df9af8a00f9fad8e119c91e39a28636b95ee2b45b6c2e5"},
-    {file = "regex-2021.11.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3576e173e7b4f88f683b4de7db0c2af1b209bb48b2bf1c827a6f3564fad59a97"},
-    {file = "regex-2021.11.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:48b4f4810117a9072a5aa70f7fea5f86fa9efbe9a798312e0a05044bd707cc33"},
-    {file = "regex-2021.11.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f5930d334c2f607711d54761956aedf8137f83f1b764b9640be21d25a976f3a4"},
-    {file = "regex-2021.11.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:956187ff49db7014ceb31e88fcacf4cf63371e6e44d209cf8816cd4a2d61e11a"},
-    {file = "regex-2021.11.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17e095f7f96a4b9f24b93c2c915f31a5201a6316618d919b0593afb070a5270e"},
-    {file = "regex-2021.11.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a56735c35a3704603d9d7b243ee06139f0837bcac2171d9ba1d638ce1df0742a"},
-    {file = "regex-2021.11.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:adf35d88d9cffc202e6046e4c32e1e11a1d0238b2fcf095c94f109e510ececea"},
-    {file = "regex-2021.11.2-cp39-cp39-win32.whl", hash = "sha256:30fe317332de0e50195665bc61a27d46e903d682f94042c36b3f88cb84bd7958"},
-    {file = "regex-2021.11.2-cp39-cp39-win_amd64.whl", hash = "sha256:85289c25f658e3260b00178757c87f033f3d4b3e40aa4abdd4dc875ff11a94fb"},
-    {file = "regex-2021.11.2.tar.gz", hash = "sha256:5e85dcfc5d0f374955015ae12c08365b565c6f1eaf36dd182476a4d8e5a1cdb7"},
+    {file = "QtPy-2.0.0-py3-none-any.whl", hash = "sha256:74bf26be3288aadc843cf3381d5ef0b82f11417ecdcbf26718a408f32590f1ac"},
+    {file = "QtPy-2.0.0.tar.gz", hash = "sha256:777e333df4d711b2ec9743117ab319dadfbd743a5a0eee35923855ca3d35cd9d"},
 ]
 requests = [
-    {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},
-    {file = "requests-2.26.0.tar.gz", hash = "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"},
+    {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
+    {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
 ]
 requests-oauthlib = [
     {file = "requests-oauthlib-1.3.0.tar.gz", hash = "sha256:b4261601a71fd721a8bd6d7aa1cc1d6a8a93b4a9f5e96626f8e4d91e8beeaa6a"},
@@ -6613,7 +6803,8 @@ requests-oauthlib = [
     {file = "requests_oauthlib-1.3.0-py3.7.egg", hash = "sha256:fa6c47b933f01060936d87ae9327fead68768b69c6c9ea2109c48be30f2d4dbc"},
 ]
 rope = [
-    {file = "rope-0.21.0.tar.gz", hash = "sha256:366789e069a267296889b2ee7631f9278173b5e7d468f2ea08abe26069a52aef"},
+    {file = "rope-0.22.0-py3-none-any.whl", hash = "sha256:2847220bf72ead09b5abe72b1edc9cacff90ab93663ece06913fc97324167870"},
+    {file = "rope-0.22.0.tar.gz", hash = "sha256:b00fbc064a26fc62d7220578a27fd639b2fad57213663cc396c137e92d73f10f"},
 ]
 rsa = [
     {file = "rsa-4.7.2-py3-none-any.whl", hash = "sha256:78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2"},
@@ -6653,29 +6844,35 @@ s3transfer = [
     {file = "s3transfer-0.5.0.tar.gz", hash = "sha256:50ed823e1dc5868ad40c8dc92072f757aa0e653a192845c94a3b676f4a62da4c"},
 ]
 scipy = [
-    {file = "scipy-1.7.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:97eb573e361a73a553b915dc195c6f72a08249964b1a33f157f9659f3b6210d1"},
-    {file = "scipy-1.7.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:359b60a0cccd17723b9d5e329a5212a710e771a3ddde800e472fb93732756c46"},
-    {file = "scipy-1.7.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82c5befebf54d799d77e5f0205c03030f57f69ba2541baa44d2e6ad138c28cd3"},
-    {file = "scipy-1.7.2-cp310-cp310-win_amd64.whl", hash = "sha256:54951f51d731c832b1b8885e0a92e89f33d087de7e40d02078bf0d49c7cbdbb5"},
-    {file = "scipy-1.7.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:30bdda199667e74b50208a793eb1ba47a04e5e3fa16f5ff06c6f7969ae78e4da"},
-    {file = "scipy-1.7.2-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:e3efe7ef75dfe627b354ab0af0dbc918eadee97cc80ff1aabea6d3e01114ebdd"},
-    {file = "scipy-1.7.2-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:17fd991a275e4283453f89d404209aa92059ac68d76d804b4bc1716a3742e1b5"},
-    {file = "scipy-1.7.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:74f518ce542533054695f743e4271cb8986b63f95bb51d70fcee4f3929cbff7d"},
-    {file = "scipy-1.7.2-cp37-cp37m-win32.whl", hash = "sha256:1437073f1d4664990879aa8f9547524764372e0fef84a077be4b19e82bba7a8d"},
-    {file = "scipy-1.7.2-cp37-cp37m-win_amd64.whl", hash = "sha256:39f838ea5ce8da868785193d88d05cf5a6d5c390804ec99de29a28e1dcdd53e6"},
-    {file = "scipy-1.7.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e08b81fcd9bf98740b58dc6fdd7879e33a64dcb682201c1135f7d4a75216bb05"},
-    {file = "scipy-1.7.2-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:7b1d0f5f524518f1a86f288443528e4ff4a739c0966db663af4129b7ac7849f8"},
-    {file = "scipy-1.7.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cac71d5476a6f56b50459da21f6221707e0051ebd428b2137db32ef4a43bb15e"},
-    {file = "scipy-1.7.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4d175ba93e00d8eef8f7cd70d4d88a9106a86800c82ea03cf2268c36d6545483"},
-    {file = "scipy-1.7.2-cp38-cp38-win32.whl", hash = "sha256:8b5726a0fedeaa6beb1095e4466998bdd1d1e960b28db9b5a16c89cbd7b2ebf1"},
-    {file = "scipy-1.7.2-cp38-cp38-win_amd64.whl", hash = "sha256:8482c8e45857ab0a5446eb7460d2307a27cbbe659d6d2257820c6d6eb950fd0f"},
-    {file = "scipy-1.7.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1ea6233f5a365cb7945b4304bd06323ece3ece85d6a3fa8598d2f53e513467c9"},
-    {file = "scipy-1.7.2-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:d86abd1ddf421dea5e9cebfeb4de0d205b3dc04e78249afedba9c6c3b2227ff2"},
-    {file = "scipy-1.7.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d25272c03ee3c0fe5e0dff1bb7889280bb6c9e1766fa9c7bde81ad8a5f78694"},
-    {file = "scipy-1.7.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5273d832fb9cd5724ee0d335c16a903b923441107dd973d27fc4293075a9f4e3"},
-    {file = "scipy-1.7.2-cp39-cp39-win32.whl", hash = "sha256:87cf3964db0f1cce17aeed5bfc1b89a6b4b07dbfc48e50d21fa3549e00456803"},
-    {file = "scipy-1.7.2-cp39-cp39-win_amd64.whl", hash = "sha256:a80eb01c43fd98257ec7a49ff5cec0edba32031b5f86503f55399a48cb2c5379"},
-    {file = "scipy-1.7.2.tar.gz", hash = "sha256:fa2dbabaaecdb502641b0b3c00dec05fb475ae48655c66da16c9ed24eda1e711"},
+    {file = "scipy-1.7.3-1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:c9e04d7e9b03a8a6ac2045f7c5ef741be86727d8f49c45db45f244bdd2bcff17"},
+    {file = "scipy-1.7.3-1-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:b0e0aeb061a1d7dcd2ed59ea57ee56c9b23dd60100825f98238c06ee5cc4467e"},
+    {file = "scipy-1.7.3-1-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:b78a35c5c74d336f42f44106174b9851c783184a85a3fe3e68857259b37b9ffb"},
+    {file = "scipy-1.7.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:173308efba2270dcd61cd45a30dfded6ec0085b4b6eb33b5eb11ab443005e088"},
+    {file = "scipy-1.7.3-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:21b66200cf44b1c3e86495e3a436fc7a26608f92b8d43d344457c54f1c024cbc"},
+    {file = "scipy-1.7.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ceebc3c4f6a109777c0053dfa0282fddb8893eddfb0d598574acfb734a926168"},
+    {file = "scipy-1.7.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7eaea089345a35130bc9a39b89ec1ff69c208efa97b3f8b25ea5d4c41d88094"},
+    {file = "scipy-1.7.3-cp310-cp310-win_amd64.whl", hash = "sha256:304dfaa7146cffdb75fbf6bb7c190fd7688795389ad060b970269c8576d038e9"},
+    {file = "scipy-1.7.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:033ce76ed4e9f62923e1f8124f7e2b0800db533828c853b402c7eec6e9465d80"},
+    {file = "scipy-1.7.3-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:4d242d13206ca4302d83d8a6388c9dfce49fc48fdd3c20efad89ba12f785bf9e"},
+    {file = "scipy-1.7.3-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8499d9dd1459dc0d0fe68db0832c3d5fc1361ae8e13d05e6849b358dc3f2c279"},
+    {file = "scipy-1.7.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca36e7d9430f7481fc7d11e015ae16fbd5575615a8e9060538104778be84addf"},
+    {file = "scipy-1.7.3-cp37-cp37m-win32.whl", hash = "sha256:e2c036492e673aad1b7b0d0ccdc0cb30a968353d2c4bf92ac8e73509e1bf212c"},
+    {file = "scipy-1.7.3-cp37-cp37m-win_amd64.whl", hash = "sha256:866ada14a95b083dd727a845a764cf95dd13ba3dc69a16b99038001b05439709"},
+    {file = "scipy-1.7.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:65bd52bf55f9a1071398557394203d881384d27b9c2cad7df9a027170aeaef93"},
+    {file = "scipy-1.7.3-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:f99d206db1f1ae735a8192ab93bd6028f3a42f6fa08467d37a14eb96c9dd34a3"},
+    {file = "scipy-1.7.3-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5f2cfc359379c56b3a41b17ebd024109b2049f878badc1e454f31418c3a18436"},
+    {file = "scipy-1.7.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb7ae2c4dbdb3c9247e07acc532f91077ae6dbc40ad5bd5dca0bb5a176ee9bda"},
+    {file = "scipy-1.7.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95c2d250074cfa76715d58830579c64dff7354484b284c2b8b87e5a38321672c"},
+    {file = "scipy-1.7.3-cp38-cp38-win32.whl", hash = "sha256:87069cf875f0262a6e3187ab0f419f5b4280d3dcf4811ef9613c605f6e4dca95"},
+    {file = "scipy-1.7.3-cp38-cp38-win_amd64.whl", hash = "sha256:7edd9a311299a61e9919ea4192dd477395b50c014cdc1a1ac572d7c27e2207fa"},
+    {file = "scipy-1.7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:eef93a446114ac0193a7b714ce67659db80caf940f3232bad63f4c7a81bc18df"},
+    {file = "scipy-1.7.3-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:eb326658f9b73c07081300daba90a8746543b5ea177184daed26528273157294"},
+    {file = "scipy-1.7.3-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:93378f3d14fff07572392ce6a6a2ceb3a1f237733bd6dcb9eb6a2b29b0d19085"},
+    {file = "scipy-1.7.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edad1cf5b2ce1912c4d8ddad20e11d333165552aba262c882e28c78bbc09dbf6"},
+    {file = "scipy-1.7.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d1cc2c19afe3b5a546ede7e6a44ce1ff52e443d12b231823268019f608b9b12"},
+    {file = "scipy-1.7.3-cp39-cp39-win32.whl", hash = "sha256:2c56b820d304dffcadbbb6cbfbc2e2c79ee46ea291db17e288e73cd3c64fefa9"},
+    {file = "scipy-1.7.3-cp39-cp39-win_amd64.whl", hash = "sha256:3f78181a153fa21c018d346f595edd648344751d7f03ab94b398be2ad083ed3e"},
+    {file = "scipy-1.7.3.tar.gz", hash = "sha256:ab5875facfdef77e0a47d5fd39ea178b58e60e454a4c85aa1e52fcb80db7babf"},
 ]
 seaborn = [
     {file = "seaborn-0.11.2-py3-none-any.whl", hash = "sha256:85a6baa9b55f81a0623abddc4a26b334653ff4c6b18c418361de19dbba0ef283"},
@@ -6686,12 +6883,16 @@ secretstorage = [
     {file = "SecretStorage-3.3.1.tar.gz", hash = "sha256:fd666c51a6bf200643495a04abb261f83229dcb6fd8472ec393df7ffc8b6f195"},
 ]
 sentry-sdk = [
-    {file = "sentry-sdk-1.4.3.tar.gz", hash = "sha256:b9844751e40710e84a457c5bc29b21c383ccb2b63d76eeaad72f7f1c808c8828"},
-    {file = "sentry_sdk-1.4.3-py2.py3-none-any.whl", hash = "sha256:c091cc7115ff25fe3a0e410dbecd7a996f81a3f6137d2272daef32d6c3cfa6dc"},
+    {file = "sentry-sdk-1.5.4.tar.gz", hash = "sha256:f7e54567937ebcbe938c4df1075ec891587faeb7c74184b88cf2894e47c86116"},
+    {file = "sentry_sdk-1.5.4-py2.py3-none-any.whl", hash = "sha256:4fc7960a82c95d906a0514cf4d9aacba1743eb9863a5b7c2a01c525a7d9b21e6"},
+]
+setuptools-scm = [
+    {file = "setuptools_scm-6.4.2-py3-none-any.whl", hash = "sha256:acea13255093849de7ccb11af9e1fb8bde7067783450cee9ef7a93139bddf6d4"},
+    {file = "setuptools_scm-6.4.2.tar.gz", hash = "sha256:6833ac65c6ed9711a4d5d2266f8024cfa07c533a0e55f4c12f6eff280a5a9e30"},
 ]
 shortuuid = [
-    {file = "shortuuid-1.0.1-py3-none-any.whl", hash = "sha256:492c7402ff91beb1342a5898bd61ea953985bf24a41cd9f247409aa2e03c8f77"},
-    {file = "shortuuid-1.0.1.tar.gz", hash = "sha256:3c11d2007b915c43bee3e10625f068d8a349e04f0d81f08f5fa08507427ebf1f"},
+    {file = "shortuuid-1.0.8-py3-none-any.whl", hash = "sha256:44a7a86bcf24dbaba2e626cf80c779926b7c3a0d31a3a013e0d3cd1077707d23"},
+    {file = "shortuuid-1.0.8.tar.gz", hash = "sha256:9435e87e5a64f3b92f7110c81f989a3b7bdb9358e22d2359829167da476cfc23"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
@@ -6702,16 +6903,16 @@ smmap = [
     {file = "smmap-5.0.0.tar.gz", hash = "sha256:c840e62059cd3be204b0c9c9f74be2c09d5648eddd4580d9314c3ecde0b30936"},
 ]
 snowballstemmer = [
-    {file = "snowballstemmer-2.1.0-py2.py3-none-any.whl", hash = "sha256:b51b447bea85f9968c13b650126a888aabd4cb4463fca868ec596826325dedc2"},
-    {file = "snowballstemmer-2.1.0.tar.gz", hash = "sha256:e997baa4f2e9139951b6f4c631bad912dfd3c792467e2f03d7239464af90e914"},
+    {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
+    {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
 ]
 sortedcontainers = [
     {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
     {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
 ]
 sphinx = [
-    {file = "Sphinx-4.2.0-py3-none-any.whl", hash = "sha256:98a535c62a4fcfcc362528592f69b26f7caec587d32cd55688db580be0287ae0"},
-    {file = "Sphinx-4.2.0.tar.gz", hash = "sha256:94078db9184491e15bce0a56d9186e0aec95f16ac20b12d00e06d4e36f1058a6"},
+    {file = "Sphinx-4.4.0-py3-none-any.whl", hash = "sha256:5da895959511473857b6d0200f56865ed62c31e8f82dd338063b84ec022701fe"},
+    {file = "Sphinx-4.4.0.tar.gz", hash = "sha256:6caad9786055cb1fa22b4a365c1775816b876f91966481765d7d50e9f0dd35cc"},
 ]
 sphinxcontrib-applehelp = [
     {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},
@@ -6755,7 +6956,7 @@ subprocess32 = [
     {file = "subprocess32-3.5.4.tar.gz", hash = "sha256:eb2937c80497978d181efa1b839ec2d9622cf9600a039a79d0e108d1f9aec79d"},
 ]
 tensorboard = [
-    {file = "tensorboard-2.7.0-py3-none-any.whl", hash = "sha256:239f78a4a8dff200ce585a030c787773a8c1184d5c159252f5f85bac4e3c3b38"},
+    {file = "tensorboard-2.8.0-py3-none-any.whl", hash = "sha256:65a338e4424e9079f2604923bdbe301792adce2ace1be68da6b3ddf005170def"},
 ]
 tensorboard-data-server = [
     {file = "tensorboard_data_server-0.6.1-py3-none-any.whl", hash = "sha256:809fe9887682d35c1f7d1f54f0f40f98bb1f771b14265b453ca051e2ce58fca7"},
@@ -6763,7 +6964,7 @@ tensorboard-data-server = [
     {file = "tensorboard_data_server-0.6.1-py3-none-manylinux2010_x86_64.whl", hash = "sha256:d8237580755e58eff68d1f3abefb5b1e39ae5c8b127cc40920f9c4fb33f4b98a"},
 ]
 tensorboard-plugin-wit = [
-    {file = "tensorboard_plugin_wit-1.8.0-py3-none-any.whl", hash = "sha256:2a80d1c551d741e99b2f197bb915d8a133e24adb8da1732b840041860f91183a"},
+    {file = "tensorboard_plugin_wit-1.8.1-py3-none-any.whl", hash = "sha256:ff26bdd583d155aa951ee3b152b3d0cffae8005dc697f72b44a8e8c2a77a8cbe"},
 ]
 termcolor = [
     {file = "termcolor-1.1.0.tar.gz", hash = "sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"},
@@ -6785,34 +6986,37 @@ three-merge = [
     {file = "three_merge-0.1.1-py2.py3-none-any.whl", hash = "sha256:dd219f4696aa0bbec6099ac3528b4de0450ff9bde862dd8f6d6f52e745f83464"},
 ]
 tinycss2 = [
-    {file = "tinycss2-1.1.0-py3-none-any.whl", hash = "sha256:0353b5234bcaee7b1ac7ca3dea7e02cd338a9f8dcbb8f2dcd32a5795ec1e5f9a"},
-    {file = "tinycss2-1.1.0.tar.gz", hash = "sha256:fbdcac3044d60eb85fdb2aa840ece43cf7dbe798e373e6ee0be545d4d134e18a"},
+    {file = "tinycss2-1.1.1-py3-none-any.whl", hash = "sha256:fe794ceaadfe3cf3e686b22155d0da5780dd0e273471a51846d0a02bc204fec8"},
+    {file = "tinycss2-1.1.1.tar.gz", hash = "sha256:b2e44dd8883c360c35dd0d1b5aad0b610e5156c2cb3b33434634e539ead9d8bf"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 tomli = [
-    {file = "tomli-1.2.2-py3-none-any.whl", hash = "sha256:f04066f68f5554911363063a30b108d2b5a5b1a010aa8b6132af78489fe3aade"},
-    {file = "tomli-1.2.2.tar.gz", hash = "sha256:c6ce0015eb38820eaf32b5db832dbc26deb3dd427bd5f6556cf0acac2c214fee"},
+    {file = "tomli-1.2.3-py3-none-any.whl", hash = "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"},
+    {file = "tomli-1.2.3.tar.gz", hash = "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f"},
 ]
 torch = [
-    {file = "torch-1.10.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:56022b0ce94c54e95a2f63fc5a1494feb1fc3d5c7a9b35a62944651d03edef05"},
-    {file = "torch-1.10.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:13e1ffab502aa32d6841a018771b47028d02dbbc685c5b79cfd61db5464dae4e"},
-    {file = "torch-1.10.0-cp36-cp36m-win_amd64.whl", hash = "sha256:3c0a942e0df104c80b0eedc30d2a19cdc3d28601bc6e280bf24b2e6255016d3b"},
-    {file = "torch-1.10.0-cp36-none-macosx_10_9_x86_64.whl", hash = "sha256:eea16c01af1980ba709c00e8d5e6c09bedb5b30f9fa2085f6a52a78d7dc4e125"},
-    {file = "torch-1.10.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:b812e8d40d7037748da40bb695bd849e7b2e7faad4cd06df53d2cc4531926fda"},
-    {file = "torch-1.10.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:034df0b20603bfc81325094586647302891b9b20be7e36f152c7dd6af00deac1"},
-    {file = "torch-1.10.0-cp37-cp37m-win_amd64.whl", hash = "sha256:67fc509e207b8e7330f2e76e77800950317d31d035a4d19593db991962afead4"},
-    {file = "torch-1.10.0-cp37-none-macosx_10_9_x86_64.whl", hash = "sha256:4499055547087d7ef7e8a754f09c2c4f1470297ae3e5490363dba66c75501b21"},
-    {file = "torch-1.10.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:ab0cf330714c8f79a837c04784a7a5658b014cf5a4ca527e7b710155ae519cdf"},
-    {file = "torch-1.10.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:e01ba5946267014abfdb30248bcdbd457aaa20cff749febe7fc191e5ae096af4"},
-    {file = "torch-1.10.0-cp38-cp38-win_amd64.whl", hash = "sha256:9013002adcb42bac05dcdbf0a03dd9f6bb5d7ab8b9817041c1176a014870786b"},
-    {file = "torch-1.10.0-cp38-none-macosx_10_9_x86_64.whl", hash = "sha256:aef7afb62e9b174b4e0e5e1e4a42e3bab3b8490a668d666f62f7d4517559fbf2"},
-    {file = "torch-1.10.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:d82e68302c9b5c76ed585e04d61be0ca2184f70cb8ffeba8610570609ad5d7c9"},
-    {file = "torch-1.10.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:e5822200bf80a1495ad98a2bb41803eeba4a85ce373e35fc65765f7f888f5374"},
-    {file = "torch-1.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:ca2c88fa4376e2648785029ab108e6e7abd784eb6535fc6036004b9254f9f7c1"},
-    {file = "torch-1.10.0-cp39-none-macosx_10_9_x86_64.whl", hash = "sha256:d6ef87470b44df9970e84542547d5ba7720bb89616602441df555a39b124e2bc"},
+    {file = "torch-1.10.2-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:8f3fd2e3ffc3bb867133fdf7fbcc8a0bb2e62a5c0696396f51856f5abf9045a8"},
+    {file = "torch-1.10.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:258a0729fb77a3457d5822d84b536057cd119b08049a8d3c41dc3dcdeb48d56e"},
+    {file = "torch-1.10.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:935e5ac804c5093c79f23a7e6ca5b912c166071aa9d8b4a0a3d6a85126d6a47b"},
+    {file = "torch-1.10.2-cp36-cp36m-win_amd64.whl", hash = "sha256:65fd02ed889c63fd82bf1a440c5a94c1310c29f3e6f9f62add416d34da355d97"},
+    {file = "torch-1.10.2-cp36-none-macosx_10_9_x86_64.whl", hash = "sha256:6a81f886823bbd15edc2dc0908fa214070df61c9f7ab8831f0a03630275cca5a"},
+    {file = "torch-1.10.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:3eee3cf53c1f8fb3f1fe107a22025a8501fc6440d14e09599ba7153002531f84"},
+    {file = "torch-1.10.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:ef99b8cca5f9358119b07956915faf6e7906f433ab4a603c160ae9de88918371"},
+    {file = "torch-1.10.2-cp37-cp37m-win_amd64.whl", hash = "sha256:d43bc3f3a2d89ae185ef96d903c935c335219231e57685658648396984e2a67a"},
+    {file = "torch-1.10.2-cp37-none-macosx_10_9_x86_64.whl", hash = "sha256:6da1b877880435440a5aa9678ef0f01986d4886416844db1d97ebfb7fd1778d0"},
+    {file = "torch-1.10.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:ab77a9f838874f295ed5410c0686fa22547456e0116efb281c66ef5f9d46fe28"},
+    {file = "torch-1.10.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:9ef4c004f9e5168bd1c1930c6aff25fed5b097de81db6271ffbb2e4fb8b89319"},
+    {file = "torch-1.10.2-cp38-cp38-win_amd64.whl", hash = "sha256:376fc18407add20daa6bbaaffc5a5e06d733abe53bcbd60ef2532bfed34bc091"},
+    {file = "torch-1.10.2-cp38-none-macosx_10_9_x86_64.whl", hash = "sha256:f281438ee99bd72ad65c0bba1026a32e45c3b636bc067fc145ad291e9ea2faab"},
+    {file = "torch-1.10.2-cp38-none-macosx_11_0_arm64.whl", hash = "sha256:3592d3dd62b32760c82624e7586222747fe2281240e8653970b35f1d6d4a434c"},
+    {file = "torch-1.10.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:fbaf18c1b3e0b31af194a9d853e3739464cf982d279df9d34dd18f1c2a471878"},
+    {file = "torch-1.10.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:97b7b0c667e8b0dd1fc70137a36e0a4841ec10ef850bda60500ad066bef3e2de"},
+    {file = "torch-1.10.2-cp39-cp39-win_amd64.whl", hash = "sha256:901b52787baeb2e9e1357ca7037da0028bc6ad743f530e0040ae96ef8e27156c"},
+    {file = "torch-1.10.2-cp39-none-macosx_10_9_x86_64.whl", hash = "sha256:5b68e9108bd7ebd99eee941686046c517cfaac5331f757bcf440fe02f2e3ced1"},
+    {file = "torch-1.10.2-cp39-none-macosx_11_0_arm64.whl", hash = "sha256:b07ef01e36b716d0d65ca60c4db0ac9d094a0e797d9b55290da4dcda91463b6c"},
 ]
 tornado = [
     {file = "tornado-6.1-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:d371e811d6b156d82aa5f9a4e08b58debf97c302a35714f6f45e35139c332e32"},
@@ -6898,63 +7102,68 @@ typed-ast = [
     {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-3.10.0.2-py2-none-any.whl", hash = "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7"},
-    {file = "typing_extensions-3.10.0.2-py3-none-any.whl", hash = "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"},
-    {file = "typing_extensions-3.10.0.2.tar.gz", hash = "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e"},
+    {file = "typing_extensions-4.0.1-py3-none-any.whl", hash = "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"},
+    {file = "typing_extensions-4.0.1.tar.gz", hash = "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e"},
 ]
 ujson = [
-    {file = "ujson-4.2.0-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:02f5a6acc5aa5b054c32bdccd17064c2cbd07c81b3a49449589a4552888f1961"},
-    {file = "ujson-4.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e7c8cffd9e45248569fa576d19b043951a3edc67cbee3dca2a6b77e6998cb1ec"},
-    {file = "ujson-4.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d0abc1526d32ebe2f2b6fefcf82b9ee8661da3f45ecac087beee6aeaa21b39ec"},
-    {file = "ujson-4.2.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:26ebe3ac1e0d18d58e11dbf7cdd0459adcefd5c025ede99be7fceae47bd1bfc6"},
-    {file = "ujson-4.2.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:6e8c30186eaa4f982b9b56cad30b173b71aac9d6a393d97cbcbc4ca805e87943"},
-    {file = "ujson-4.2.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0db1acd8dbbf120095ce4ab118585219066ea2860332df2385a435c585036cae"},
-    {file = "ujson-4.2.0-cp310-cp310-win32.whl", hash = "sha256:68088596e237dcda862c1760d1feb2236a8cc36804507a9fcfaa3ed21442ff64"},
-    {file = "ujson-4.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:dd98d659365fb9271d9f9ba21160670ddfecb93deaec8a5350519a0ab3604654"},
-    {file = "ujson-4.2.0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:42f8def3e44d880774f644b53b4701a46889a9506e3fdc191c314c9e2e9b2a38"},
-    {file = "ujson-4.2.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bc9e2e6933ecec17a7d351116f555caee84b798076a4c5276ab1e8654c83bd90"},
-    {file = "ujson-4.2.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:adca402a97b8388c378d92c55b2bf4e8402baa5dfa059a85870a41e2f142a0d0"},
-    {file = "ujson-4.2.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0076de81aadc287f025525969bbc1272703be92933e988e5663a76ec5863628f"},
-    {file = "ujson-4.2.0-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:ff0ae4b1dc70c3362b04f4127e228b17e84946de611f85b32f565b990762deaf"},
-    {file = "ujson-4.2.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:40235c3704ac7f29b24a7a785f856e1c45a567c8cd4b57a025f516733e358972"},
-    {file = "ujson-4.2.0-cp36-cp36m-win32.whl", hash = "sha256:32f4340c8d6a34e7fa1f9447919ebd4b6256afef0965868d51ea3cdf0694a8f7"},
-    {file = "ujson-4.2.0-cp36-cp36m-win_amd64.whl", hash = "sha256:bac42d0131740b6f1d2b6a15f770c1fef0db97d05aba8564f3c75bb59a9c91c7"},
-    {file = "ujson-4.2.0-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:0ebc82847938e417092fd463e593da39a280fd12585b998e435a2a45bb7a33f7"},
-    {file = "ujson-4.2.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6bccfff9910fbe3dae6a17ec080c48fca0bfe939b18e4b2622122109d4d2570d"},
-    {file = "ujson-4.2.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8ec19982b7a40fb526b8ffd6edfff2c5c10556a54416d554c4bc83b1e4140a4c"},
-    {file = "ujson-4.2.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3697cae44a92c2264cf307d4cdd9ea436faa75a009d35a4097362a6bbf221a1b"},
-    {file = "ujson-4.2.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:b55dde52028f3c426197b9a928618fbb2b548172eb45824ddb19cdcdf8e493f9"},
-    {file = "ujson-4.2.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:d9a0252da73d8b69de60811252cbfde215d76ee6eea935a519e223353352026c"},
-    {file = "ujson-4.2.0-cp37-cp37m-win32.whl", hash = "sha256:a6e27ff0f92c719de004b806d84f471fff0157679e57517092b8f89345eb3a79"},
-    {file = "ujson-4.2.0-cp37-cp37m-win_amd64.whl", hash = "sha256:50f413177206373b3568dff28c091b2d8c9145e5e54b0a524d3823293d7a29b8"},
-    {file = "ujson-4.2.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:944dfdfae0cb4e4274a23e5070be913f7ff8f05666d8d143f2356cf873f9a77a"},
-    {file = "ujson-4.2.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50ddff58727cc4f90ade4c818884c4f0fbeeb1f78f764ab2b2bc89cf1f4db126"},
-    {file = "ujson-4.2.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78f8da27231b20d589319f743bd65011862691c102922be85c9f27e40656a0f7"},
-    {file = "ujson-4.2.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:99322e08e53580867c9909637747343354b7028a8208dc5df3d09233c8f52c30"},
-    {file = "ujson-4.2.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:5f863b12d27867b733d380a9878fc8c3ad11d3aea8a3650c33e7a8c2a888e1eb"},
-    {file = "ujson-4.2.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:c53653a12f6ce67b12e7806c190cce1db09c75de31212a5a9adbdbd7a2aba116"},
-    {file = "ujson-4.2.0-cp38-cp38-win32.whl", hash = "sha256:c9723a5e2743ded9bc6106cb04f86244dd779ad847d8ac189cfe808ab16946c1"},
-    {file = "ujson-4.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:fae1e251d9f9362ebc4adbbb252d0f4a023f66f180390624826fcb1812b808e9"},
-    {file = "ujson-4.2.0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:ab70a29914fc202f7c8f6353bb0622b91f878e2892e57a4c7293b341d5a85133"},
-    {file = "ujson-4.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf272e6302c62a42ed0125efcc1d891dd909bcfb3c6aa075d89de209b2b8e930"},
-    {file = "ujson-4.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6182898d7031d083017f9be47c6d57f9c2155d9f4391b77ed6c020cab8e5a471"},
-    {file = "ujson-4.2.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5a885675252e041e19cb92ff76419251fdd1ab4c2ca9766cb3ecfa6ae07884d2"},
-    {file = "ujson-4.2.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:535f1e5b336f7a0573da59bd9352e9cc6a93185bf4b1d96fb3379e07b4fc619a"},
-    {file = "ujson-4.2.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:26e299caa9bfc2e532e16de38de2af48cde48258922cda5efc0dd447d42692fc"},
-    {file = "ujson-4.2.0-cp39-cp39-win32.whl", hash = "sha256:fa68b25c987b73fb1c83ece34e52856c2c6da3031384f72638696c56fa8baca9"},
-    {file = "ujson-4.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:c7b2643b063f33e5e0d539cf2811793a7df9da525e63483f70c9262a343bd59d"},
-    {file = "ujson-4.2.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d61ae7a505105a16220a4282dbd552bef76968203e5e4f5edfdbb03d3159e3a"},
-    {file = "ujson-4.2.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bff484c162bd77877bc9ae6333b0a684493037ce3c5d8b664e8339becf9ad139"},
-    {file = "ujson-4.2.0-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:74961587e9c1682d3e04fe29e02b67ec9c88cb0c3406ad94cc617d04c6fa6db2"},
-    {file = "ujson-4.2.0.tar.gz", hash = "sha256:fffe509f556861c7343c6cba57ed05fe7bcf4b48a934a5b946ccb45428cf8883"},
+    {file = "ujson-5.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:644552d1e89983c08d0c24358fbcb5829ae5b5deee9d876e16d20085cfa7dc81"},
+    {file = "ujson-5.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0cae4a9c141856f7ad1a79c17ff1aaebf7fd8faa2f2c2614c37d6f82ed261d96"},
+    {file = "ujson-5.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ba63b789d83ca92237dbc72041a268d91559f981c01763a107105878bae442e"},
+    {file = "ujson-5.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe4e8f71e2fd42dce245bace7e2aa97dabef13926750a351eadca89a1e0f1abd"},
+    {file = "ujson-5.1.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6f73946c047a38640b1f5a2a459237b7bdc417ab028a76c796e4eea984b359b9"},
+    {file = "ujson-5.1.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:afe91153c2046fa8210b92def513124e0ea5b87ad8fa4c14fef8197204b980f1"},
+    {file = "ujson-5.1.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:b1ef400fc73ab0cb61b74a662ad4207917223aba6f933a9fea9b0fbe75de2361"},
+    {file = "ujson-5.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:5c8a884d60dd2eed2fc95a9474d57ead82adf254f54caffb3d9e8ed185c49aba"},
+    {file = "ujson-5.1.0-cp310-cp310-win32.whl", hash = "sha256:173b90a2c2836ee42f708df88ecfe3efbc4d868df73c9fcea8cb8f6f3ab93892"},
+    {file = "ujson-5.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:6c45ad95e82155372d9908774db46e0ef7880af28a734d0b14eaa4f505e64982"},
+    {file = "ujson-5.1.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:4155a7c29bf330329519027c815e15e381c1fff22f50d26f135584d482bbd95d"},
+    {file = "ujson-5.1.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fa616d0d3c594785c6e9b7f42686bb1c86f9e64aa0f30a72c86d8eb315f54194"},
+    {file = "ujson-5.1.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a48efcb5d3695b295c26835ed81048da8cd40e76c4fde2940c807aa452b560c9"},
+    {file = "ujson-5.1.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:838d35eb9006d36f9241e95958d9f4819bcf1ea2ec155daf92d5751c31bcc62b"},
+    {file = "ujson-5.1.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:05aa6c7297a22081f65497b6f586de6b7060ea47c3ecda80896f47200e9dbf04"},
+    {file = "ujson-5.1.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:ce441ab7ad1db592e2db95b6c2a1eb882123532897340afac1342c28819e9833"},
+    {file = "ujson-5.1.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:9937e819196b894ffd00801b24f1042dabda142f355313c3f20410993219bc4f"},
+    {file = "ujson-5.1.0-cp37-cp37m-win32.whl", hash = "sha256:06bed66ae62d517f67a61cf53c056800b35ef364270723168a1db62702e2d30c"},
+    {file = "ujson-5.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:74e41a0222e6e8136e38f103d6cc228e4e20f1c35cc80224a42804fd67fb35c8"},
+    {file = "ujson-5.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7bbb87f040e618bebe8c6257b3e4e8ae2f708dcbff3270c84718b3360a152799"},
+    {file = "ujson-5.1.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:68e38122115a8097fbe1cfe52979a797eaff91c10c1bf4b27774e5f30e7f723a"},
+    {file = "ujson-5.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b09843123425337d2efee5c8ff6519e4dfc7b044db66c8bd560517fc1070a157"},
+    {file = "ujson-5.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8dca10174a3bd482d969a2d12d0aec2fdd63fb974e255ec0147e36a516a2d68a"},
+    {file = "ujson-5.1.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:202ae52f4a53f03c42ead6d046b1a146517e93bd757f517bdeef0a26228e0260"},
+    {file = "ujson-5.1.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:7a4bed7bd7b288cf73ba47bda27fdd1d78ef6906831489e7f296aef9e786eccb"},
+    {file = "ujson-5.1.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:d423956f8dfd98a075c9338b886414b6e3c2817dbf67935797466c998af39936"},
+    {file = "ujson-5.1.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:083c1078e4de3a39019e590c43865b17e07a763fee25b012e650bb4f42c89703"},
+    {file = "ujson-5.1.0-cp38-cp38-win32.whl", hash = "sha256:31671ad99f0395eb881d698f2871dc64ff00fbd4380c5d9bfd8bff3d4c8f8d88"},
+    {file = "ujson-5.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:994eaf4369e6bc24258f59fe8c6345037abcf24557571814e27879851c4353aa"},
+    {file = "ujson-5.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:00d6ea9702c2eaeaf1a826934eaba1b4c609c873379bf54e36ba7b7e128edf94"},
+    {file = "ujson-5.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a53c4fe8e1c067e6c98b4526e982ed9486f08578ad8eb5f0e94f8cadf0c1d911"},
+    {file = "ujson-5.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:368f855779fded560724a6448838304621f498113a116d66bc5ed5ad5ad3ca92"},
+    {file = "ujson-5.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4dd97e45a0f450ba2c43cda18147e54b8e41e886c22e3506c62f7d61e9e53b0d"},
+    {file = "ujson-5.1.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:caeadbf95ce277f1f8f4f71913bc20c01f49fc9228f238920f9ff6f7645d2a5f"},
+    {file = "ujson-5.1.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:681fed63c948f757466eeb3aea98873e2ab8b2b18e9020c96a97479a513e2018"},
+    {file = "ujson-5.1.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:6fc4376266ae67f6d8f9e69386ab950eb84ba345c6fdbeb1884fa5b773c8c76b"},
+    {file = "ujson-5.1.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:585271d6ad545a2ccfc237582f70c160e627735c89d0ca2bde24afa321bc0750"},
+    {file = "ujson-5.1.0-cp39-cp39-win32.whl", hash = "sha256:b631af423e6d5d35f9f37fbcc4fbdb6085abc1c441cf864c64b7fbb5b150faf7"},
+    {file = "ujson-5.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:08265db5ccff8b521ff68aee13a417d68cca784d7e711d961b92fda6ccffcc4f"},
+    {file = "ujson-5.1.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:e2b1c372583eb4363b42e21222d3a18116a41973781d502d61e1b0daf4b8352f"},
+    {file = "ujson-5.1.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:51142c9d40439f299594e399bef8892a16586ded54c88d3af926865ca221a177"},
+    {file = "ujson-5.1.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ba8be1717b1867a85b2413a8585bad0e4507a22d6af2c244e1c74151f6d5cc0"},
+    {file = "ujson-5.1.0-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d0b26d9d6eb9a0979d37f28c715e717a409c9e03163e5cd8fa73aab806351ab5"},
+    {file = "ujson-5.1.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:b2c7e4afde0d36926b091fa9613b18b65e911fcaa60024e8721f2dcfedc25329"},
+    {file = "ujson-5.1.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:110633a8dda6c8ca78090292231e15381f8b2423e998399d4bc5f135149c722b"},
+    {file = "ujson-5.1.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fdac161127ef8e0889180a4c07475457c55fe0bbd644436d8f4c7ef07565d653"},
+    {file = "ujson-5.1.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:452990c2b18445a7379a45873527d2ec47789b9289c13a17a3c1cc76b9641126"},
+    {file = "ujson-5.1.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5304ad25d100d50b5bc8513ef110335df678f66c7ccf3d4728c0c3aa69e08e0c"},
+    {file = "ujson-5.1.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:ce620a6563b21aa3fbb1658bc1bfddb484a6dad542de1efb5121eb7bb4f2b93a"},
+    {file = "ujson-5.1.0.tar.gz", hash = "sha256:a88944d2f99db71a3ca0c63d81f37e55b660edde0b07216fb65a3e46403ef004"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.7-py2.py3-none-any.whl", hash = "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"},
-    {file = "urllib3-1.26.7.tar.gz", hash = "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece"},
+    {file = "urllib3-1.26.8-py2.py3-none-any.whl", hash = "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed"},
+    {file = "urllib3-1.26.8.tar.gz", hash = "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"},
 ]
 wandb = [
-    {file = "wandb-0.12.6-py2.py3-none-any.whl", hash = "sha256:a486a697d18ca82e1cde64aa60997a9a37c71af3c6946240bda81a4d61f2bcf4"},
-    {file = "wandb-0.12.6.tar.gz", hash = "sha256:ad946efc269b25a36b500a831b6bf9ae26b4a695add55e4a53f5b7220e03b177"},
+    {file = "wandb-0.12.9-py2.py3-none-any.whl", hash = "sha256:32b24334c6f59ed238481c4cb3cffa2b951749fd62aaf061c6cac666bb0f30ac"},
+    {file = "wandb-0.12.9.tar.gz", hash = "sha256:2aad811ff0151be62ffdf49d5fcd027c222d2861b5f459134e778d1a7eee6a1b"},
 ]
 watchdog = [
     {file = "watchdog-2.1.6-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9693f35162dc6208d10b10ddf0458cc09ad70c30ba689d9206e02cd836ce28a3"},
@@ -7001,14 +7210,14 @@ wurlitzer = [
     {file = "wurlitzer-3.0.2.tar.gz", hash = "sha256:36051ac530ddb461a86b6227c4b09d95f30a1d1043de2b4a592e97ae8a84fcdf"},
 ]
 yapf = [
-    {file = "yapf-0.31.0-py2.py3-none-any.whl", hash = "sha256:e3a234ba8455fe201eaa649cdac872d590089a18b661e39bbac7020978dd9c2e"},
-    {file = "yapf-0.31.0.tar.gz", hash = "sha256:408fb9a2b254c302f49db83c59f9aa0b4b0fd0ec25be3a5c51181327922ff63d"},
+    {file = "yapf-0.32.0-py2.py3-none-any.whl", hash = "sha256:8fea849025584e486fd06d6ba2bed717f396080fd3cc236ba10cb97c4c51cf32"},
+    {file = "yapf-0.32.0.tar.gz", hash = "sha256:a3f5085d37ef7e3e004c4ba9f9b3e40c54ff1901cd111f05145ae313a7c67d1b"},
 ]
 yaspin = [
     {file = "yaspin-2.1.0-py3-none-any.whl", hash = "sha256:d574cbfaf0a349df466c91f7f81b22460ae5ebb15ecb8bf9411d6049923aee8d"},
     {file = "yaspin-2.1.0.tar.gz", hash = "sha256:c8d34eca9fda3f4dfbe59f57f3cf0f3641af3eefbf1544fbeb9b3bacf82c580a"},
 ]
 zipp = [
-    {file = "zipp-3.6.0-py3-none-any.whl", hash = "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"},
-    {file = "zipp-3.6.0.tar.gz", hash = "sha256:71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832"},
+    {file = "zipp-3.7.0-py3-none-any.whl", hash = "sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375"},
+    {file = "zipp-3.7.0.tar.gz", hash = "sha256:9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -406,7 +406,7 @@ name = "cycler"
 version = "0.11.0"
 description = "Composable style cycles"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 
 [[package]]
@@ -519,7 +519,7 @@ name = "fonttools"
 version = "4.29.0"
 description = "Tools to manipulate font files"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 
 [package.extras]
@@ -668,12 +668,12 @@ numpy = ">=1.18.0"
 
 [package.extras]
 accept-rom-license = ["autorom[accept-rom-license] (>=0.4.2,<0.5.0)"]
-all = ["box2d-py (==2.3.5)", "pyglet (>=1.4.0)", "ale-py (>=0.7.1,<0.8.0)", "lz4 (>=3.1.0)", "opencv-python (>=3.0)", "pygame (==2.1.0)", "scipy (>=1.4.1)", "mujoco-py (>=1.50,<2.0)"]
+all = ["pygame (==2.1.0)", "scipy (>=1.4.1)", "lz4 (>=3.1.0)", "opencv-python (>=3.0)", "ale-py (>=0.7.1,<0.8.0)", "box2d-py (==2.3.5)", "pyglet (>=1.4.0)", "mujoco-py (>=1.50,<2.0)"]
 atari = ["ale-py (>=0.7.1,<0.8.0)"]
 box2d = ["box2d-py (==2.3.5)", "pyglet (>=1.4.0)"]
 classic_control = ["pyglet (>=1.4.0)"]
 mujoco = ["mujoco-py (>=1.50,<2.0)"]
-nomujoco = ["box2d-py (==2.3.5)", "pyglet (>=1.4.0)", "lz4 (>=3.1.0)", "opencv-python (>=3.0)", "pygame (==2.1.0)", "scipy (>=1.4.1)"]
+nomujoco = ["lz4 (>=3.1.0)", "opencv-python (>=3.0)", "box2d-py (==2.3.5)", "pyglet (>=1.4.0)", "pygame (==2.1.0)", "scipy (>=1.4.1)"]
 other = ["lz4 (>=3.1.0)", "opencv-python (>=3.0)"]
 toy_text = ["pygame (==2.1.0)", "scipy (>=1.4.1)"]
 
@@ -1031,7 +1031,7 @@ name = "kiwisolver"
 version = "1.3.2"
 description = "A fast implementation of the Cassowary constraint solver"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 
 [[package]]
@@ -1069,7 +1069,7 @@ name = "matplotlib"
 version = "3.5.1"
 description = "Python plotting package"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -1323,7 +1323,7 @@ name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -1334,7 +1334,7 @@ name = "pandas"
 version = "1.3.5"
 description = "Powerful data structures for data analysis, time series, and statistics"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7.1"
 
 [package.dependencies]
@@ -1451,7 +1451,7 @@ name = "pillow"
 version = "9.0.0"
 description = "Python Imaging Library (Fork)"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 
 [[package]]
@@ -1587,7 +1587,7 @@ pyasn1 = ">=0.4.6,<0.5.0"
 
 [[package]]
 name = "pybullet"
-version = "3.2.1"
+version = "3.1.8"
 description = "Official Python Interface for the Bullet Physics SDK specialized for Robotics Simulation and Reinforcement Learning"
 category = "main"
 optional = true
@@ -3577,7 +3577,7 @@ name = "pyparsing"
 version = "3.0.7"
 description = "Python parsing module"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 
 [package.extras]
@@ -3739,7 +3739,7 @@ name = "pytz"
 version = "2021.3"
 description = "World timezone definitions, modern and historical"
 category = "main"
-optional = true
+optional = false
 python-versions = "*"
 
 [[package]]
@@ -4025,7 +4025,7 @@ name = "setuptools-scm"
 version = "6.4.2"
 description = "the blessed package to manage your versions by scm tags"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -4254,7 +4254,7 @@ name = "stable-baselines3"
 version = "1.2.0"
 description = "Pytorch version of Stable Baselines, implementations of reinforcement learning algorithms."
 category = "main"
-optional = true
+optional = false
 python-versions = "*"
 
 [package.dependencies]
@@ -4406,7 +4406,7 @@ name = "tomli"
 version = "1.2.3"
 description = "A lil' TOML parser"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 
 [[package]]
@@ -4614,13 +4614,13 @@ docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [extras]
-atari = ["ale-py", "AutoROM", "stable-baselines3"]
+atari = ["ale-py", "AutoROM"]
 cloud = ["boto3", "awscli"]
 docs = ["mkdocs-material"]
 mujoco = ["free-mujoco-py"]
-pettingzoo = ["pettingzoo", "stable-baselines3", "pygame", "pymunk"]
+pettingzoo = ["pettingzoo", "pygame", "pymunk"]
 plot = ["pandas", "seaborn"]
-procgen = ["procgen", "stable-baselines3"]
+procgen = ["procgen"]
 pybullet = ["pybullet"]
 pytest = ["pytest"]
 spyder = ["spyder"]
@@ -4628,7 +4628,7 @@ spyder = ["spyder"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<3.10"
-content-hash = "340df3ea47e965ceb0a5e33b5e8c288ac91f92205eec11dc23148caaf93959b2"
+content-hash = "1a87f0fe31e2902e2fa094a2028cfd449762e23fc28bf67ef1b03832a4b02d95"
 
 [metadata.files]
 absl-py = [
@@ -5675,13 +5675,14 @@ pyasn1-modules = [
     {file = "pyasn1_modules-0.2.8-py3.7.egg", hash = "sha256:c29a5e5cc7a3f05926aff34e097e84f8589cd790ce0ed41b67aed6857b26aafd"},
 ]
 pybullet = [
-    {file = "pybullet-3.2.1-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a7558b63c754ee13e5937d348a6a1e496bc317983b0229a0351f896bd5678ed7"},
-    {file = "pybullet-3.2.1-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:ed73517895eee6b238e5bc140040edab9fd6883b49fce2fed03f8fe87877e36d"},
-    {file = "pybullet-3.2.1-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:86ea0d85d538ffdbdc4684708fc81bff3371b14b5ad2207e67d653b5083879d2"},
-    {file = "pybullet-3.2.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:10f0b947eeea4d42f324a727be701bef1cfebf3cb532332a9c7549cf34b76475"},
-    {file = "pybullet-3.2.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:8c3cfff5f2c3797891ccfdfe5893945be9545c44596034f7240a2c766b1f4d73"},
-    {file = "pybullet-3.2.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:ef8101bcac2f618b4b9fdd926394d5611b0c7c8df8217f98b728da254b597cb6"},
-    {file = "pybullet-3.2.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6196110885debf7528f03ab9aecd5f61d5de4654a39c8cbea3ce496220ea6e4f"},
+    {file = "pybullet-3.1.8-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:53e7ca296a9efecb33ee80be29a28a49508bfaea6624c2dd26c670d76b0bd7fb"},
+    {file = "pybullet-3.1.8-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:b70d560786a94bada2537f3d55a7820855d1fa3caea8de023d88f03c97d40539"},
+    {file = "pybullet-3.1.8-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:bc3c4873d12ec9acbf46a47fac8339c0be7ce6b32ee22a5b209eda18d2dfd08e"},
+    {file = "pybullet-3.1.8-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0ae9bef2f8ea6b30ee0f8fbc7051801d9b47e82ec8637a47e47a0675d4f03fa4"},
+    {file = "pybullet-3.1.8-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d47ca592b2621fd05e2c234f15858293e6a53bb04cbd29df5c06d5ca7ef2c6e5"},
+    {file = "pybullet-3.1.8-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2f4741953b56917231a44ff5767e2b5bb2e8bb2cb1ea6488f555f6754ef90751"},
+    {file = "pybullet-3.1.8-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:df0ccb74e8e307506fd6cc57e5ad7b2c3b7d23ec2a7c8fa16c02fae863ded904"},
+    {file = "pybullet-3.1.8.tar.gz", hash = "sha256:a7e6c7c77cab39e1559c98e4290c5138247b15d3a26a76a23b2737c159f3f905"},
 ]
 pycodestyle = [
     {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ gym = { git = "https://github.com/openai/gym", rev = "b9e8b6c" }
 # Optinal dependencies
 ale-py = {version = "^0.7", optional = true}
 AutoROM = {version = "^0.4.2", optional = true, extras = ["accept-rom-license"]}
-pybullet = {version = "^3.1.8", optional = true}
+pybullet = {version = "3.1.8", optional = true}
 procgen = {version = "^0.10.4", optional = true}
 pettingzoo = {version = "^1.11.2", optional = true}
 pygame = {version = "^2.0.1", optional = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,10 @@ tensorboard = "^2.5.0"
 wandb = "^0.12.1"
 pyglet = "^1.5.19"
 opencv-python = "^4.5.3"
-gym = "^0.21.0"
+stable-baselines3 = "^1.1.0"
+gym = { git = "https://github.com/openai/gym", rev = "b9e8b6c" }
 
 # Optinal dependencies
-stable-baselines3 = {version = "^1.1.0", optional = true}
 ale-py = {version = "^0.7", optional = true}
 AutoROM = {version = "^0.4.2", optional = true, extras = ["accept-rom-license"]}
 pybullet = {version = "^3.1.8", optional = true}
@@ -39,10 +39,10 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.extras]
-atari = ["ale-py", "AutoROM", "stable-baselines3"]
+atari = ["ale-py", "AutoROM"]
 pybullet = ["pybullet"]
-procgen = ["procgen", "stable-baselines3"]
-pettingzoo = ["pettingzoo", "stable-baselines3", "pygame", "pymunk"]
+procgen = ["procgen"]
+pettingzoo = ["pettingzoo", "pygame", "pymunk"]
 plot = ["pandas", "seaborn"]
 cloud = ["boto3", "awscli"]
 spyder = ["spyder"]

--- a/tests/test_atari.py
+++ b/tests/test_atari.py
@@ -11,7 +11,7 @@ def test_ppo():
 
 def test_dqn():
     subprocess.run(
-        "python cleanrl/dqn_atari.py --learning-starts 10 --total-timesteps 16 --buffer-size 10",
+        "python cleanrl/dqn_atari.py --learning-starts 10 --total-timesteps 16 --buffer-size 10 --batch-size 4",
         shell=True,
         check=True,
     )
@@ -19,7 +19,7 @@ def test_dqn():
 
 def test_c51():
     subprocess.run(
-        "python cleanrl/c51_atari.py --learning-starts 10 --total-timesteps 16 --buffer-size 10",
+        "python cleanrl/c51_atari.py --learning-starts 10 --total-timesteps 16 --buffer-size 10 --batch-size 4",
         shell=True,
         check=True,
     )

--- a/tests/test_atari.py
+++ b/tests/test_atari.py
@@ -11,7 +11,7 @@ def test_ppo():
 
 def test_dqn():
     subprocess.run(
-        "python cleanrl/dqn_atari.py --learning-starts 200 --total-timesteps 204",
+        "python cleanrl/dqn_atari.py --learning-starts 10 --total-timesteps 16 --buffer-size 10",
         shell=True,
         check=True,
     )
@@ -19,7 +19,7 @@ def test_dqn():
 
 def test_c51():
     subprocess.run(
-        "python cleanrl/c51_atari.py --learning-starts 200 --total-timesteps 204",
+        "python cleanrl/c51_atari.py --learning-starts 10 --total-timesteps 16 --buffer-size 10",
         shell=True,
         check=True,
     )


### PR DESCRIPTION
Continue on #79. This PR refactors the value based methods. Specifically, we

1. Adopted the replay buffer from Stable-baselines 3. SB3's replay buffer is well-implemented and its behavior is intuitive. That is, we can imagine what happens when we do `buffer.sample()` compared to something like `agent.learn()`, which is much more abstract. To this end, I think it's worth to adopt SB3's replay buffer. In the future, when SB3 introduce prioritized replay buffer (https://github.com/hill-a/stable-baselines/issues/751), it will also make it easier for us to adopt.
2. General format refactoring.

- [x] match DDPG performance
- [x] match TD3 performance
- [x] match C51 performance
- [x] match DQN performance