### PR TITLE
Fix replay buffer compatibility with mujoco envs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -115,5 +115,12 @@ jobs:
         run: poetry install -E mujoco
       - name: Downgrade setuptools
         run: poetry run pip install setuptools==59.5.0
-      - name: Run pybullet tests
+      - name: install mujoco dependencies
+        run: |
+          apt-get -y install wget unzip software-properties-common \
+            libgl1-mesa-dev \
+            libgl1-mesa-glx \
+            libglew-dev \
+            libosmesa6-dev patchelf
+      - name: Run mujoco tests
         run: poetry run pytest tests/test_mujoco.py

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -86,3 +86,34 @@ jobs:
         run: poetry run pip install setuptools==59.5.0
       - name: Run pybullet tests
         run: poetry run pytest tests/test_pybullet.py
+
+
+  test-mujoco-envs:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.8]
+        poetry-version: [1.1.11]
+        os: [ubuntu-18.04]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Run image
+        uses: abatilo/actions-poetry@v2.0.0
+        with:
+          poetry-version: ${{ matrix.poetry-version }}
+
+      # pybullet tests
+      - name: Install core dependencies
+        run: poetry install -E pytest
+      - name: Install pybullet dependencies
+        run: poetry install -E pybullet
+      - name: Install mujoco dependencies
+        run: poetry install -E mujoco
+      - name: Downgrade setuptools
+        run: poetry run pip install setuptools==59.5.0
+      - name: Run pybullet tests
+        run: poetry run pytest tests/test_mujoco.py

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -117,7 +117,7 @@ jobs:
         run: poetry run pip install setuptools==59.5.0
       - name: install mujoco dependencies
         run: |
-          apt-get -y install wget unzip software-properties-common \
+          sudo apt-get update && sudo apt-get -y install wget unzip software-properties-common \
             libgl1-mesa-dev \
             libgl1-mesa-glx \
             libglew-dev \

--- a/cleanrl/ddpg_continuous_action.py
+++ b/cleanrl/ddpg_continuous_action.py
@@ -153,9 +153,7 @@ if __name__ == "__main__":
     actor_optimizer = optim.Adam(list(actor.parameters()), lr=args.learning_rate)
 
     envs.single_observation_space.dtype = np.float32
-    rb = ReplayBuffer(
-        args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device
-    )
+    rb = ReplayBuffer(args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device)
     loss_fn = nn.MSELoss()
 
     # TRY NOT TO MODIFY: start the game

--- a/cleanrl/ddpg_continuous_action.py
+++ b/cleanrl/ddpg_continuous_action.py
@@ -168,7 +168,7 @@ if __name__ == "__main__":
                 [
                     (
                         actions.tolist()[0]
-                        + np.random.normal(0, max_action * args.exploration_noise, size=envs.action_space.shape[0])
+                        + np.random.normal(0, max_action * args.exploration_noise, size=envs.single_action_space.shape[0])
                     ).clip(envs.single_action_space.low, envs.single_action_space.high)
                 ]
             )

--- a/cleanrl/ddpg_continuous_action.py
+++ b/cleanrl/ddpg_continuous_action.py
@@ -152,8 +152,9 @@ if __name__ == "__main__":
     q_optimizer = optim.Adam(list(qf1.parameters()), lr=args.learning_rate)
     actor_optimizer = optim.Adam(list(actor.parameters()), lr=args.learning_rate)
 
+    envs.single_observation_space.dtype = np.float32
     rb = ReplayBuffer(
-        args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device, optimize_memory_usage=True
+        args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device
     )
     loss_fn = nn.MSELoss()
 

--- a/cleanrl/ddpg_continuous_action.py
+++ b/cleanrl/ddpg_continuous_action.py
@@ -168,7 +168,7 @@ if __name__ == "__main__":
                 [
                     (
                         actions.tolist()[0]
-                        + np.random.normal(0, max_action * args.exploration_noise, size=envs.single_action_space.shape[0])
+                        + np.random.normal(0, max_action * args.exploration_noise, size=envs.action_space.shape[0])
                     ).clip(envs.single_action_space.low, envs.single_action_space.high)
                 ]
             )

--- a/cleanrl/sac_continuous_action.py
+++ b/cleanrl/sac_continuous_action.py
@@ -203,8 +203,9 @@ if __name__ == "__main__":
     else:
         alpha = args.alpha
 
+    envs.single_observation_space.dtype = np.float32
     rb = ReplayBuffer(
-        args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device, optimize_memory_usage=True
+        args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device
     )
 
     # TRY NOT TO MODIFY: start the game

--- a/cleanrl/sac_continuous_action.py
+++ b/cleanrl/sac_continuous_action.py
@@ -204,9 +204,7 @@ if __name__ == "__main__":
         alpha = args.alpha
 
     envs.single_observation_space.dtype = np.float32
-    rb = ReplayBuffer(
-        args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device
-    )
+    rb = ReplayBuffer(args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device)
 
     # TRY NOT TO MODIFY: start the game
     obs = envs.reset()

--- a/cleanrl/td3_continuous_action.py
+++ b/cleanrl/td3_continuous_action.py
@@ -157,8 +157,9 @@ if __name__ == "__main__":
     q_optimizer = optim.Adam(list(qf1.parameters()) + list(qf2.parameters()), lr=args.learning_rate)
     actor_optimizer = optim.Adam(list(actor.parameters()), lr=args.learning_rate)
 
