### PR TITLE
Refactor `parse_args()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ poetry install
 # `python run cleanrl/ppo.py`
 poetry run python cleanrl/ppo.py \
     --seed 1 \
-    --gym-id CartPole-v0 \
+    --env-id CartPole-v0 \
     --total-timesteps 50000
 
 # open another temrminal and enter `cd cleanrl/cleanrl`
@@ -55,7 +55,7 @@ To use experiment tracking with wandb, run
 wandb login # only required for the first time
 poetry run python cleanrl/ppo.py \
     --seed 1 \
-    --gym-id CartPole-v0 \
+    --env-id CartPole-v0 \
     --total-timesteps 50000 \
     --track \
     --wandb-project-name cleanrltest
@@ -66,37 +66,37 @@ To run training scripts in other games:
 poetry shell
 
 # classic control
-python cleanrl/dqn.py --gym-id CartPole-v1
-python cleanrl/ppo.py --gym-id CartPole-v1
-python cleanrl/c51.py --gym-id CartPole-v1
+python cleanrl/dqn.py --env-id CartPole-v1
+python cleanrl/ppo.py --env-id CartPole-v1
+python cleanrl/c51.py --env-id CartPole-v1
 
 # atari
 poetry install -E atari
-python cleanrl/dqn_atari.py --gym-id BreakoutNoFrameskip-v4
-python cleanrl/c51_atari.py --gym-id BreakoutNoFrameskip-v4
-python cleanrl/ppo_atari.py --gym-id BreakoutNoFrameskip-v4
-python cleanrl/apex_dqn_atari.py --gym-id BreakoutNoFrameskip-v4
+python cleanrl/dqn_atari.py --env-id BreakoutNoFrameskip-v4
+python cleanrl/c51_atari.py --env-id BreakoutNoFrameskip-v4
+python cleanrl/ppo_atari.py --env-id BreakoutNoFrameskip-v4
+python cleanrl/apex_dqn_atari.py --env-id BreakoutNoFrameskip-v4
 
 # NEW: 3-4x side-effects free speed up with envpool's atari (only available to linux)
 poetry install -E envpool
-python cleanrl/ppo_atari_envpool.py --gym-id BreakoutNoFrameskip-v4
+python cleanrl/ppo_atari_envpool.py --env-id BreakoutNoFrameskip-v4
 # Learn Pong-v5 in ~5-10 mins
 # Side effects such as lower sample efficiency might occur
 poetry run python ppo_atari_envpool.py --clip-coef=0.2 --num-envs=16 --num-minibatches=8 --num-steps=128 --update-epochs=3
 
 # pybullet
 poetry install -E pybullet
-python cleanrl/td3_continuous_action.py --gym-id MinitaurBulletDuckEnv-v0
-python cleanrl/ddpg_continuous_action.py --gym-id MinitaurBulletDuckEnv-v0
-python cleanrl/sac_continuous_action.py --gym-id MinitaurBulletDuckEnv-v0
+python cleanrl/td3_continuous_action.py --env-id MinitaurBulletDuckEnv-v0
+python cleanrl/ddpg_continuous_action.py --env-id MinitaurBulletDuckEnv-v0
+python cleanrl/sac_continuous_action.py --env-id MinitaurBulletDuckEnv-v0
 
 # procgen
 poetry install -E procgen
-python cleanrl/ppo_procgen.py --gym-id starpilot
-python cleanrl/ppg_procgen.py --gym-id starpilot
+python cleanrl/ppo_procgen.py --env-id starpilot
+python cleanrl/ppg_procgen.py --env-id starpilot
 
 # ppo + lstm
-python cleanrl/ppo_atari_lstm.py --gym-id BreakoutNoFrameskip-v4
+python cleanrl/ppo_atari_lstm.py --env-id BreakoutNoFrameskip-v4
 python cleanrl/ppo_memory_env_lstm.py
 ```
 

--- a/cleanrl/apex_dqn_atari.py
+++ b/cleanrl/apex_dqn_atari.py
@@ -750,7 +750,7 @@ def linear_schedule(start_e: float, end_e: float, duration: int, t: int):
 
 
 def act(args, experiment_name, i, q_network, target_network, lock, rollouts_queue, stats_queue, global_step, device):
-    env = gym.make(args.gym_id)
+    env = gym.make(args.env_id)
     env = wrap_atari(env)
     env = gym.wrappers.RecordEpisodeStatistics(env)  # records episode reward in `info['episode']['r']`
     if args.capture_video:
@@ -920,7 +920,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"), help="the name of this experiment"
     )
-    parser.add_argument("--gym-id", type=str, default="BreakoutNoFrameskip-v4", help="the id of the gym environment")
+    parser.add_argument("--env-id", type=str, default="BreakoutNoFrameskip-v4", help="the id of the environment")
     parser.add_argument("--learning-rate", type=float, default=1e-4, help="the learning rate of the optimizer")
     parser.add_argument("--seed", type=int, default=2, help="seed of the experiment")
     parser.add_argument("--total-timesteps", type=int, default=10000000, help="total timesteps of the experiments")
@@ -988,7 +988,7 @@ if __name__ == "__main__":
         args.seed = int(time.time())
 
     # TRY NOT TO MODIFY: setup the environment