+    envs.single_observation_space.dtype = np.float32
     rb = ReplayBuffer(
-        args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device, optimize_memory_usage=True
+        args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device
     )
     loss_fn = nn.MSELoss()
 
@@ -174,7 +175,7 @@ if __name__ == "__main__":
                 [
                     (
                         actions.tolist()[0]
-                        + np.random.normal(0, max_action * args.exploration_noise, size=envs.action_space.shape[0])
+                        + np.random.normal(0, max_action * args.exploration_noise, size=envs.single_action_space.shape[0])
                     ).clip(envs.single_action_space.low, envs.single_action_space.high)
                 ]
             )

--- a/cleanrl/td3_continuous_action.py
+++ b/cleanrl/td3_continuous_action.py
@@ -158,9 +158,7 @@ if __name__ == "__main__":
     actor_optimizer = optim.Adam(list(actor.parameters()), lr=args.learning_rate)
 
     envs.single_observation_space.dtype = np.float32
-    rb = ReplayBuffer(
-        args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device
-    )
+    rb = ReplayBuffer(args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device)
     loss_fn = nn.MSELoss()
 
     # TRY NOT TO MODIFY: start the game

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ wandb = "^0.12.1"
 pyglet = "^1.5.19"
 opencv-python = "^4.5.3"
 stable-baselines3 = "^1.1.0"
-gym = "^0.22.0"
+gym = { git = "https://github.com/openai/gym", rev = "b9e8b6c" }
 
 # Optional dependencies
 ale-py = {version = "^0.7", optional = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ wandb = "^0.12.1"
 pyglet = "^1.5.19"
 opencv-python = "^4.5.3"
 stable-baselines3 = "^1.1.0"
-gym = { git = "https://github.com/openai/gym", rev = "b9e8b6c" }
+gym = "^0.22.0"
 
 # Optional dependencies
 ale-py = {version = "^0.7", optional = true}

--- a/tests/test_mujoco.py
+++ b/tests/test_mujoco.py
@@ -1,0 +1,27 @@
+import subprocess
+
+
+def test_pybullet():
+    """
+    Test classic control
+    """
+    subprocess.run(
+        "python cleanrl/ppo_continuous_action.py --gym-id Hopper-v2 --num-envs 1 --num-steps 64 --total-timesteps 256",
+        shell=True,
+        check=True,
+    )
+    subprocess.run(
+        "python cleanrl/ddpg_continuous_action.py --gym-id Hopper-v2 --learning-starts 100 --batch-size 32 --total-timesteps 105",
+        shell=True,
+        check=True,
+    )
+    subprocess.run(
+        "python cleanrl/td3_continuous_action.py --gym-id Hopper-v2 --learning-starts 100 --batch-size 32 --total-timesteps 105",
+        shell=True,
+        check=True,
+    )
+    subprocess.run(
+        "python cleanrl/sac_continuous_action.py --gym-id Hopper-v2 --batch-size 128 --total-timesteps 135",
+        shell=True,
+        check=True,
+    )


### PR DESCRIPTION
The current DDPG SAC TD3 files are not compatible with mujoco envs (see below), and this PR fixes it.

```
(cleanrl-ghSZGHE3-py3.9) ➜  cleanrl git:(fix-mujoco-compatibility) ✗ python -i ddpg_continuous_action.py --gym-id Hopper-v2 --learning-starts 100
/home/costa/.cache/pypoetry/virtualenvs/cleanrl-ghSZGHE3-py3.9/lib/python3.9/site-packages/gym/envs/registration.py:479: UserWarning: WARN: The environment Hopper-v2 is out of date. You should consider upgrading to version `v3` with the environment ID `Hopper-v3`.
  logger.warn(
global_step=23, episode_reward=8.566108703613281
global_step=41, episode_reward=7.716689109802246
global_step=63, episode_reward=17.882747650146484
global_step=73, episode_reward=6.347293853759766
global_step=86, episode_reward=10.202958106994629
global_step=99, episode_reward=7.710036277770996
Traceback (most recent call last):
  File "/home/costa/Documents/go/src/github.com/cleanrl/cleanrl/ddpg_continuous_action.py", line 200, in <module>
    next_state_actions = (target_actor.forward(data.next_observations)).clamp(
  File "/home/costa/Documents/go/src/github.com/cleanrl/cleanrl/ddpg_continuous_action.py", line 107, in forward
    x = F.relu(self.fc1(x))
  File "/home/costa/.cache/pypoetry/virtualenvs/cleanrl-ghSZGHE3-py3.9/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1102, in _call_impl
    return forward_call(*input, **kwargs)
  File "/home/costa/.cache/pypoetry/virtualenvs/cleanrl-ghSZGHE3-py3.9/lib/python3.9/site-packages/torch/nn/modules/linear.py", line 103, in forward
    return F.linear(input, self.weight, self.bias)
  File "/home/costa/.cache/pypoetry/virtualenvs/cleanrl-ghSZGHE3-py3.9/lib/python3.9/site-packages/torch/nn/functional.py", line 1848, in linear
    return torch._C._nn.linear(input, weight, bias)
RuntimeError: expected scalar type Float but found Double
```