-    experiment_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    experiment_name = f"{args.env_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
     writer = SummaryWriter(f"runs/{experiment_name}")
     writer.add_text(
         "hyperparameters", "|param|value|\n|-|-|\n%s" % ("\n".join([f"|{key}|{value}|" for key, value in vars(args).items()]))
@@ -1009,7 +1009,7 @@ if __name__ == "__main__":
 
     # TRY NOT TO MODIFY: seeding
     device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
-    env = gym.make(args.gym_id)
+    env = gym.make(args.env_id)
     env = wrap_atari(env)
     env = gym.wrappers.RecordEpisodeStatistics(env)  # records episode reward in `info['episode']['r']`
     env = wrap_deepmind(

--- a/cleanrl/c51.py
+++ b/cleanrl/c51.py
@@ -34,8 +34,8 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
-    parser.add_argument("--gym-id", type=str, default="CartPole-v1",
-        help="the id of the gym environment")
+    parser.add_argument("--env-id", type=str, default="CartPole-v1",
+        help="the id of the environment")
     parser.add_argument("--total-timesteps", type=int, default=50000,
         help="total timesteps of the experiments")
     parser.add_argument("--learning-rate", type=float, default=2.5e-4,
@@ -71,9 +71,9 @@ def parse_args():
     return args
 
 
-def make_env(gym_id, seed, idx, capture_video, run_name):
+def make_env(env_id, seed, idx, capture_video, run_name):
     def thunk():
-        env = gym.make(gym_id)
+        env = gym.make(env_id)
         env = gym.wrappers.RecordEpisodeStatistics(env)
         if capture_video:
             if idx == 0:
@@ -122,7 +122,7 @@ def linear_schedule(start_e: float, end_e: float, duration: int, t: int):
 
 if __name__ == "__main__":
     args = parse_args()
-    run_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    run_name = f"{args.env_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
     if args.track:
         import wandb
 
@@ -150,7 +150,7 @@ if __name__ == "__main__":
     device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
 
     # env setup
-    envs = gym.vector.SyncVectorEnv([make_env(args.gym_id, 0, 0, args.capture_video, run_name)])
+    envs = gym.vector.SyncVectorEnv([make_env(args.env_id, 0, 0, args.capture_video, run_name)])
     assert isinstance(envs.single_action_space, gym.spaces.Discrete), "only discrete action space is supported"
 
     q_network = QNetwork(envs, n_atoms=args.n_atoms, v_min=args.v_min, v_max=args.v_max).to(device)

--- a/cleanrl/c51.py
+++ b/cleanrl/c51.py
@@ -18,14 +18,8 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
         help="the name of this experiment")
-    parser.add_argument("--gym-id", type=str, default="CartPole-v1",
-        help="the id of the gym environment")
-    parser.add_argument("--learning-rate", type=float, default=2.5e-4,
-        help="the learning rate of the optimizer")
     parser.add_argument("--seed", type=int, default=1,
         help="seed of the experiment")
-    parser.add_argument("--total-timesteps", type=int, default=50000,
-        help="total timesteps of the experiments")
     parser.add_argument("--torch-deterministic", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
         help="if toggled, `torch.backends.cudnn.deterministic=False`")
     parser.add_argument("--cuda", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
@@ -40,6 +34,12 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
+    parser.add_argument("--gym-id", type=str, default="CartPole-v1",
+        help="the id of the gym environment")
+    parser.add_argument("--total-timesteps", type=int, default=50000,
+        help="total timesteps of the experiments")
+    parser.add_argument("--learning-rate", type=float, default=2.5e-4,
+        help="the learning rate of the optimizer")
     parser.add_argument("--n-atoms", type=int, default=101,
         help="the number of atoms")
     parser.add_argument("--v-min", type=float, default=-100,

--- a/cleanrl/c51_atari.py
+++ b/cleanrl/c51_atari.py
@@ -25,14 +25,8 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
         help="the name of this experiment")
-    parser.add_argument("--gym-id", type=str, default="BreakoutNoFrameskip-v4",
-        help="the id of the gym environment")
-    parser.add_argument("--learning-rate", type=float, default=2.5e-4,
-        help="the learning rate of the optimizer")
     parser.add_argument("--seed", type=int, default=1,
         help="seed of the experiment")
-    parser.add_argument("--total-timesteps", type=int, default=10000000,
-        help="total timesteps of the experiments")
     parser.add_argument("--torch-deterministic", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
         help="if toggled, `torch.backends.cudnn.deterministic=False`")
     parser.add_argument("--cuda", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
@@ -47,6 +41,12 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
+    parser.add_argument("--gym-id", type=str, default="BreakoutNoFrameskip-v4",
+        help="the id of the gym environment")
+    parser.add_argument("--total-timesteps", type=int, default=10000000,
+        help="total timesteps of the experiments")
+    parser.add_argument("--learning-rate", type=float, default=2.5e-4,
+        help="the learning rate of the optimizer")
     parser.add_argument("--n-atoms", type=int, default=51,
         help="the number of atoms")
     parser.add_argument("--v-min", type=float, default=-10,

--- a/cleanrl/c51_atari.py
+++ b/cleanrl/c51_atari.py
@@ -41,8 +41,8 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
-    parser.add_argument("--gym-id", type=str, default="BreakoutNoFrameskip-v4",
-        help="the id of the gym environment")
+    parser.add_argument("--env-id", type=str, default="BreakoutNoFrameskip-v4",
+        help="the id of the environment")
     parser.add_argument("--total-timesteps", type=int, default=10000000,
         help="total timesteps of the experiments")
     parser.add_argument("--learning-rate", type=float, default=2.5e-4,
@@ -78,9 +78,9 @@ def parse_args():
     return args
 
 
-def make_env(gym_id, seed, idx, capture_video, run_name):
+def make_env(env_id, seed, idx, capture_video, run_name):
     def thunk():
-        env = gym.make(gym_id)
+        env = gym.make(env_id)
         env = gym.wrappers.RecordEpisodeStatistics(env)
         if capture_video:
             if idx == 0:
@@ -143,7 +143,7 @@ def linear_schedule(start_e: float, end_e: float, duration: int, t: int):
 
 if __name__ == "__main__":
     args = parse_args()
-    run_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    run_name = f"{args.env_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
     if args.track:
         import wandb
 
@@ -171,7 +171,7 @@ if __name__ == "__main__":
     device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
 
     # env setup
-    envs = gym.vector.SyncVectorEnv([make_env(args.gym_id, 0, 0, args.capture_video, run_name)])
+    envs = gym.vector.SyncVectorEnv([make_env(args.env_id, 0, 0, args.capture_video, run_name)])
     assert isinstance(envs.single_action_space, gym.spaces.Discrete), "only discrete action space is supported"
 
     q_network = QNetwork(envs, n_atoms=args.n_atoms, v_min=args.v_min, v_max=args.v_max).to(device)

--- a/cleanrl/ddpg_continuous_action.py
+++ b/cleanrl/ddpg_continuous_action.py
@@ -20,14 +20,8 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
         help="the name of this experiment")
-    parser.add_argument("--gym-id", type=str, default="HopperBulletEnv-v0",
-        help="the id of the gym environment")
-    parser.add_argument("--learning-rate", type=float, default=3e-4,
-        help="the learning rate of the optimizer")
     parser.add_argument("--seed", type=int, default=1,
         help="seed of the experiment")
-    parser.add_argument("--total-timesteps", type=int, default=1000000,
-        help="total timesteps of the experiments")
     parser.add_argument("--torch-deterministic", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
         help="if toggled, `torch.backends.cudnn.deterministic=False`")
     parser.add_argument("--cuda", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
@@ -42,6 +36,12 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
+    parser.add_argument("--gym-id", type=str, default="HopperBulletEnv-v0",
+        help="the id of the gym environment")
+    parser.add_argument("--total-timesteps", type=int, default=1000000,
+        help="total timesteps of the experiments")
+    parser.add_argument("--learning-rate", type=float, default=3e-4,
+        help="the learning rate of the optimizer")
     parser.add_argument("--buffer-size", type=int, default=int(1e6),
         help="the replay memory buffer size")
     parser.add_argument("--gamma", type=float, default=0.99,

--- a/cleanrl/ddpg_continuous_action.py
+++ b/cleanrl/ddpg_continuous_action.py
@@ -36,8 +36,8 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
-    parser.add_argument("--gym-id", type=str, default="HopperBulletEnv-v0",
-        help="the id of the gym environment")
+    parser.add_argument("--env-id", type=str, default="HopperBulletEnv-v0",
+        help="the id of the environment")
     parser.add_argument("--total-timesteps", type=int, default=1000000,
         help="total timesteps of the experiments")
     parser.add_argument("--learning-rate", type=float, default=3e-4,
@@ -65,9 +65,9 @@ def parse_args():
     return args
 
 
-def make_env(gym_id, seed, idx, capture_video, run_name):
+def make_env(env_id, seed, idx, capture_video, run_name):
     def thunk():
-        env = gym.make(gym_id)
+        env = gym.make(env_id)
         env = gym.wrappers.RecordEpisodeStatistics(env)
         if capture_video:
             if idx == 0:
@@ -111,7 +111,7 @@ class Actor(nn.Module):
 
 if __name__ == "__main__":
     args = parse_args()
-    run_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    run_name = f"{args.env_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
     if args.track:
         import wandb
 
@@ -139,7 +139,7 @@ if __name__ == "__main__":
     device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
 
     # env setup
-    envs = gym.vector.SyncVectorEnv([make_env(args.gym_id, 0, 0, args.capture_video, run_name)])
+    envs = gym.vector.SyncVectorEnv([make_env(args.env_id, 0, 0, args.capture_video, run_name)])
     assert isinstance(envs.single_action_space, gym.spaces.Box), "only continuous action space is supported"
 
     max_action = float(envs.single_action_space.high[0])

--- a/cleanrl/dqn.py
+++ b/cleanrl/dqn.py
@@ -34,8 +34,8 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
-    parser.add_argument("--gym-id", type=str, default="CartPole-v1",
-        help="the id of the gym environment")
+    parser.add_argument("--env-id", type=str, default="CartPole-v1",
+        help="the id of the environment")
     parser.add_argument("--total-timesteps", type=int, default=25000,
         help="total timesteps of the experiments")
     parser.add_argument("--learning-rate", type=float, default=2.5e-4,
@@ -65,9 +65,9 @@ def parse_args():
     return args
 
 
-def make_env(gym_id, seed, idx, capture_video, run_name):
+def make_env(env_id, seed, idx, capture_video, run_name):
     def thunk():
-        env = gym.make(gym_id)
+        env = gym.make(env_id)
         env = gym.wrappers.RecordEpisodeStatistics(env)
         if capture_video:
             if idx == 0:
@@ -103,7 +103,7 @@ def linear_schedule(start_e: float, end_e: float, duration: int, t: int):
 
 if __name__ == "__main__":
     args = parse_args()
-    run_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    run_name = f"{args.env_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
     if args.track:
         import wandb
 
@@ -131,7 +131,7 @@ if __name__ == "__main__":
     device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
 
     # env setup
-    envs = gym.vector.SyncVectorEnv([make_env(args.gym_id, 0, 0, args.capture_video, run_name)])
+    envs = gym.vector.SyncVectorEnv([make_env(args.env_id, 0, 0, args.capture_video, run_name)])
     assert isinstance(envs.single_action_space, gym.spaces.Discrete), "only discrete action space is supported"
 
     q_network = QNetwork(envs).to(device)

--- a/cleanrl/dqn.py
+++ b/cleanrl/dqn.py
@@ -18,14 +18,8 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
         help="the name of this experiment")
-    parser.add_argument("--gym-id", type=str, default="CartPole-v1",
-        help="the id of the gym environment")
-    parser.add_argument("--learning-rate", type=float, default=2.5e-4,
-        help="the learning rate of the optimizer")
     parser.add_argument("--seed", type=int, default=1,
         help="seed of the experiment")
-    parser.add_argument("--total-timesteps", type=int, default=25000,
-        help="total timesteps of the experiments")
     parser.add_argument("--torch-deterministic", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
         help="if toggled, `torch.backends.cudnn.deterministic=False`")
     parser.add_argument("--cuda", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
@@ -40,6 +34,12 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
+    parser.add_argument("--gym-id", type=str, default="CartPole-v1",
+        help="the id of the gym environment")
+    parser.add_argument("--total-timesteps", type=int, default=25000,
+        help="total timesteps of the experiments")
+    parser.add_argument("--learning-rate", type=float, default=2.5e-4,
+        help="the learning rate of the optimizer")
     parser.add_argument("--buffer-size", type=int, default=10000,
         help="the replay memory buffer size")
     parser.add_argument("--gamma", type=float, default=0.99,

--- a/cleanrl/dqn_atari.py
+++ b/cleanrl/dqn_atari.py
@@ -25,14 +25,8 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
         help="the name of this experiment")
-    parser.add_argument("--gym-id", type=str, default="BreakoutNoFrameskip-v4",
-        help="the id of the gym environment")
-    parser.add_argument("--learning-rate", type=float, default=1e-4,
-        help="the learning rate of the optimizer")
     parser.add_argument("--seed", type=int, default=1,
         help="seed of the experiment")
-    parser.add_argument("--total-timesteps", type=int, default=10000000,
-        help="total timesteps of the experiments")
     parser.add_argument("--torch-deterministic", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
         help="if toggled, `torch.backends.cudnn.deterministic=False`")
     parser.add_argument("--cuda", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
@@ -47,6 +41,12 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
+    parser.add_argument("--gym-id", type=str, default="BreakoutNoFrameskip-v4",
+        help="the id of the gym environment")
+    parser.add_argument("--total-timesteps", type=int, default=10000000,
+        help="total timesteps of the experiments")
+    parser.add_argument("--learning-rate", type=float, default=1e-4,
+        help="the learning rate of the optimizer")
     parser.add_argument("--buffer-size", type=int, default=1000000,
         help="the replay memory buffer size")
     parser.add_argument("--gamma", type=float, default=0.99,

--- a/cleanrl/dqn_atari.py
+++ b/cleanrl/dqn_atari.py
@@ -41,8 +41,8 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
-    parser.add_argument("--gym-id", type=str, default="BreakoutNoFrameskip-v4",
-        help="the id of the gym environment")
+    parser.add_argument("--env-id", type=str, default="BreakoutNoFrameskip-v4",
+        help="the id of the environment")
     parser.add_argument("--total-timesteps", type=int, default=10000000,
         help="total timesteps of the experiments")
     parser.add_argument("--learning-rate", type=float, default=1e-4,
@@ -72,9 +72,9 @@ def parse_args():
     return args
 
 
-def make_env(gym_id, seed, idx, capture_video, run_name):
+def make_env(env_id, seed, idx, capture_video, run_name):
     def thunk():
-        env = gym.make(gym_id)
+        env = gym.make(env_id)
         env = gym.wrappers.RecordEpisodeStatistics(env)
         if capture_video:
             if idx == 0:
@@ -124,7 +124,7 @@ def linear_schedule(start_e: float, end_e: float, duration: int, t: int):
 
 if __name__ == "__main__":
     args = parse_args()
-    run_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    run_name = f"{args.env_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
     if args.track:
         import wandb
 
@@ -152,7 +152,7 @@ if __name__ == "__main__":
     device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
 
     # env setup
-    envs = gym.vector.SyncVectorEnv([make_env(args.gym_id, 0, 0, args.capture_video, run_name)])
+    envs = gym.vector.SyncVectorEnv([make_env(args.env_id, 0, 0, args.capture_video, run_name)])
     assert isinstance(envs.single_action_space, gym.spaces.Discrete), "only discrete action space is supported"
 
     q_network = QNetwork(envs).to(device)

--- a/cleanrl/offline/offline_dqn_atari_visual.py
+++ b/cleanrl/offline/offline_dqn_atari_visual.py
@@ -346,7 +346,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"), help="the name of this experiment"
     )
-    parser.add_argument("--gym-id", type=str, default="BreakoutNoFrameskip-v4", help="the id of the gym environment")
+    parser.add_argument("--env-id", type=str, default="BreakoutNoFrameskip-v4", help="the id of the environment")
     parser.add_argument("--learning-rate", type=float, default=1e-4, help="the learning rate of the optimizer")
     parser.add_argument("--seed", type=int, default=2, help="seed of the experiment")
     parser.add_argument("--total-timesteps", type=int, default=10000000, help="total timesteps of the experiments")
@@ -410,8 +410,8 @@ if __name__ == "__main__":
     if not args.seed:
         args.seed = int(time.time())
     # create offline gym id: 'BeamRiderNoFrameskip-v4' -> 'beam-rider-expert-v0'
-    args.offline_gym_id = (
-        re.sub(r"(?<!^)(?=[A-Z])", "-", args.gym_id).lower().replace("no-frameskip-v4", "") + args.offline_dataset_id
+    args.offline_env_id = (
+        re.sub(r"(?<!^)(?=[A-Z])", "-", args.env_id).lower().replace("no-frameskip-v4", "") + args.offline_dataset_id
     )
 
 
@@ -448,7 +448,7 @@ class QValueVisualizationWrapper(gym.Wrapper):
 
 
 # TRY NOT TO MODIFY: setup the environment
-experiment_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+experiment_name = f"{args.env_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
 writer = SummaryWriter(f"runs/{experiment_name}")
 writer.add_text(
     "hyperparameters", "|param|value|\n|-|-|\n%s" % ("\n".join([f"|{key}|{value}|" for key, value in vars(args).items()]))
@@ -469,7 +469,7 @@ if args.track:
 
 # TRY NOT TO MODIFY: seeding
 device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
-env = gym.make(args.gym_id)
+env = gym.make(args.env_id)
 env = wrap_atari(env)
 env = gym.wrappers.RecordEpisodeStatistics(env)  # records episode reward in `info['episode']['r']`
 if args.capture_video:
@@ -540,7 +540,7 @@ def linear_schedule(start_e: float, end_e: float, duration: int, t: int):
 
 class ExperienceReplayDataset(IterableDataset):
     def __init__(self):
-        self.dataset_env = gym.make(args.offline_gym_id)
+        self.dataset_env = gym.make(args.offline_env_id)
         self.dataset = self.dataset_env.get_dataset()
 
     def __iter__(self):

--- a/cleanrl/offline/offline_dqn_cql_atari_visual.py
+++ b/cleanrl/offline/offline_dqn_cql_atari_visual.py
@@ -346,7 +346,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"), help="the name of this experiment"
     )
-    parser.add_argument("--gym-id", type=str, default="BreakoutNoFrameskip-v4", help="the id of the gym environment")
+    parser.add_argument("--env-id", type=str, default="BreakoutNoFrameskip-v4", help="the id of the environment")
     parser.add_argument("--learning-rate", type=float, default=1e-4, help="the learning rate of the optimizer")
     parser.add_argument("--seed", type=int, default=2, help="seed of the experiment")
     parser.add_argument("--total-timesteps", type=int, default=10000000, help="total timesteps of the experiments")
@@ -413,8 +413,8 @@ if __name__ == "__main__":
     if not args.seed:
         args.seed = int(time.time())
     # create offline gym id: 'BeamRiderNoFrameskip-v4' -> 'beam-rider-expert-v0'
-    args.offline_gym_id = (
-        re.sub(r"(?<!^)(?=[A-Z])", "-", args.gym_id).lower().replace("no-frameskip-v4", "") + args.offline_dataset_id
+    args.offline_env_id = (
+        re.sub(r"(?<!^)(?=[A-Z])", "-", args.env_id).lower().replace("no-frameskip-v4", "") + args.offline_dataset_id
     )
 
 
@@ -451,7 +451,7 @@ class QValueVisualizationWrapper(gym.Wrapper):
 
 
 # TRY NOT TO MODIFY: setup the environment
-experiment_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+experiment_name = f"{args.env_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
 writer = SummaryWriter(f"runs/{experiment_name}")
 writer.add_text(
     "hyperparameters", "|param|value|\n|-|-|\n%s" % ("\n".join([f"|{key}|{value}|" for key, value in vars(args).items()]))
@@ -472,7 +472,7 @@ if args.track:
 
 # TRY NOT TO MODIFY: seeding
 device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
-env = gym.make(args.gym_id)
+env = gym.make(args.env_id)
 env = wrap_atari(env)
 env = gym.wrappers.RecordEpisodeStatistics(env)  # records episode reward in `info['episode']['r']`
 if args.capture_video:
@@ -543,7 +543,7 @@ def linear_schedule(start_e: float, end_e: float, duration: int, t: int):
 
 class ExperienceReplayDataset(IterableDataset):
     def __init__(self):
-        self.dataset_env = gym.make(args.offline_gym_id)
+        self.dataset_env = gym.make(args.offline_env_id)
         self.dataset = self.dataset_env.get_dataset()
 
     def __iter__(self):

--- a/cleanrl/ppg_procgen.py
+++ b/cleanrl/ppg_procgen.py
@@ -20,14 +20,8 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
         help="the name of this experiment")
-    parser.add_argument("--gym-id", type=str, default="starpilot",
-        help="the id of the gym environment")
-    parser.add_argument("--learning-rate", type=float, default=5e-4,
-        help="the learning rate of the optimizer")
     parser.add_argument("--seed", type=int, default=1,
         help="seed of the experiment")
-    parser.add_argument("--total-timesteps", type=int, default=25e6,
-        help="total timesteps of the experiments")
     parser.add_argument("--torch-deterministic", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
         help="if toggled, `torch.backends.cudnn.deterministic=False`")
     parser.add_argument("--cuda", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
@@ -42,6 +36,12 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
+    parser.add_argument("--gym-id", type=str, default="starpilot",
+        help="the id of the gym environment")
+    parser.add_argument("--learning-rate", type=float, default=5e-4,
+        help="the learning rate of the optimizer")
+    parser.add_argument("--total-timesteps", type=int, default=25e6,
+        help="total timesteps of the experiments")
     parser.add_argument("--num-envs", type=int, default=64,
         help="the number of parallel game environments")
     parser.add_argument("--num-steps", type=int, default=256,

--- a/cleanrl/ppg_procgen.py
+++ b/cleanrl/ppg_procgen.py
@@ -36,8 +36,8 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
-    parser.add_argument("--gym-id", type=str, default="starpilot",
-        help="the id of the gym environment")
+    parser.add_argument("--env-id", type=str, default="starpilot",
+        help="the id of the environment")
     parser.add_argument("--learning-rate", type=float, default=5e-4,
         help="the learning rate of the optimizer")
     parser.add_argument("--total-timesteps", type=int, default=25e6,
@@ -183,7 +183,7 @@ class Agent(nn.Module):
 
 if __name__ == "__main__":
     args = parse_args()
-    run_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    run_name = f"{args.env_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
     if args.track:
         import wandb
 
@@ -211,7 +211,7 @@ if __name__ == "__main__":
     device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
 
     # env setup
-    envs = ProcgenEnv(num_envs=args.num_envs, env_name=args.gym_id, num_levels=0, start_level=0, distribution_mode="easy")
+    envs = ProcgenEnv(num_envs=args.num_envs, env_name=args.env_id, num_levels=0, start_level=0, distribution_mode="easy")
     envs = gym.wrappers.TransformObservation(envs, lambda obs: obs["rgb"])
     envs.single_action_space = envs.action_space
     envs.single_observation_space = envs.observation_space["rgb"]

--- a/cleanrl/ppo.py
+++ b/cleanrl/ppo.py
@@ -34,8 +34,8 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
-    parser.add_argument("--gym-id", type=str, default="CartPole-v1",
-        help="the id of the gym environment")
+    parser.add_argument("--env-id", type=str, default="CartPole-v1",
+        help="the id of the environment")
     parser.add_argument("--total-timesteps", type=int, default=25000,
         help="total timesteps of the experiments")
     parser.add_argument("--learning-rate", type=float, default=2.5e-4,
@@ -77,9 +77,9 @@ def parse_args():
     return args
 
 
-def make_env(gym_id, seed, idx, capture_video, run_name):
+def make_env(env_id, seed, idx, capture_video, run_name):
     def thunk():
-        env = gym.make(gym_id)
+        env = gym.make(env_id)
         env = gym.wrappers.RecordEpisodeStatistics(env)
         if capture_video:
             if idx == 0:
@@ -129,7 +129,7 @@ class Agent(nn.Module):
 
 if __name__ == "__main__":
     args = parse_args()
-    run_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    run_name = f"{args.env_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
     if args.track:
         import wandb
 
@@ -158,7 +158,7 @@ if __name__ == "__main__":
 
     # env setup
     envs = gym.vector.SyncVectorEnv(
-        [make_env(args.gym_id, args.seed + i, i, args.capture_video, run_name) for i in range(args.num_envs)]
+        [make_env(args.env_id, args.seed + i, i, args.capture_video, run_name) for i in range(args.num_envs)]
     )
     assert isinstance(envs.single_action_space, gym.spaces.Discrete), "only discrete action space is supported"
 

--- a/cleanrl/ppo.py
+++ b/cleanrl/ppo.py
@@ -18,14 +18,8 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
         help="the name of this experiment")
-    parser.add_argument("--gym-id", type=str, default="CartPole-v1",
-        help="the id of the gym environment")
-    parser.add_argument("--learning-rate", type=float, default=2.5e-4,
-        help="the learning rate of the optimizer")
     parser.add_argument("--seed", type=int, default=1,
         help="seed of the experiment")
-    parser.add_argument("--total-timesteps", type=int, default=25000,
-        help="total timesteps of the experiments")
     parser.add_argument("--torch-deterministic", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
         help="if toggled, `torch.backends.cudnn.deterministic=False`")
     parser.add_argument("--cuda", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
@@ -40,6 +34,12 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
+    parser.add_argument("--gym-id", type=str, default="CartPole-v1",
+        help="the id of the gym environment")
+    parser.add_argument("--total-timesteps", type=int, default=25000,
+        help="total timesteps of the experiments")
+    parser.add_argument("--learning-rate", type=float, default=2.5e-4,
+        help="the learning rate of the optimizer")
     parser.add_argument("--num-envs", type=int, default=4,
         help="the number of parallel game environments")
     parser.add_argument("--num-steps", type=int, default=128,

--- a/cleanrl/ppo_atari.py
+++ b/cleanrl/ppo_atari.py
@@ -26,14 +26,8 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
         help="the name of this experiment")
-    parser.add_argument("--gym-id", type=str, default="BreakoutNoFrameskip-v4",
-        help="the id of the gym environment")
-    parser.add_argument("--learning-rate", type=float, default=2.5e-4,
-        help="the learning rate of the optimizer")
     parser.add_argument("--seed", type=int, default=1,
         help="seed of the experiment")
-    parser.add_argument("--total-timesteps", type=int, default=10000000,
-        help="total timesteps of the experiments")
     parser.add_argument("--torch-deterministic", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
         help="if toggled, `torch.backends.cudnn.deterministic=False`")
     parser.add_argument("--cuda", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
@@ -48,6 +42,12 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
+    parser.add_argument("--gym-id", type=str, default="BreakoutNoFrameskip-v4",
+        help="the id of the gym environment")
+    parser.add_argument("--total-timesteps", type=int, default=10000000,
+        help="total timesteps of the experiments")
+    parser.add_argument("--learning-rate", type=float, default=2.5e-4,
+        help="the learning rate of the optimizer")
     parser.add_argument("--num-envs", type=int, default=8,
         help="the number of parallel game environments")
     parser.add_argument("--num-steps", type=int, default=128,

--- a/cleanrl/ppo_atari.py
+++ b/cleanrl/ppo_atari.py
@@ -42,8 +42,8 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
-    parser.add_argument("--gym-id", type=str, default="BreakoutNoFrameskip-v4",
-        help="the id of the gym environment")
+    parser.add_argument("--env-id", type=str, default="BreakoutNoFrameskip-v4",
+        help="the id of the environment")
     parser.add_argument("--total-timesteps", type=int, default=10000000,
         help="total timesteps of the experiments")
     parser.add_argument("--learning-rate", type=float, default=2.5e-4,
@@ -85,9 +85,9 @@ def parse_args():
     return args
 
 
-def make_env(gym_id, seed, idx, capture_video, run_name):
+def make_env(env_id, seed, idx, capture_video, run_name):
     def thunk():
-        env = gym.make(gym_id)
+        env = gym.make(env_id)
         env = gym.wrappers.RecordEpisodeStatistics(env)
         if capture_video:
             if idx == 0:
@@ -146,7 +146,7 @@ class Agent(nn.Module):
 
 if __name__ == "__main__":
     args = parse_args()
-    run_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    run_name = f"{args.env_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
     if args.track:
         import wandb
 
@@ -175,7 +175,7 @@ if __name__ == "__main__":
 
     # env setup
     envs = gym.vector.SyncVectorEnv(
-        [make_env(args.gym_id, args.seed + i, i, args.capture_video, run_name) for i in range(args.num_envs)]
+        [make_env(args.env_id, args.seed + i, i, args.capture_video, run_name) for i in range(args.num_envs)]
     )
     assert isinstance(envs.single_action_space, gym.spaces.Discrete), "only discrete action space is supported"
 

--- a/cleanrl/ppo_atari_envpool.py
+++ b/cleanrl/ppo_atari_envpool.py
@@ -20,14 +20,8 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
         help="the name of this experiment")
-    parser.add_argument("--gym-id", type=str, default="Pong-v5",
-        help="the id of the gym environment")
-    parser.add_argument("--learning-rate", type=float, default=2.5e-4,
-        help="the learning rate of the optimizer")
     parser.add_argument("--seed", type=int, default=1,
         help="seed of the experiment")
-    parser.add_argument("--total-timesteps", type=int, default=10000000,
-        help="total timesteps of the experiments")
     parser.add_argument("--torch-deterministic", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
         help="if toggled, `torch.backends.cudnn.deterministic=False`")
     parser.add_argument("--cuda", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
@@ -42,6 +36,12 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
+    parser.add_argument("--gym-id", type=str, default="Pong-v5",
+        help="the id of the gym environment")
+    parser.add_argument("--total-timesteps", type=int, default=10000000,
+        help="total timesteps of the experiments")
+    parser.add_argument("--learning-rate", type=float, default=2.5e-4,
+        help="the learning rate of the optimizer")
     parser.add_argument("--num-envs", type=int, default=8,
         help="the number of parallel game environments")
     parser.add_argument("--num-steps", type=int, default=128,

--- a/cleanrl/ppo_atari_envpool.py
+++ b/cleanrl/ppo_atari_envpool.py
@@ -36,8 +36,8 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
-    parser.add_argument("--gym-id", type=str, default="Pong-v5",
-        help="the id of the gym environment")
+    parser.add_argument("--env-id", type=str, default="Pong-v5",
+        help="the id of the environment")
     parser.add_argument("--total-timesteps", type=int, default=10000000,
         help="total timesteps of the experiments")
     parser.add_argument("--learning-rate", type=float, default=2.5e-4,
@@ -162,7 +162,7 @@ class Agent(nn.Module):
 
 if __name__ == "__main__":
     args = parse_args()
-    run_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    run_name = f"{args.env_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
     if args.track:
         import wandb
 
@@ -191,7 +191,7 @@ if __name__ == "__main__":
 
     # env setup
     envs = envpool.make(
-        args.gym_id,
+        args.env_id,
         env_type="gym",
         num_envs=args.num_envs,
         episodic_life=True,

--- a/cleanrl/ppo_atari_lstm.py
+++ b/cleanrl/ppo_atari_lstm.py
@@ -26,14 +26,8 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
         help="the name of this experiment")
-    parser.add_argument("--gym-id", type=str, default="BreakoutNoFrameskip-v4",
-        help="the id of the gym environment")
-    parser.add_argument("--learning-rate", type=float, default=2.5e-4,
-        help="the learning rate of the optimizer")
     parser.add_argument("--seed", type=int, default=1,
         help="seed of the experiment")
-    parser.add_argument("--total-timesteps", type=int, default=10000000,
-        help="total timesteps of the experiments")
     parser.add_argument("--torch-deterministic", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
         help="if toggled, `torch.backends.cudnn.deterministic=False`")
     parser.add_argument("--cuda", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
@@ -48,6 +42,12 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
+    parser.add_argument("--gym-id", type=str, default="BreakoutNoFrameskip-v4",
+        help="the id of the gym environment")
+    parser.add_argument("--total-timesteps", type=int, default=10000000,
+        help="total timesteps of the experiments")
+    parser.add_argument("--learning-rate", type=float, default=2.5e-4,
+        help="the learning rate of the optimizer")
     parser.add_argument("--num-envs", type=int, default=8,
         help="the number of parallel game environments")
     parser.add_argument("--num-steps", type=int, default=128,

--- a/cleanrl/ppo_atari_lstm.py
+++ b/cleanrl/ppo_atari_lstm.py
@@ -42,8 +42,8 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
-    parser.add_argument("--gym-id", type=str, default="BreakoutNoFrameskip-v4",
-        help="the id of the gym environment")
+    parser.add_argument("--env-id", type=str, default="BreakoutNoFrameskip-v4",
+        help="the id of the environment")
     parser.add_argument("--total-timesteps", type=int, default=10000000,
         help="total timesteps of the experiments")
     parser.add_argument("--learning-rate", type=float, default=2.5e-4,
@@ -85,9 +85,9 @@ def parse_args():
     return args
 
 
-def make_env(gym_id, seed, idx, capture_video, run_name):
+def make_env(env_id, seed, idx, capture_video, run_name):
     def thunk():
-        env = gym.make(gym_id)
+        env = gym.make(env_id)
         env = gym.wrappers.RecordEpisodeStatistics(env)
         if capture_video:
             if idx == 0:
@@ -173,7 +173,7 @@ class Agent(nn.Module):
 
 if __name__ == "__main__":
     args = parse_args()
-    run_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    run_name = f"{args.env_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
     if args.track:
         import wandb
 
@@ -202,7 +202,7 @@ if __name__ == "__main__":
 
     # env setup
     envs = gym.vector.SyncVectorEnv(
-        [make_env(args.gym_id, args.seed + i, i, args.capture_video, run_name) for i in range(args.num_envs)]
+        [make_env(args.env_id, args.seed + i, i, args.capture_video, run_name) for i in range(args.num_envs)]
     )
     assert isinstance(envs.single_action_space, gym.spaces.Discrete), "only discrete action space is supported"
 

--- a/cleanrl/ppo_continuous_action.py
+++ b/cleanrl/ppo_continuous_action.py
@@ -35,8 +35,8 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
-    parser.add_argument("--gym-id", type=str, default="HalfCheetahBulletEnv-v0",
-        help="the id of the gym environment")
+    parser.add_argument("--env-id", type=str, default="HalfCheetahBulletEnv-v0",
+        help="the id of the environment")
     parser.add_argument("--total-timesteps", type=int, default=2000000,
         help="total timesteps of the experiments")
     parser.add_argument("--learning-rate", type=float, default=3e-4,
@@ -78,9 +78,9 @@ def parse_args():
     return args
 
 
-def make_env(gym_id, seed, idx, capture_video, run_name):
+def make_env(env_id, seed, idx, capture_video, run_name):
     def thunk():
-        env = gym.make(gym_id)
+        env = gym.make(env_id)
         env = gym.wrappers.RecordEpisodeStatistics(env)
         if capture_video:
             if idx == 0:
@@ -138,7 +138,7 @@ class Agent(nn.Module):
 
 if __name__ == "__main__":
     args = parse_args()
-    run_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    run_name = f"{args.env_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
     if args.track:
         import wandb
 
@@ -167,7 +167,7 @@ if __name__ == "__main__":
 
     # env setup
     envs = gym.vector.SyncVectorEnv(
-        [make_env(args.gym_id, args.seed + i, i, args.capture_video, run_name) for i in range(args.num_envs)]
+        [make_env(args.env_id, args.seed + i, i, args.capture_video, run_name) for i in range(args.num_envs)]
     )
     assert isinstance(envs.single_action_space, gym.spaces.Box), "only continuous action space is supported"
 

--- a/cleanrl/ppo_continuous_action.py
+++ b/cleanrl/ppo_continuous_action.py
@@ -19,14 +19,8 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
         help="the name of this experiment")
-    parser.add_argument("--gym-id", type=str, default="HalfCheetahBulletEnv-v0",
-        help="the id of the gym environment")
-    parser.add_argument("--learning-rate", type=float, default=3e-4,
-        help="the learning rate of the optimizer")
     parser.add_argument("--seed", type=int, default=1,
         help="seed of the experiment")
-    parser.add_argument("--total-timesteps", type=int, default=2000000,
-        help="total timesteps of the experiments")
     parser.add_argument("--torch-deterministic", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
         help="if toggled, `torch.backends.cudnn.deterministic=False`")
     parser.add_argument("--cuda", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
@@ -41,6 +35,12 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
+    parser.add_argument("--gym-id", type=str, default="HalfCheetahBulletEnv-v0",
+        help="the id of the gym environment")
+    parser.add_argument("--total-timesteps", type=int, default=2000000,
+        help="total timesteps of the experiments")
+    parser.add_argument("--learning-rate", type=float, default=3e-4,
+        help="the learning rate of the optimizer")
     parser.add_argument("--num-envs", type=int, default=1,
         help="the number of parallel game environments")
     parser.add_argument("--num-steps", type=int, default=2048,

--- a/cleanrl/ppo_memory_env_lstm.py
+++ b/cleanrl/ppo_memory_env_lstm.py
@@ -34,8 +34,8 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
-    parser.add_argument("--gym-id", type=str, default="TestMemoryEnv",
-        help="the id of the gym environment")
+    parser.add_argument("--env-id", type=str, default="TestMemoryEnv",
+        help="the id of the environment")
     parser.add_argument("--total-timesteps", type=int, default=30000,
         help="total timesteps of the experiments")
     parser.add_argument("--learning-rate", type=float, default=2.5e-4,
@@ -128,7 +128,7 @@ class TestMemoryEnv(gym.Env):
                 return third_state, reward, True, {}
 
 
-def make_env(gym_id, seed, idx, capture_video, run_name):
+def make_env(env_id, seed, idx, capture_video, run_name):
     def thunk():
         env = TestMemoryEnv()
         env = gym.wrappers.TimeLimit(env, max_episode_steps=500)
@@ -203,7 +203,7 @@ class Agent(nn.Module):
 
 if __name__ == "__main__":
     args = parse_args()
-    run_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    run_name = f"{args.env_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
     if args.track:
         import wandb
 
@@ -232,7 +232,7 @@ if __name__ == "__main__":
 
     # env setup
     envs = gym.vector.SyncVectorEnv(
-        [make_env(args.gym_id, args.seed + i, i, args.capture_video, run_name) for i in range(args.num_envs)]
+        [make_env(args.env_id, args.seed + i, i, args.capture_video, run_name) for i in range(args.num_envs)]
     )
     assert isinstance(envs.single_action_space, gym.spaces.Discrete), "only discrete action space is supported"
 

--- a/cleanrl/ppo_memory_env_lstm.py
+++ b/cleanrl/ppo_memory_env_lstm.py
@@ -18,14 +18,8 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
         help="the name of this experiment")
-    parser.add_argument("--gym-id", type=str, default="TestMemoryEnv",
-        help="the id of the gym environment")
-    parser.add_argument("--learning-rate", type=float, default=2.5e-4,
-        help="the learning rate of the optimizer")
     parser.add_argument("--seed", type=int, default=1,
         help="seed of the experiment")
-    parser.add_argument("--total-timesteps", type=int, default=30000,
-        help="total timesteps of the experiments")
     parser.add_argument("--torch-deterministic", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
         help="if toggled, `torch.backends.cudnn.deterministic=False`")
     parser.add_argument("--cuda", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
@@ -40,6 +34,12 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
+    parser.add_argument("--gym-id", type=str, default="TestMemoryEnv",
+        help="the id of the gym environment")
+    parser.add_argument("--total-timesteps", type=int, default=30000,
+        help="total timesteps of the experiments")
+    parser.add_argument("--learning-rate", type=float, default=2.5e-4,
+        help="the learning rate of the optimizer")
     parser.add_argument("--num-envs", type=int, default=8,
         help="the number of parallel game environments")
     parser.add_argument("--num-steps", type=int, default=128,

--- a/cleanrl/ppo_pettingzoo.py
+++ b/cleanrl/ppo_pettingzoo.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"), help="the name of this experiment"
     )
-    parser.add_argument("--gym-id", type=str, default="pistonball_v4-v0", help="the id of the gym environment")
+    parser.add_argument("--env-id", type=str, default="pistonball_v4-v0", help="the id of the environment")
     parser.add_argument("--learning-rate", type=float, default=3e-4, help="the learning rate of the optimizer")
     parser.add_argument("--seed", type=int, default=1, help="seed of the experiment")
     parser.add_argument("--total-timesteps", type=int, default=2000000, help="total timesteps of the experiments")
@@ -182,7 +182,7 @@ class VecMonitor(VecEnvWrapper):
 
 
 # TRY NOT TO MODIFY: setup the environment
-experiment_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+experiment_name = f"{args.env_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
 writer = SummaryWriter(f"runs/{experiment_name}")
 writer.add_text(
     "hyperparameters", "|param|value|\n|-|-|\n%s" % ("\n".join([f"|{key}|{value}|" for key, value in vars(args).items()]))

--- a/cleanrl/ppo_procgen.py
+++ b/cleanrl/ppo_procgen.py
@@ -35,8 +35,8 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
-    parser.add_argument("--gym-id", type=str, default="starpilot",
-        help="the id of the gym environment")
+    parser.add_argument("--env-id", type=str, default="starpilot",
+        help="the id of the environment")
     parser.add_argument("--total-timesteps", type=int, default=int(25e6),
         help="total timesteps of the experiments")
     parser.add_argument("--learning-rate", type=float, default=5e-4,
@@ -156,7 +156,7 @@ class Agent(nn.Module):
 
 if __name__ == "__main__":
     args = parse_args()
-    run_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    run_name = f"{args.env_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
     if args.track:
         import wandb
 
@@ -184,7 +184,7 @@ if __name__ == "__main__":
     device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
 
     # env setup
-    envs = ProcgenEnv(num_envs=args.num_envs, env_name=args.gym_id, num_levels=0, start_level=0, distribution_mode="easy")
+    envs = ProcgenEnv(num_envs=args.num_envs, env_name=args.env_id, num_levels=0, start_level=0, distribution_mode="easy")
     envs = gym.wrappers.TransformObservation(envs, lambda obs: obs["rgb"])
     envs.single_action_space = envs.action_space
     envs.single_observation_space = envs.observation_space["rgb"]

--- a/cleanrl/ppo_procgen.py
+++ b/cleanrl/ppo_procgen.py
@@ -19,14 +19,8 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
         help="the name of this experiment")
-    parser.add_argument("--gym-id", type=str, default="starpilot",
-        help="the id of the gym environment")
-    parser.add_argument("--learning-rate", type=float, default=5e-4,
-        help="the learning rate of the optimizer")
     parser.add_argument("--seed", type=int, default=1,
         help="seed of the experiment")
-    parser.add_argument("--total-timesteps", type=int, default=int(25e6),
-        help="total timesteps of the experiments")
     parser.add_argument("--torch-deterministic", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
         help="if toggled, `torch.backends.cudnn.deterministic=False`")
     parser.add_argument("--cuda", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
@@ -41,6 +35,12 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
+    parser.add_argument("--gym-id", type=str, default="starpilot",
+        help="the id of the gym environment")
+    parser.add_argument("--total-timesteps", type=int, default=int(25e6),
+        help="total timesteps of the experiments")
+    parser.add_argument("--learning-rate", type=float, default=5e-4,
+        help="the learning rate of the optimizer")
     parser.add_argument("--num-envs", type=int, default=64,
         help="the number of parallel game environments")
     parser.add_argument("--num-steps", type=int, default=256,

--- a/cleanrl/rnd_ppo.py
+++ b/cleanrl/rnd_ppo.py
@@ -407,7 +407,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"), help="the name of this experiment"
     )
-    parser.add_argument("--gym-id", type=str, default="BreakoutNoFrameskip-v4", help="the id of the gym environment")
+    parser.add_argument("--env-id", type=str, default="BreakoutNoFrameskip-v4", help="the id of the environment")
     parser.add_argument("--learning-rate", type=float, default=2.5e-4, help="the learning rate of the optimizer")
     parser.add_argument("--seed", type=int, default=1, help="seed of the experiment")
     parser.add_argument("--total-timesteps", type=int, default=10000000, help="total timesteps of the experiments")
@@ -585,7 +585,7 @@ class ProbsVisualizationWrapper(gym.Wrapper):
 
 
 # TRY NOT TO MODIFY: setup the environment
-experiment_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+experiment_name = f"{args.env_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
 writer = SummaryWriter(f"runs/{experiment_name}")
 writer.add_text(
     "hyperparameters", "|param|value|\n|-|-|\n%s" % ("\n".join([f"|{key}|{value}|" for key, value in vars(args).items()]))
@@ -612,9 +612,9 @@ torch.manual_seed(args.seed)
 torch.backends.cudnn.deterministic = args.torch_deterministic
 
 
-def make_env(gym_id, seed, idx):
+def make_env(env_id, seed, idx):
     def thunk():
-        env = gym.make(gym_id)
+        env = gym.make(env_id)
         env = wrap_atari(env, sticky_action=args.sticky_action)
         env = gym.wrappers.RecordEpisodeStatistics(env)
         if args.capture_video:
@@ -640,10 +640,10 @@ def make_env(gym_id, seed, idx):
     return thunk
 
 
-envs = VecPyTorch(DummyVecEnv([make_env(args.gym_id, args.seed + i, i) for i in range(args.num_envs)]), device)
+envs = VecPyTorch(DummyVecEnv([make_env(args.env_id, args.seed + i, i) for i in range(args.num_envs)]), device)
 # if args.track:
 #     envs = VecPyTorch(
-#         SubprocVecEnv([make_env(args.gym_id, args.seed+i, i) for i in range(args.num_envs)], "fork"),
+#         SubprocVecEnv([make_env(args.env_id, args.seed+i, i) for i in range(args.num_envs)], "fork"),
 #         device
 #     )
 assert isinstance(envs.action_space, Discrete), "only discrete action space is supported"

--- a/cleanrl/sac_continuous_action.py
+++ b/cleanrl/sac_continuous_action.py
@@ -36,8 +36,8 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
-    parser.add_argument("--gym-id", type=str, default="HopperBulletEnv-v0",
-        help="the id of the gym environment")
+    parser.add_argument("--env-id", type=str, default="HopperBulletEnv-v0",
+        help="the id of the environment")
     parser.add_argument("--total-timesteps", type=int, default=1000000,
         help="total timesteps of the experiments")
     parser.add_argument("--buffer-size", type=int, default=int(1e6),
@@ -73,9 +73,9 @@ def parse_args():
     return args
 
 
-def make_env(gym_id, seed, idx, capture_video, run_name):
+def make_env(env_id, seed, idx, capture_video, run_name):
     def thunk():
-        env = gym.make(gym_id)
+        env = gym.make(env_id)
         env = gym.wrappers.RecordEpisodeStatistics(env)
         if capture_video:
             if idx == 0:
@@ -151,7 +151,7 @@ class Actor(nn.Module):
 
 if __name__ == "__main__":
     args = parse_args()
-    run_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    run_name = f"{args.env_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
     if args.track:
         import wandb
 
@@ -179,7 +179,7 @@ if __name__ == "__main__":
     device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
 
     # env setup
-    envs = gym.vector.SyncVectorEnv([make_env(args.gym_id, 0, 0, args.capture_video, run_name)])
+    envs = gym.vector.SyncVectorEnv([make_env(args.env_id, 0, 0, args.capture_video, run_name)])
     assert isinstance(envs.single_action_space, gym.spaces.Box), "only continuous action space is supported"
 
     max_action = float(envs.single_action_space.high[0])

--- a/cleanrl/sac_continuous_action.py
+++ b/cleanrl/sac_continuous_action.py
@@ -20,12 +20,8 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
         help="the name of this experiment")
-    parser.add_argument("--gym-id", type=str, default="HopperBulletEnv-v0",
-        help="the id of the gym environment")
     parser.add_argument("--seed", type=int, default=1,
         help="seed of the experiment")
-    parser.add_argument("--total-timesteps", type=int, default=1000000,
-        help="total timesteps of the experiments")
     parser.add_argument("--torch-deterministic", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
         help="if toggled, `torch.backends.cudnn.deterministic=False`")
     parser.add_argument("--cuda", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
@@ -40,6 +36,10 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
+    parser.add_argument("--gym-id", type=str, default="HopperBulletEnv-v0",
+        help="the id of the gym environment")
+    parser.add_argument("--total-timesteps", type=int, default=1000000,
+        help="total timesteps of the experiments")
     parser.add_argument("--buffer-size", type=int, default=int(1e6),
         help="the replay memory buffer size")
     parser.add_argument("--gamma", type=float, default=0.99,

--- a/cleanrl/td3_continuous_action.py
+++ b/cleanrl/td3_continuous_action.py
@@ -20,14 +20,8 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
         help="the name of this experiment")
-    parser.add_argument("--gym-id", type=str, default="HopperBulletEnv-v0",
-        help="the id of the gym environment")
-    parser.add_argument("--learning-rate", type=float, default=3e-4,
-        help="the learning rate of the optimizer")
     parser.add_argument("--seed", type=int, default=1,
         help="seed of the experiment")
-    parser.add_argument("--total-timesteps", type=int, default=1000000,
-        help="total timesteps of the experiments")
     parser.add_argument("--torch-deterministic", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
         help="if toggled, `torch.backends.cudnn.deterministic=False`")
     parser.add_argument("--cuda", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
@@ -42,6 +36,12 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
+    parser.add_argument("--gym-id", type=str, default="HopperBulletEnv-v0",
+        help="the id of the gym environment")
+    parser.add_argument("--total-timesteps", type=int, default=1000000,
+        help="total timesteps of the experiments")
+    parser.add_argument("--learning-rate", type=float, default=3e-4,
+        help="the learning rate of the optimizer")
     parser.add_argument("--buffer-size", type=int, default=int(1e6),
         help="the replay memory buffer size")
     parser.add_argument("--gamma", type=float, default=0.99,

--- a/cleanrl/td3_continuous_action.py
+++ b/cleanrl/td3_continuous_action.py
@@ -36,8 +36,8 @@ def parse_args():
         help="weather to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
-    parser.add_argument("--gym-id", type=str, default="HopperBulletEnv-v0",
-        help="the id of the gym environment")
+    parser.add_argument("--env-id", type=str, default="HopperBulletEnv-v0",
+        help="the id of the environment")
     parser.add_argument("--total-timesteps", type=int, default=1000000,
         help="total timesteps of the experiments")
     parser.add_argument("--learning-rate", type=float, default=3e-4,
@@ -67,9 +67,9 @@ def parse_args():
     return args
 
 
-def make_env(gym_id, seed, idx, capture_video, run_name):
+def make_env(env_id, seed, idx, capture_video, run_name):
     def thunk():
-        env = gym.make(gym_id)
+        env = gym.make(env_id)
         env = gym.wrappers.RecordEpisodeStatistics(env)
         if capture_video:
             if idx == 0:
@@ -113,7 +113,7 @@ class Actor(nn.Module):
 
 if __name__ == "__main__":
     args = parse_args()
-    run_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    run_name = f"{args.env_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
     if args.track:
         import wandb
 
@@ -141,7 +141,7 @@ if __name__ == "__main__":
     device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
 
     # env setup
-    envs = gym.vector.SyncVectorEnv([make_env(args.gym_id, 0, 0, args.capture_video, run_name)])
+    envs = gym.vector.SyncVectorEnv([make_env(args.env_id, 0, 0, args.capture_video, run_name)])
     assert isinstance(envs.single_action_space, gym.spaces.Box), "only continuous action space is supported"
 
     max_action = float(envs.single_action_space.high[0])

--- a/cleanrl_utils/paper_plot.py
+++ b/cleanrl_utils/paper_plot.py
@@ -94,11 +94,11 @@ for idx, run in enumerate(runs):
             metrics_dataframe.insert(len(metrics_dataframe.columns), "seed", run.config["seed"])
 
             data += [metrics_dataframe]
-            if run.config["gym_id"] not in envs:
-                envs[run.config["gym_id"]] = [metrics_dataframe]
-                envs[run.config["gym_id"] + "total_timesteps"] = run.config["total_timesteps"]
+            if run.config["env_id"] not in envs:
+                envs[run.config["env_id"]] = [metrics_dataframe]
+                envs[run.config["env_id"] + "total_timesteps"] = run.config["total_timesteps"]
             else:
-                envs[run.config["gym_id"]] += [metrics_dataframe]
+                envs[run.config["env_id"]] += [metrics_dataframe]
 
             # run.summary are the output key/values like accuracy.  We call ._json_dict to omit large files
             summary_list.append(run.summary._json_dict)
@@ -141,11 +141,11 @@ for env in envs:
 sns.set(style="darkgrid")
 
 
-def get_df_for_env(gym_id):
-    env_total_timesteps = envs[gym_id + "total_timesteps"]
+def get_df_for_env(env_id):
+    env_total_timesteps = envs[env_id + "total_timesteps"]
     env_increment = env_total_timesteps / 500
     envs_same_x_axis = []
-    for sampled_run in envs[gym_id]:
+    for sampled_run in envs[env_id]:
         df = pd.DataFrame(columns=sampled_run.columns)
         x_axis = [i * env_increment for i in range(500 - 2)]
         current_row = 0
@@ -223,9 +223,9 @@ if args.font_size:
     plt.rc("ytick", labelsize=args.font_size)  # fontsize of the tick labels
     plt.rc("legend", fontsize=args.font_size)  # legend fontsize
 
-stats = {item: [] for item in ["gym_id", "exp_name", args.feature_of_interest]}
+stats = {item: [] for item in ["env_id", "exp_name", args.feature_of_interest]}
 # uncommenet the following to generate all figures
-for env in set(all_df["gym_id"]):
+for env in set(all_df["env_id"]):
     if not path.exists(f"{feature_name}/data/{env}.pkl"):
         with open(f"{feature_name}/data/{env}.pkl", "wb") as handle:
             data = get_df_for_env(env)
@@ -273,7 +273,7 @@ for env in set(all_df["gym_id"]):
                 stats["exp_name"] += [exp_convert_dict[algo]]
             else:
                 stats["exp_name"] += [algo]
-            stats["gym_id"] += [env]
+            stats["env_id"] += [env]
 
     # export legend
     # legend_df = pd.DataFrame()
@@ -303,5 +303,5 @@ plt.clf()
 
 # analysis
 stats_df = pd.DataFrame(stats)
-g = stats_df.groupby(["gym_id", "exp_name"]).agg(lambda x: f"{np.mean(x):.2f} ± {np.std(x):.2f}")
-print(g.reset_index().pivot("exp_name", "gym_id", args.feature_of_interest).to_latex().replace("±", "$\pm$"))
+g = stats_df.groupby(["env_id", "exp_name"]).agg(lambda x: f"{np.mean(x):.2f} ± {np.std(x):.2f}")
+print(g.reset_index().pivot("exp_name", "env_id", args.feature_of_interest).to_latex().replace("±", "$\pm$"))

--- a/cleanrl_utils/plot.py
+++ b/cleanrl_utils/plot.py
@@ -89,11 +89,11 @@ for idx, run in enumerate(runs):
             metrics_dataframe.insert(len(metrics_dataframe.columns), "seed", run.config["seed"])
 
             data += [metrics_dataframe]
-            if run.config["gym_id"] not in envs:
-                envs[run.config["gym_id"]] = [metrics_dataframe]
-                envs[run.config["gym_id"] + "total_timesteps"] = run.config["total_timesteps"]
+            if run.config["env_id"] not in envs:
+                envs[run.config["env_id"]] = [metrics_dataframe]
+                envs[run.config["env_id"] + "total_timesteps"] = run.config["total_timesteps"]
             else:
-                envs[run.config["gym_id"]] += [metrics_dataframe]
+                envs[run.config["env_id"]] += [metrics_dataframe]
 
             # run.summary are the output key/values like accuracy.  We call ._json_dict to omit large files
             summary_list.append(run.summary._json_dict)
@@ -136,11 +136,11 @@ for env in envs:
 sns.set(style="darkgrid")
 
 
-def get_df_for_env(gym_id):
-    env_total_timesteps = envs[gym_id + "total_timesteps"]
+def get_df_for_env(env_id):
+    env_total_timesteps = envs[env_id + "total_timesteps"]
     env_increment = env_total_timesteps / 500
     envs_same_x_axis = []
-    for sampled_run in envs[gym_id]:
+    for sampled_run in envs[env_id]:
         df = pd.DataFrame(columns=sampled_run.columns)
         x_axis = [i * env_increment for i in range(500 - 2)]
         current_row = 0
@@ -212,9 +212,9 @@ if args.font_size:
     plt.rc("ytick", labelsize=args.font_size)  # fontsize of the tick labels
     plt.rc("legend", fontsize=args.font_size)  # legend fontsize
 
-stats = {item: [] for item in ["gym_id", "exp_name", args.feature_of_interest]}
+stats = {item: [] for item in ["env_id", "exp_name", args.feature_of_interest]}
 # uncommenet the following to generate all figures
-for env in set(all_df["gym_id"]):
+for env in set(all_df["env_id"]):
     if not path.exists(f"{feature_name}/data/{env}.pkl"):
         with open(f"{feature_name}/data/{env}.pkl", "wb") as handle:
             data = get_df_for_env(env)
@@ -280,10 +280,10 @@ for env in set(all_df["gym_id"]):
                 stats["exp_name"] += [exp_convert_dict[algo]]
             else:
                 stats["exp_name"] += [algo]
-            stats["gym_id"] += [env]
+            stats["env_id"] += [env]
 
 
 # analysis
 stats_df = pd.DataFrame(stats)
-g = stats_df.groupby(["gym_id", "exp_name"]).agg(lambda x: f"{np.mean(x):.2f} ± {np.std(x):.2f}")
-print(g.reset_index().pivot("exp_name", "gym_id", args.feature_of_interest).to_latex().replace("±", "$\pm$"))
+g = stats_df.groupby(["env_id", "exp_name"]).agg(lambda x: f"{np.mean(x):.2f} ± {np.std(x):.2f}")
+print(g.reset_index().pivot("exp_name", "env_id", args.feature_of_interest).to_latex().replace("±", "$\pm$"))

--- a/cloud/examples/scripts/apex_dqn_atari.sh
+++ b/cloud/examples/scripts/apex_dqn_atari.sh
@@ -2,7 +2,7 @@
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python apex_dqn_atari_visual.py \
-    --gym-id BeamRiderNoFrameskip-v4 \
+    --env-id BeamRiderNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -15,7 +15,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python apex_dqn_atari_visual.py \
-    --gym-id QbertNoFrameskip-v4 \
+    --env-id QbertNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -28,7 +28,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python apex_dqn_atari_visual.py \
-    --gym-id SpaceInvadersNoFrameskip-v4 \
+    --env-id SpaceInvadersNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -41,7 +41,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python apex_dqn_atari_visual.py \
-    --gym-id PongNoFrameskip-v4 \
+    --env-id PongNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -54,7 +54,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python apex_dqn_atari_visual.py \
-    --gym-id BreakoutNoFrameskip-v4 \
+    --env-id BreakoutNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \

--- a/cloud/examples/scripts/c51_atari.sh
+++ b/cloud/examples/scripts/c51_atari.sh
@@ -2,7 +2,7 @@
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python c51_atari_visual.py \
-    --gym-id BeamRiderNoFrameskip-v4 \
+    --env-id BeamRiderNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -15,7 +15,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python c51_atari_visual.py \
-    --gym-id QbertNoFrameskip-v4 \
+    --env-id QbertNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -28,7 +28,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python c51_atari_visual.py \
-    --gym-id SpaceInvadersNoFrameskip-v4 \
+    --env-id SpaceInvadersNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -41,7 +41,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python c51_atari_visual.py \
-    --gym-id PongNoFrameskip-v4 \
+    --env-id PongNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -54,7 +54,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python c51_atari_visual.py \
-    --gym-id BreakoutNoFrameskip-v4 \
+    --env-id BreakoutNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \

--- a/cloud/examples/scripts/c51_other.sh
+++ b/cloud/examples/scripts/c51_other.sh
@@ -2,7 +2,7 @@
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python c51.py \
-    --gym-id CartPole-v1 \
+    --env-id CartPole-v1 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -15,7 +15,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python c51.py \
-    --gym-id Acrobot-v1 \
+    --env-id Acrobot-v1 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -28,7 +28,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python c51.py \
-    --gym-id MountainCar-v0 \
+    --env-id MountainCar-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -41,7 +41,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python c51.py \
-    --gym-id LunarLander-v2 \
+    --env-id LunarLander-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \

--- a/cloud/examples/scripts/ddpg_mujoco.sh
+++ b/cloud/examples/scripts/ddpg_mujoco.sh
@@ -2,7 +2,7 @@
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ddpg_continuous_action.py \
-    --gym-id Reacher-v2 \
+    --env-id Reacher-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -15,7 +15,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ddpg_continuous_action.py \
-    --gym-id Pusher-v2 \
+    --env-id Pusher-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -28,7 +28,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ddpg_continuous_action.py \
-    --gym-id Thrower-v2 \
+    --env-id Thrower-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -41,7 +41,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ddpg_continuous_action.py \
-    --gym-id Striker-v2 \
+    --env-id Striker-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -54,7 +54,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ddpg_continuous_action.py \
-    --gym-id InvertedPendulum-v2 \
+    --env-id InvertedPendulum-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -67,7 +67,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ddpg_continuous_action.py \
-    --gym-id HalfCheetah-v2 \
+    --env-id HalfCheetah-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -80,7 +80,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ddpg_continuous_action.py \
-    --gym-id Hopper-v2 \
+    --env-id Hopper-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -93,7 +93,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ddpg_continuous_action.py \
-    --gym-id Swimmer-v2 \
+    --env-id Swimmer-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -106,7 +106,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ddpg_continuous_action.py \
-    --gym-id Walker2d-v2 \
+    --env-id Walker2d-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -119,7 +119,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ddpg_continuous_action.py \
-    --gym-id Ant-v2 \
+    --env-id Ant-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -132,7 +132,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ddpg_continuous_action.py \
-    --gym-id Humanoid-v2 \
+    --env-id Humanoid-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \

--- a/cloud/examples/scripts/ddpg_pybullet.sh
+++ b/cloud/examples/scripts/ddpg_pybullet.sh
@@ -2,7 +2,7 @@
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ddpg_continuous_action.py \
-    --gym-id MinitaurBulletEnv-v0 \
+    --env-id MinitaurBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -15,7 +15,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ddpg_continuous_action.py \
-    --gym-id MinitaurBulletDuckEnv-v0 \
+    --env-id MinitaurBulletDuckEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -28,7 +28,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ddpg_continuous_action.py \
-    --gym-id InvertedPendulumBulletEnv-v0 \
+    --env-id InvertedPendulumBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -41,7 +41,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ddpg_continuous_action.py \
-    --gym-id InvertedDoublePendulumBulletEnv-v0 \
+    --env-id InvertedDoublePendulumBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -54,7 +54,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ddpg_continuous_action.py \
-    --gym-id Walker2DBulletEnv-v0 \
+    --env-id Walker2DBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -67,7 +67,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ddpg_continuous_action.py \
-    --gym-id HalfCheetahBulletEnv-v0 \
+    --env-id HalfCheetahBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -80,7 +80,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ddpg_continuous_action.py \
-    --gym-id AntBulletEnv-v0 \
+    --env-id AntBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -93,7 +93,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ddpg_continuous_action.py \
-    --gym-id HopperBulletEnv-v0 \
+    --env-id HopperBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -106,7 +106,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ddpg_continuous_action.py \
-    --gym-id HumanoidBulletEnv-v0 \
+    --env-id HumanoidBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -119,7 +119,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ddpg_continuous_action.py \
-    --gym-id BipedalWalker-v3 \
+    --env-id BipedalWalker-v3 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -132,7 +132,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ddpg_continuous_action.py \
-    --gym-id LunarLanderContinuous-v2 \
+    --env-id LunarLanderContinuous-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -145,7 +145,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ddpg_continuous_action.py \
-    --gym-id Pendulum-v0 \
+    --env-id Pendulum-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -158,7 +158,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ddpg_continuous_action.py \
-    --gym-id MountainCarContinuous-v0 \
+    --env-id MountainCarContinuous-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \

--- a/cloud/examples/scripts/dqn_atari.sh
+++ b/cloud/examples/scripts/dqn_atari.sh
@@ -2,7 +2,7 @@
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python dqn_atari_visual.py \
-    --gym-id BeamRiderNoFrameskip-v4 \
+    --env-id BeamRiderNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -15,7 +15,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python dqn_atari_visual.py \
-    --gym-id QbertNoFrameskip-v4 \
+    --env-id QbertNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -28,7 +28,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python dqn_atari_visual.py \
-    --gym-id SpaceInvadersNoFrameskip-v4 \
+    --env-id SpaceInvadersNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -41,7 +41,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python dqn_atari_visual.py \
-    --gym-id PongNoFrameskip-v4 \
+    --env-id PongNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -54,7 +54,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python dqn_atari_visual.py \
-    --gym-id BreakoutNoFrameskip-v4 \
+    --env-id BreakoutNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \

--- a/cloud/examples/scripts/dqn_other.sh
+++ b/cloud/examples/scripts/dqn_other.sh
@@ -2,7 +2,7 @@
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python dqn.py \
-    --gym-id CartPole-v1 \
+    --env-id CartPole-v1 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -15,7 +15,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python dqn.py \
-    --gym-id Acrobot-v1 \
+    --env-id Acrobot-v1 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -28,7 +28,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python dqn.py \
-    --gym-id MountainCar-v0 \
+    --env-id MountainCar-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -41,7 +41,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python dqn.py \
-    --gym-id LunarLander-v2 \
+    --env-id LunarLander-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \

--- a/cloud/examples/scripts/offline_dqn_atari_visual.sh
+++ b/cloud/examples/scripts/offline_dqn_atari_visual.sh
@@ -2,7 +2,7 @@
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python offline_dqn_atari_visual.py \
-    --gym-id BeamRiderNoFrameskip-v4 \
+    --env-id BeamRiderNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -15,7 +15,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python offline_dqn_atari_visual.py \
-    --gym-id QbertNoFrameskip-v4 \
+    --env-id QbertNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -28,7 +28,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python offline_dqn_atari_visual.py \
-    --gym-id SpaceInvadersNoFrameskip-v4 \
+    --env-id SpaceInvadersNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -41,7 +41,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python offline_dqn_atari_visual.py \
-    --gym-id PongNoFrameskip-v4 \
+    --env-id PongNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -54,7 +54,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python offline_dqn_atari_visual.py \
-    --gym-id BreakoutNoFrameskip-v4 \
+    --env-id BreakoutNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \

--- a/cloud/examples/scripts/offline_dqn_cql_atari_visual.sh
+++ b/cloud/examples/scripts/offline_dqn_cql_atari_visual.sh
@@ -2,7 +2,7 @@
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python offline_dqn_cql_atari_visual.py \
-    --gym-id BeamRiderNoFrameskip-v4 \
+    --env-id BeamRiderNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -15,7 +15,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python offline_dqn_cql_atari_visual.py \
-    --gym-id QbertNoFrameskip-v4 \
+    --env-id QbertNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -28,7 +28,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python offline_dqn_cql_atari_visual.py \
-    --gym-id SpaceInvadersNoFrameskip-v4 \
+    --env-id SpaceInvadersNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -41,7 +41,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python offline_dqn_cql_atari_visual.py \
-    --gym-id PongNoFrameskip-v4 \
+    --env-id PongNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -54,7 +54,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python offline_dqn_cql_atari_visual.py \
-    --gym-id BreakoutNoFrameskip-v4 \
+    --env-id BreakoutNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \

--- a/cloud/examples/scripts/ppo_atari.sh
+++ b/cloud/examples/scripts/ppo_atari.sh
@@ -2,7 +2,7 @@
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_atari_visual.py \
-    --gym-id BeamRiderNoFrameskip-v4 \
+    --env-id BeamRiderNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -15,7 +15,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_atari_visual.py \
-    --gym-id QbertNoFrameskip-v4 \
+    --env-id QbertNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -28,7 +28,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_atari_visual.py \
-    --gym-id SpaceInvadersNoFrameskip-v4 \
+    --env-id SpaceInvadersNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -41,7 +41,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_atari_visual.py \
-    --gym-id PongNoFrameskip-v4 \
+    --env-id PongNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -54,7 +54,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_atari_visual.py \
-    --gym-id BreakoutNoFrameskip-v4 \
+    --env-id BreakoutNoFrameskip-v4 \
     --total-timesteps 10000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \

--- a/cloud/examples/scripts/ppo_mujoco.sh
+++ b/cloud/examples/scripts/ppo_mujoco.sh
@@ -2,7 +2,7 @@
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_continuous_action.py \
-    --gym-id Reacher-v2 \
+    --env-id Reacher-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -15,7 +15,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_continuous_action.py \
-    --gym-id Pusher-v2 \
+    --env-id Pusher-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -28,7 +28,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_continuous_action.py \
-    --gym-id Thrower-v2 \
+    --env-id Thrower-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -41,7 +41,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_continuous_action.py \
-    --gym-id Striker-v2 \
+    --env-id Striker-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -54,7 +54,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_continuous_action.py \
-    --gym-id InvertedPendulum-v2 \
+    --env-id InvertedPendulum-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -67,7 +67,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_continuous_action.py \
-    --gym-id HalfCheetah-v2 \
+    --env-id HalfCheetah-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -80,7 +80,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_continuous_action.py \
-    --gym-id Hopper-v2 \
+    --env-id Hopper-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -93,7 +93,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_continuous_action.py \
-    --gym-id Swimmer-v2 \
+    --env-id Swimmer-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -106,7 +106,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_continuous_action.py \
-    --gym-id Walker2d-v2 \
+    --env-id Walker2d-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -119,7 +119,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_continuous_action.py \
-    --gym-id Ant-v2 \
+    --env-id Ant-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -132,7 +132,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_continuous_action.py \
-    --gym-id Humanoid-v2 \
+    --env-id Humanoid-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \

--- a/cloud/examples/scripts/ppo_other.sh
+++ b/cloud/examples/scripts/ppo_other.sh
@@ -2,7 +2,7 @@
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo.py \
-    --gym-id CartPole-v1 \
+    --env-id CartPole-v1 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -15,7 +15,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo.py \
-    --gym-id Acrobot-v1 \
+    --env-id Acrobot-v1 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -28,7 +28,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo.py \
-    --gym-id MountainCar-v0 \
+    --env-id MountainCar-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -41,7 +41,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo.py \
-    --gym-id LunarLander-v2 \
+    --env-id LunarLander-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \

--- a/cloud/examples/scripts/ppo_pybullet.sh
+++ b/cloud/examples/scripts/ppo_pybullet.sh
@@ -2,7 +2,7 @@
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_continuous_action.py \
-    --gym-id MinitaurBulletEnv-v0 \
+    --env-id MinitaurBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -15,7 +15,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_continuous_action.py \
-    --gym-id MinitaurBulletDuckEnv-v0 \
+    --env-id MinitaurBulletDuckEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -28,7 +28,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_continuous_action.py \
-    --gym-id InvertedPendulumBulletEnv-v0 \
+    --env-id InvertedPendulumBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -41,7 +41,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_continuous_action.py \
-    --gym-id InvertedDoublePendulumBulletEnv-v0 \
+    --env-id InvertedDoublePendulumBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -54,7 +54,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_continuous_action.py \
-    --gym-id Walker2DBulletEnv-v0 \
+    --env-id Walker2DBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -67,7 +67,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_continuous_action.py \
-    --gym-id HalfCheetahBulletEnv-v0 \
+    --env-id HalfCheetahBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -80,7 +80,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_continuous_action.py \
-    --gym-id AntBulletEnv-v0 \
+    --env-id AntBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -93,7 +93,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_continuous_action.py \
-    --gym-id HopperBulletEnv-v0 \
+    --env-id HopperBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -106,7 +106,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_continuous_action.py \
-    --gym-id HumanoidBulletEnv-v0 \
+    --env-id HumanoidBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -119,7 +119,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_continuous_action.py \
-    --gym-id BipedalWalker-v3 \
+    --env-id BipedalWalker-v3 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -132,7 +132,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_continuous_action.py \
-    --gym-id LunarLanderContinuous-v2 \
+    --env-id LunarLanderContinuous-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -145,7 +145,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_continuous_action.py \
-    --gym-id Pendulum-v0 \
+    --env-id Pendulum-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -158,7 +158,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python ppo_continuous_action.py \
-    --gym-id MountainCarContinuous-v0 \
+    --env-id MountainCarContinuous-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \

--- a/cloud/examples/scripts/sac_mujoco.sh
+++ b/cloud/examples/scripts/sac_mujoco.sh
@@ -2,7 +2,7 @@
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python sac_continuous_action.py \
-    --gym-id Reacher-v2 \
+    --env-id Reacher-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -15,7 +15,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python sac_continuous_action.py \
-    --gym-id Pusher-v2 \
+    --env-id Pusher-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -28,7 +28,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python sac_continuous_action.py \
-    --gym-id Thrower-v2 \
+    --env-id Thrower-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -41,7 +41,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python sac_continuous_action.py \
-    --gym-id Striker-v2 \
+    --env-id Striker-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -54,7 +54,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python sac_continuous_action.py \
-    --gym-id InvertedPendulum-v2 \
+    --env-id InvertedPendulum-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -67,7 +67,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python sac_continuous_action.py \
-    --gym-id HalfCheetah-v2 \
+    --env-id HalfCheetah-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -80,7 +80,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python sac_continuous_action.py \
-    --gym-id Hopper-v2 \
+    --env-id Hopper-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -93,7 +93,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python sac_continuous_action.py \
-    --gym-id Swimmer-v2 \
+    --env-id Swimmer-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -106,7 +106,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python sac_continuous_action.py \
-    --gym-id Walker2d-v2 \
+    --env-id Walker2d-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -119,7 +119,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python sac_continuous_action.py \
-    --gym-id Ant-v2 \
+    --env-id Ant-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -132,7 +132,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python sac_continuous_action.py \
-    --gym-id Humanoid-v2 \
+    --env-id Humanoid-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \

--- a/cloud/examples/scripts/sac_pybullet.sh
+++ b/cloud/examples/scripts/sac_pybullet.sh
@@ -2,7 +2,7 @@
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python sac_continuous_action.py \
-    --gym-id MinitaurBulletEnv-v0 \
+    --env-id MinitaurBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -15,7 +15,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python sac_continuous_action.py \
-    --gym-id MinitaurBulletDuckEnv-v0 \
+    --env-id MinitaurBulletDuckEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -28,7 +28,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python sac_continuous_action.py \
-    --gym-id InvertedPendulumBulletEnv-v0 \
+    --env-id InvertedPendulumBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -41,7 +41,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python sac_continuous_action.py \
-    --gym-id InvertedDoublePendulumBulletEnv-v0 \
+    --env-id InvertedDoublePendulumBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -54,7 +54,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python sac_continuous_action.py \
-    --gym-id Walker2DBulletEnv-v0 \
+    --env-id Walker2DBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -67,7 +67,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python sac_continuous_action.py \
-    --gym-id HalfCheetahBulletEnv-v0 \
+    --env-id HalfCheetahBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -80,7 +80,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python sac_continuous_action.py \
-    --gym-id AntBulletEnv-v0 \
+    --env-id AntBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -93,7 +93,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python sac_continuous_action.py \
-    --gym-id HopperBulletEnv-v0 \
+    --env-id HopperBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -106,7 +106,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python sac_continuous_action.py \
-    --gym-id HumanoidBulletEnv-v0 \
+    --env-id HumanoidBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -119,7 +119,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python sac_continuous_action.py \
-    --gym-id BipedalWalker-v3 \
+    --env-id BipedalWalker-v3 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -132,7 +132,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python sac_continuous_action.py \
-    --gym-id LunarLanderContinuous-v2 \
+    --env-id LunarLanderContinuous-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -145,7 +145,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python sac_continuous_action.py \
-    --gym-id Pendulum-v0 \
+    --env-id Pendulum-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -158,7 +158,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python sac_continuous_action.py \
-    --gym-id MountainCarContinuous-v0 \
+    --env-id MountainCarContinuous-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \

--- a/cloud/examples/scripts/td3_mujoco.sh
+++ b/cloud/examples/scripts/td3_mujoco.sh
@@ -2,7 +2,7 @@
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python td3_continuous_action.py \
-    --gym-id Reacher-v2 \
+    --env-id Reacher-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -15,7 +15,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python td3_continuous_action.py \
-    --gym-id Pusher-v2 \
+    --env-id Pusher-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -28,7 +28,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python td3_continuous_action.py \
-    --gym-id Thrower-v2 \
+    --env-id Thrower-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -41,7 +41,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python td3_continuous_action.py \
-    --gym-id Striker-v2 \
+    --env-id Striker-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -54,7 +54,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python td3_continuous_action.py \
-    --gym-id InvertedPendulum-v2 \
+    --env-id InvertedPendulum-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -67,7 +67,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python td3_continuous_action.py \
-    --gym-id HalfCheetah-v2 \
+    --env-id HalfCheetah-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -80,7 +80,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python td3_continuous_action.py \
-    --gym-id Hopper-v2 \
+    --env-id Hopper-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -93,7 +93,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python td3_continuous_action.py \
-    --gym-id Swimmer-v2 \
+    --env-id Swimmer-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -106,7 +106,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python td3_continuous_action.py \
-    --gym-id Walker2d-v2 \
+    --env-id Walker2d-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -119,7 +119,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python td3_continuous_action.py \
-    --gym-id Ant-v2 \
+    --env-id Ant-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -132,7 +132,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python td3_continuous_action.py \
-    --gym-id Humanoid-v2 \
+    --env-id Humanoid-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \

--- a/cloud/examples/scripts/td3_pybullet.sh
+++ b/cloud/examples/scripts/td3_pybullet.sh
@@ -2,7 +2,7 @@
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python td3_continuous_action.py \
-    --gym-id MinitaurBulletEnv-v0 \
+    --env-id MinitaurBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -15,7 +15,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python td3_continuous_action.py \
-    --gym-id MinitaurBulletDuckEnv-v0 \
+    --env-id MinitaurBulletDuckEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -28,7 +28,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python td3_continuous_action.py \
-    --gym-id InvertedPendulumBulletEnv-v0 \
+    --env-id InvertedPendulumBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -41,7 +41,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python td3_continuous_action.py \
-    --gym-id InvertedDoublePendulumBulletEnv-v0 \
+    --env-id InvertedDoublePendulumBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -54,7 +54,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python td3_continuous_action.py \
-    --gym-id Walker2DBulletEnv-v0 \
+    --env-id Walker2DBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -67,7 +67,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python td3_continuous_action.py \
-    --gym-id HalfCheetahBulletEnv-v0 \
+    --env-id HalfCheetahBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -80,7 +80,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python td3_continuous_action.py \
-    --gym-id AntBulletEnv-v0 \
+    --env-id AntBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -93,7 +93,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python td3_continuous_action.py \
-    --gym-id HopperBulletEnv-v0 \
+    --env-id HopperBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -106,7 +106,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python td3_continuous_action.py \
-    --gym-id HumanoidBulletEnv-v0 \
+    --env-id HumanoidBulletEnv-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -119,7 +119,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python td3_continuous_action.py \
-    --gym-id BipedalWalker-v3 \
+    --env-id BipedalWalker-v3 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -132,7 +132,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python td3_continuous_action.py \
-    --gym-id LunarLanderContinuous-v2 \
+    --env-id LunarLanderContinuous-v2 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -145,7 +145,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python td3_continuous_action.py \
-    --gym-id Pendulum-v0 \
+    --env-id Pendulum-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \
@@ -158,7 +158,7 @@ done
 for seed in {1..2}
 do
     (sleep 0.3 && nohup xvfb-run -a python td3_continuous_action.py \
-    --gym-id MountainCarContinuous-v0 \
+    --env-id MountainCarContinuous-v0 \
     --total-timesteps 2000000 \
     --wandb-project-name cleanrl.benchmark \
     --track \

--- a/cloud/examples/submit_exp.sh
+++ b/cloud/examples/submit_exp.sh
@@ -1,7 +1,7 @@
 python -m cleanrl.submit_exp --exp-script offline_dqn_cql_atari_visual.sh \
     --algo offline_dqn_cql_atari_visual.py \
     --total-timesteps 10000000 \
-    --gym-ids BeamRiderNoFrameskip-v4 QbertNoFrameskip-v4 SpaceInvadersNoFrameskip-v4 PongNoFrameskip-v4 BreakoutNoFrameskip-v4 \
+    --env-ids BeamRiderNoFrameskip-v4 QbertNoFrameskip-v4 SpaceInvadersNoFrameskip-v4 PongNoFrameskip-v4 BreakoutNoFrameskip-v4 \
     --wandb-project-name cleanrl.benchmark \
     --other-args "--wandb-entity cleanrl --cuda True" \
     --job-queue cleanrl_gpu_large_memory \
@@ -13,12 +13,12 @@ python -m cleanrl.submit_exp --exp-script offline_dqn_cql_atari_visual.sh \
     --num-hours 48.0 \
     --submit-aws $SUBMIT_AWS
 
-python ppg_procgen_impala_cnn.py --gym-id starpilot --capture-video --track --wandb-entity cleanrl --wandb-project cleanrl.benchmark --seed 1
+python ppg_procgen_impala_cnn.py --env-id starpilot --capture-video --track --wandb-entity cleanrl --wandb-project cleanrl.benchmark --seed 1
 
 python -m cleanrl.utils.submit_exp --exp-script ppo.sh \
     --algo ppo.py \
     --total-timesteps 100000 \
-    --gym-ids CartPole-v0 \
+    --env-ids CartPole-v0 \
     --wandb-project-name cleanrl \
     --other-args "--wandb-entity cleanrl --cuda True" \
     --job-queue gpu \
@@ -33,7 +33,7 @@ python -m cleanrl.utils.submit_exp --exp-script ppo.sh \
 python -m cleanrl.utils.submit_exp --exp-script ppo.sh \
     --algo ppo.py \
     --total-timesteps 100000 \
-    --gym-ids CartPole-v0 \
+    --env-ids CartPole-v0 \
     --wandb-project-name cleanrl \
     --other-args "--wandb-entity cleanrl --cuda True" \
     --job-queue cpu \
@@ -47,7 +47,7 @@ python -m cleanrl.utils.submit_exp --exp-script ppo.sh \
 
 python -m cleanrl.utils.submit_exp --exp-script ppo.sh \
     --algo ppo.py \
-    --other-args "--gym-id CartPole-v0 --wandb-project-name cleanrl --total-timesteps 100000 --wandb-entity cleanrl --cuda True" \
+    --other-args "--env-id CartPole-v0 --wandb-project-name cleanrl --total-timesteps 100000 --wandb-entity cleanrl --cuda True" \
     --job-queue cpu \
     --job-definition cleanrl \
     --num-seed 1 \

--- a/docs/cloud/submit-experiments.md
+++ b/docs/cloud/submit-experiments.md
@@ -6,13 +6,13 @@ Dry run to inspect the generated docker command
 ```
 poetry run python -m cleanrl_utils.submit_exp \
     --docker-tag vwxyzjn/cleanrl:latest \
-    --command "poetry run python cleanrl/ppo.py --gym-id CartPole-v1 --total-timesteps 100000 --track --capture-video" \
+    --command "poetry run python cleanrl/ppo.py --env-id CartPole-v1 --total-timesteps 100000 --track --capture-video" \
     --num-seed 1
 ```
 
 The generated docker command should look like
 ```
-docker run -d --cpuset-cpus="0" -e WANDB_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx vwxyzjn/cleanrl:latest /bin/bash -c "poetry run python cleanrl/ppo.py --gym-id CartPole-v1 --total-timesteps 100000 --track --capture-video --seed 1"
+docker run -d --cpuset-cpus="0" -e WANDB_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx vwxyzjn/cleanrl:latest /bin/bash -c "poetry run python cleanrl/ppo.py --env-id CartPole-v1 --total-timesteps 100000 --track --capture-video --seed 1"
 ```
 
 ### Run on AWS
@@ -21,7 +21,7 @@ Submit a job using AWS's compute-optimized spot instances
 ```
 poetry run python -m cleanrl_utils.submit_exp \
     --docker-tag vwxyzjn/cleanrl:latest \
-    --command "poetry run python cleanrl/ppo.py --gym-id CartPole-v1 --total-timesteps 100000 --track --capture-video" \
+    --command "poetry run python cleanrl/ppo.py --env-id CartPole-v1 --total-timesteps 100000 --track --capture-video" \
     --job-queue c5a-large-spot \
     --num-seed 1 \
     --num-vcpu 1 \
@@ -34,7 +34,7 @@ Submit a job using AWS's accelerated-computing spot instances
 ```
 poetry run python -m cleanrl_utils.submit_exp \
     --docker-tag vwxyzjn/cleanrl:latest \
-    --command "poetry run python cleanrl/ppo_atari.py --gym-id BreakoutNoFrameskip-v4 --track --capture-video" \
+    --command "poetry run python cleanrl/ppo_atari.py --env-id BreakoutNoFrameskip-v4 --track --capture-video" \
     --job-queue g4dn-xlarge-spot \
     --num-seed 1 \
     --num-vcpu 1 \
@@ -48,7 +48,7 @@ Submit a job using AWS's compute-optimized on-demand instances
 ```
 poetry run python -m cleanrl_utils.submit_exp \
     --docker-tag vwxyzjn/cleanrl:latest \
-    --command "poetry run python cleanrl/ppo.py --gym-id CartPole-v1 --total-timesteps 100000 --track --capture-video" \
+    --command "poetry run python cleanrl/ppo.py --env-id CartPole-v1 --total-timesteps 100000 --track --capture-video" \
     --job-queue c5a-large \
     --num-seed 1 \
     --num-vcpu 1 \
@@ -61,7 +61,7 @@ Submit a job using AWS's accelerated-computing on-demand instances
 ```
 poetry run python -m cleanrl_utils.submit_exp \
     --docker-tag vwxyzjn/cleanrl:latest \
-    --command "poetry run python cleanrl/ppo_atari.py --gym-id BreakoutNoFrameskip-v4 --track --capture-video" \
+    --command "poetry run python cleanrl/ppo_atari.py --env-id BreakoutNoFrameskip-v4 --track --capture-video" \
     --job-queue g4dn-xlarge \
     --num-seed 1 \
     --num-vcpu 1 \
@@ -94,7 +94,7 @@ Then you could build a container using the `--build` flag based on the `Dockerfi
 ```
 poetry run python -m cleanrl_utils.submit_exp \
     --docker-tag vwxyzjn/cleanrl:latest \
-    --command "poetry run python cleanrl/ppo.py --gym-id CartPole-v1 --total-timesteps 100000 --track --capture-video" \
+    --command "poetry run python cleanrl/ppo.py --env-id CartPole-v1 --total-timesteps 100000 --track --capture-video" \
     --build --push
 ```
 
@@ -103,7 +103,7 @@ To build a multi-arch image using `--archs linux/arm64,linux/amd64`:
 ```
 poetry run python -m cleanrl_utils.submit_exp \
     --docker-tag vwxyzjn/cleanrl:latest \
-    --command "poetry run python cleanrl/ppo.py --gym-id CartPole-v1 --total-timesteps 100000 --track --capture-video" \
+    --command "poetry run python cleanrl/ppo.py --env-id CartPole-v1 --total-timesteps 100000 --track --capture-video" \
     --archs linux/arm64,linux/amd64
     --build --push
 ```

--- a/docs/get-started/basic-usage.md
+++ b/docs/get-started/basic-usage.md
@@ -10,7 +10,7 @@ the CleanRL script under the poetry virtual environments.
     ```bash
     poetry run python cleanrl/ppo.py \
         --seed 1 \
-        --gym-id CartPole-v0 \
+        --env-id CartPole-v0 \
         --total-timesteps 50000
     ```
     <script id="asciicast-443649" src="https://asciinema.org/a/443649.js" async></script>
@@ -31,7 +31,7 @@ the CleanRL script under the poetry virtual environments.
     ```bash
     python cleanrl/ppo.py \
         --seed 1 \
-        --gym-id CartPole-v0 \
+        --env-id CartPole-v0 \
         --total-timesteps 50000
     ```
     <script id="asciicast-JL1FR00I2JNklAhMd2dwEAQuz" src="https://asciinema.org/a/JL1FR00I2JNklAhMd2dwEAQuz.js" async></script>
@@ -64,7 +64,7 @@ which will save the videos in the `videos/{$run_name}` folder.
 ```bash linenums="1" hl_lines="5"
 python cleanrl/ppo.py \
     --seed 1 \
-    --gym-id CartPole-v0 \
+    --env-id CartPole-v0 \
     --total-timesteps 50000 \
     --capture-video
 ```
@@ -79,7 +79,7 @@ You can directly obtained the documentation by using the `--help` flag.
 ```bash
 python cleanrl/ppo.py --help
 
-usage: ppo.py [-h] [--exp-name EXP_NAME] [--gym-id GYM_ID]
+usage: ppo.py [-h] [--exp-name EXP_NAME] [--env-id ENV_ID]
               [--learning-rate LEARNING_RATE] [--seed SEED]
               [--total-timesteps TOTAL_TIMESTEPS]
               [--torch-deterministic [TORCH_DETERMINISTIC]] [--cuda [CUDA]]
@@ -96,7 +96,7 @@ usage: ppo.py [-h] [--exp-name EXP_NAME] [--gym-id GYM_ID]
 optional arguments:
   -h, --help            show this help message and exit
   --exp-name EXP_NAME   the name of this experiment
-  --gym-id GYM_ID       the id of the gym environment
+  --env-id ENV_ID       the id of the environment
   --learning-rate LEARNING_RATE
                         the learning rate of the optimizer
   --seed SEED           seed of the experiment

--- a/docs/get-started/examples.md
+++ b/docs/get-started/examples.md
@@ -5,14 +5,14 @@
 poetry shell
 
 poetry install -E atari
-python cleanrl/dqn_atari.py --gym-id BreakoutNoFrameskip-v4
-python cleanrl/c51_atari.py --gym-id BreakoutNoFrameskip-v4
-python cleanrl/ppo_atari.py --gym-id BreakoutNoFrameskip-v4
-python cleanrl/apex_dqn_atari.py --gym-id BreakoutNoFrameskip-v4
+python cleanrl/dqn_atari.py --env-id BreakoutNoFrameskip-v4
+python cleanrl/c51_atari.py --env-id BreakoutNoFrameskip-v4
+python cleanrl/ppo_atari.py --env-id BreakoutNoFrameskip-v4
+python cleanrl/apex_dqn_atari.py --env-id BreakoutNoFrameskip-v4
 
 # NEW: 3-4x side-effects free speed up with envpool's atari (only available to linux)
 poetry install -E envpool
-python cleanrl/ppo_atari_envpool.py --gym-id BreakoutNoFrameskip-v4
+python cleanrl/ppo_atari_envpool.py --env-id BreakoutNoFrameskip-v4
 # Learn Pong-v5 in ~5-10 mins
 # Side effects such as lower sample efficiency might occur
 poetry run python ppo_atari_envpool.py --clip-coef=0.2 --num-envs=16 --num-minibatches=8 --num-steps=128 --update-epochs=3
@@ -27,9 +27,9 @@ You can also run training scripts in other games, such as:
 ```
 poetry shell
 
-python cleanrl/dqn.py --gym-id CartPole-v1
-python cleanrl/ppo.py --gym-id CartPole-v1
-python cleanrl/c51.py --gym-id CartPole-v1
+python cleanrl/dqn.py --env-id CartPole-v1
+python cleanrl/ppo.py --env-id CartPole-v1
+python cleanrl/c51.py --env-id CartPole-v1
 ```
 
 ## PyBullet
@@ -37,9 +37,9 @@ python cleanrl/c51.py --gym-id CartPole-v1
 poetry shell
 
 poetry install -E pybullet
-python cleanrl/td3_continuous_action.py --gym-id MinitaurBulletDuckEnv-v0
-python cleanrl/ddpg_continuous_action.py --gym-id MinitaurBulletDuckEnv-v0
-python cleanrl/sac_continuous_action.py --gym-id MinitaurBulletDuckEnv-v0
+python cleanrl/td3_continuous_action.py --env-id MinitaurBulletDuckEnv-v0
+python cleanrl/ddpg_continuous_action.py --env-id MinitaurBulletDuckEnv-v0
+python cleanrl/sac_continuous_action.py --env-id MinitaurBulletDuckEnv-v0
 ```
 
 ## Procgen 
@@ -47,8 +47,8 @@ python cleanrl/sac_continuous_action.py --gym-id MinitaurBulletDuckEnv-v0
 poetry shell
 
 poetry install -E procgen
-python cleanrl/ppo_procgen.py --gym-id starpilot
-python cleanrl/ppg_procgen.py --gym-id starpilot
+python cleanrl/ppo_procgen.py --env-id starpilot
+python cleanrl/ppg_procgen.py --env-id starpilot
 ```
 
 
@@ -57,6 +57,6 @@ python cleanrl/ppg_procgen.py --gym-id starpilot
 poetry shell
 
 poetry install -E atari
-python cleanrl/ppo_atari_lstm.py --gym-id BreakoutNoFrameskip-v4
+python cleanrl/ppo_atari_lstm.py --env-id BreakoutNoFrameskip-v4
 python cleanrl/ppo_memory_env_lstm.py
 ```

--- a/tests/test_mujoco.py
+++ b/tests/test_mujoco.py
@@ -6,22 +6,22 @@ def test_pybullet():
     Test classic control
     """
     subprocess.run(
-        "python cleanrl/ppo_continuous_action.py --gym-id Hopper-v2 --num-envs 1 --num-steps 64 --total-timesteps 256",
+        "python cleanrl/ppo_continuous_action.py --env-id Hopper-v2 --num-envs 1 --num-steps 64 --total-timesteps 256",
         shell=True,
         check=True,
     )
     subprocess.run(
-        "python cleanrl/ddpg_continuous_action.py --gym-id Hopper-v2 --learning-starts 100 --batch-size 32 --total-timesteps 105",
+        "python cleanrl/ddpg_continuous_action.py --env-id Hopper-v2 --learning-starts 100 --batch-size 32 --total-timesteps 105",
         shell=True,
         check=True,
     )
     subprocess.run(
-        "python cleanrl/td3_continuous_action.py --gym-id Hopper-v2 --learning-starts 100 --batch-size 32 --total-timesteps 105",
+        "python cleanrl/td3_continuous_action.py --env-id Hopper-v2 --learning-starts 100 --batch-size 32 --total-timesteps 105",
         shell=True,
         check=True,
     )
     subprocess.run(
-        "python cleanrl/sac_continuous_action.py --gym-id Hopper-v2 --batch-size 128 --total-timesteps 135",
+        "python cleanrl/sac_continuous_action.py --env-id Hopper-v2 --batch-size 128 --total-timesteps 135",
         shell=True,
         check=True,
     )


### PR DESCRIPTION
This PR refactors a few arguments in `parse_args()`:

1. This PR moves the `gym_id`, `learning_rate`, `total_timesteps` move down to algorithm-specific arguments. Currently when doing a file diff between `c51_atari.py` and `ppo_continuous_action.py`, we have the following screenshot:
![image](https://user-images.githubusercontent.com/5555347/155023370-5f678b87-3467-4c8d-a46f-73f70d6ebf69.png)
However, it's more desirable to all of the differences in one place, as shown below:
![image](https://user-images.githubusercontent.com/5555347/155023723-548220e3-3ce5-4325-8a36-ed367a243e2d.png)

2. This PR also renames the `gym-id` to `env-id`. The reason is that as we adopt different environments, some of them don't necessarily have a `gym-id` but they have an environment name. For example, procgen has the `env-id` but not `gym-id`.

Curious about your thoughts @yooceii @dosssman on whether this is necessary.



