### PR TITLE
Add SPS and q-values metrics for value-based methods

### DIFF
--- a/cleanrl/apex_dqn_atari.py
+++ b/cleanrl/apex_dqn_atari.py
@@ -820,9 +820,7 @@ def act(args, experiment_name, i, q_network, target_network, lock, rollouts_queu
                     1 - torch.Tensor(s_dones).to(device)
                 )
 
-                old_val = (
-                    q_network(s_obs, device).gather(1, torch.LongTensor(s_actions).view(-1, 1).to(device)).squeeze()
-                )
+                old_val = q_network(s_obs, device).gather(1, torch.LongTensor(s_actions).view(-1, 1).to(device)).squeeze()
                 td_errors = td_target - old_val
             new_priorities = np.abs(td_errors.tolist()) + args.pr_eps
             rollouts_queue.put((storage, new_priorities))

--- a/cleanrl/apex_dqn_atari.py
+++ b/cleanrl/apex_dqn_atari.py
@@ -1100,13 +1100,12 @@ if __name__ == "__main__":
             m = stats_queue.get()
             if m[0] == "charts/episodic_return":
                 r, l = m[1], m[2]
-                print(f"global_step={global_step}, episodic_return={r}")
                 writer.add_scalar("charts/episodic_return", r, global_step)
                 writer.add_scalar("charts/stats_queue_size", stats_queue.qsize(), global_step)
                 writer.add_scalar("charts/rollouts_queue_size", rollouts_queue.qsize(), global_step)
                 writer.add_scalar("charts/data_process_queue_size", data_process_queue.qsize(), global_step)
-                writer.add_scalar("charts/fps", (global_step.item() - start_global_step) / (timer() - start_time), global_step)
-                print("FPS: ", (global_step.item() - start_global_step) / (timer() - start_time))
+                writer.add_scalar("charts/SPS", (global_step.item() - start_global_step) / (timer() - start_time), global_step)
+                print("SPS: ", (global_step.item() - start_global_step) / (timer() - start_time))
             else:
                 # print(m[0], m[1], global_step)
                 writer.add_scalar(m[0], m[1], global_step)

--- a/cleanrl/c51.py
+++ b/cleanrl/c51.py
@@ -161,7 +161,6 @@ if __name__ == "__main__":
     rb = ReplayBuffer(
         args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device, optimize_memory_usage=True
     )
-    loss_fn = nn.MSELoss()
     start_time = time.time()
 
     # TRY NOT TO MODIFY: start the game

--- a/cleanrl/c51.py
+++ b/cleanrl/c51.py
@@ -102,11 +102,8 @@ class QNetwork(nn.Module):
             nn.Linear(84, self.n * n_atoms),
         )
 
-    def forward(self, x):
-        return self.network(x)
-
     def get_action(self, x, action=None):
-        logits = self.forward(x)
+        logits = self.network(x)
         # probability mass function for each action
         pmfs = torch.softmax(logits.view(len(x), self.n, self.n_atoms), dim=2)
         q_values = (pmfs * self.atoms).sum(2)

--- a/cleanrl/c51.py
+++ b/cleanrl/c51.py
@@ -162,6 +162,7 @@ if __name__ == "__main__":
         args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device, optimize_memory_usage=True
     )
     loss_fn = nn.MSELoss()
+    start_time = time.time()
 
     # TRY NOT TO MODIFY: start the game
     obs = envs.reset()
@@ -222,7 +223,10 @@ if __name__ == "__main__":
             loss = (-(target_pmfs * old_pmfs.clamp(min=1e-5, max=1 - 1e-5).log()).sum(-1)).mean()
 
             if global_step % 100 == 0:
-                writer.add_scalar("losses/td_loss", loss, global_step)
+                old_val = (old_pmfs * q_network.atoms).sum(1)
+                writer.add_scalar("losses/q_values", old_val.mean().item(), global_step)
+                print("SPS:", int(global_step / (time.time() - start_time)))
+                writer.add_scalar("charts/SPS", int(global_step / (time.time() - start_time)), global_step)
 
             # optimize the model
             optimizer.zero_grad()

--- a/cleanrl/c51_atari.py
+++ b/cleanrl/c51_atari.py
@@ -182,7 +182,6 @@ if __name__ == "__main__":
     rb = ReplayBuffer(
         args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device, optimize_memory_usage=True
     )
-    loss_fn = nn.MSELoss()
     start_time = time.time()
 
     # TRY NOT TO MODIFY: start the game

--- a/cleanrl/c51_atari.py
+++ b/cleanrl/c51_atari.py
@@ -123,11 +123,8 @@ class QNetwork(nn.Module):
             nn.Linear(512, self.n * n_atoms),
         )
 
-    def forward(self, x):
-        return self.network(x / 255.0)
-
     def get_action(self, x, action=None):
-        logits = self.forward(x)
+        logits = self.network(x / 255.0)
         # probability mass function for each action
         pmfs = torch.softmax(logits.view(len(x), self.n, self.n_atoms), dim=2)
         q_values = (pmfs * self.atoms).sum(2)

--- a/cleanrl/c51_atari.py
+++ b/cleanrl/c51_atari.py
@@ -183,6 +183,7 @@ if __name__ == "__main__":
         args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device, optimize_memory_usage=True
     )
     loss_fn = nn.MSELoss()
+    start_time = time.time()
 
     # TRY NOT TO MODIFY: start the game
     obs = envs.reset()
@@ -243,7 +244,10 @@ if __name__ == "__main__":
             loss = (-(target_pmfs * old_pmfs.clamp(min=1e-5, max=1 - 1e-5).log()).sum(-1)).mean()
 
             if global_step % 100 == 0:
-                writer.add_scalar("losses/td_loss", loss, global_step)
+                old_val = (old_pmfs * q_network.atoms).sum(1)
+                writer.add_scalar("losses/q_values", old_val.mean().item(), global_step)
+                print("SPS:", int(global_step / (time.time() - start_time)))
+                writer.add_scalar("charts/SPS", int(global_step / (time.time() - start_time)), global_step)
 
             # optimize the model
             optimizer.zero_grad()

--- a/cleanrl/ddpg_continuous_action.py
+++ b/cleanrl/ddpg_continuous_action.py
@@ -154,7 +154,6 @@ if __name__ == "__main__":
 
     envs.single_observation_space.dtype = np.float32
     rb = ReplayBuffer(args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device)
-    loss_fn = nn.MSELoss()
     start_time = time.time()
 
     # TRY NOT TO MODIFY: start the game
@@ -205,7 +204,7 @@ if __name__ == "__main__":
                 next_q_value = data.rewards.flatten() + (1 - data.dones.flatten()) * args.gamma * (qf1_next_target).view(-1)
 
             qf1_a_values = qf1.forward(data.observations, data.actions).view(-1)
-            qf1_loss = loss_fn(qf1_a_values, next_q_value)
+            qf1_loss = F.mse_loss(qf1_a_values, next_q_value)
 
             # optimize the model
             q_optimizer.zero_grad()

--- a/cleanrl/ddpg_continuous_action.py
+++ b/cleanrl/ddpg_continuous_action.py
@@ -155,6 +155,7 @@ if __name__ == "__main__":
     envs.single_observation_space.dtype = np.float32
     rb = ReplayBuffer(args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device)
     loss_fn = nn.MSELoss()
+    start_time = time.time()
 
     # TRY NOT TO MODIFY: start the game
     obs = envs.reset()
@@ -228,6 +229,9 @@ if __name__ == "__main__":
             if global_step % 100 == 0:
                 writer.add_scalar("losses/qf1_loss", qf1_loss.item(), global_step)
                 writer.add_scalar("losses/actor_loss", actor_loss.item(), global_step)
+                writer.add_scalar("losses/qf1_values", qf1_a_values.mean().item(), global_step)
+                print("SPS:", int(global_step / (time.time() - start_time)))
+                writer.add_scalar("charts/SPS", int(global_step / (time.time() - start_time)), global_step)
 
     envs.close()
     writer.close()

--- a/cleanrl/dqn.py
+++ b/cleanrl/dqn.py
@@ -8,6 +8,7 @@ import gym
 import numpy as np
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 import torch.optim as optim
 from stable_baselines3.common.buffers import ReplayBuffer
 from torch.utils.tensorboard import SummaryWriter
@@ -142,7 +143,6 @@ if __name__ == "__main__":
     rb = ReplayBuffer(
         args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device, optimize_memory_usage=True
     )
-    loss_fn = nn.MSELoss()
     start_time = time.time()
 
     # TRY NOT TO MODIFY: start the game
@@ -184,7 +184,7 @@ if __name__ == "__main__":
                 target_max, _ = target_network.forward(data.next_observations).max(dim=1)
                 td_target = data.rewards.flatten() + args.gamma * target_max * (1 - data.dones.flatten())
             old_val = q_network.forward(data.observations).gather(1, data.actions).squeeze()
-            loss = loss_fn(td_target, old_val)
+            loss = F.mse_loss(td_target, old_val)
 
             if global_step % 100 == 0:
                 writer.add_scalar("losses/td_loss", loss, global_step)

--- a/cleanrl/dqn.py
+++ b/cleanrl/dqn.py
@@ -153,7 +153,7 @@ if __name__ == "__main__":
         if random.random() < epsilon:
             actions = envs.action_space.sample()
         else:
-            logits = q_network.forward(torch.Tensor(obs).to(device))
+            logits = q_network(torch.Tensor(obs).to(device))
             actions = torch.argmax(logits, dim=1).cpu().numpy()
 
         # TRY NOT TO MODIFY: execute the game and log data.
@@ -181,9 +181,9 @@ if __name__ == "__main__":
         if global_step > args.learning_starts and global_step % args.train_frequency == 0:
             data = rb.sample(args.batch_size)
             with torch.no_grad():
-                target_max, _ = target_network.forward(data.next_observations).max(dim=1)
+                target_max, _ = target_network(data.next_observations).max(dim=1)
                 td_target = data.rewards.flatten() + args.gamma * target_max * (1 - data.dones.flatten())
-            old_val = q_network.forward(data.observations).gather(1, data.actions).squeeze()
+            old_val = q_network(data.observations).gather(1, data.actions).squeeze()
             loss = F.mse_loss(td_target, old_val)
 
             if global_step % 100 == 0:

--- a/cleanrl/dqn.py
+++ b/cleanrl/dqn.py
@@ -143,6 +143,7 @@ if __name__ == "__main__":
         args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device, optimize_memory_usage=True
     )
     loss_fn = nn.MSELoss()
+    start_time = time.time()
 
     # TRY NOT TO MODIFY: start the game
     obs = envs.reset()
@@ -187,6 +188,9 @@ if __name__ == "__main__":
 
             if global_step % 100 == 0:
                 writer.add_scalar("losses/td_loss", loss, global_step)
+                writer.add_scalar("losses/q_values", old_val.mean().item(), global_step)
+                print("SPS:", int(global_step / (time.time() - start_time)))
+                writer.add_scalar("charts/SPS", int(global_step / (time.time() - start_time)), global_step)
 
             # optimize the model
             optimizer.zero_grad()

--- a/cleanrl/dqn_atari.py
+++ b/cleanrl/dqn_atari.py
@@ -174,7 +174,7 @@ if __name__ == "__main__":
         if random.random() < epsilon:
             actions = envs.action_space.sample()
         else:
-            logits = q_network.forward(torch.Tensor(obs).to(device))
+            logits = q_network(torch.Tensor(obs).to(device))
             actions = torch.argmax(logits, dim=1).cpu().numpy()
 
         # TRY NOT TO MODIFY: execute the game and log data.
@@ -202,9 +202,9 @@ if __name__ == "__main__":
         if global_step > args.learning_starts and global_step % args.train_frequency == 0:
             data = rb.sample(args.batch_size)
             with torch.no_grad():
-                target_max, _ = target_network.forward(data.next_observations).max(dim=1)
+                target_max, _ = target_network(data.next_observations).max(dim=1)
                 td_target = data.rewards.flatten() + args.gamma * target_max * (1 - data.dones.flatten())
-            old_val = q_network.forward(data.observations).gather(1, data.actions).squeeze()
+            old_val = q_network(data.observations).gather(1, data.actions).squeeze()
             loss = F.mse_loss(td_target, old_val)
 
             if global_step % 100 == 0:

--- a/cleanrl/dqn_atari.py
+++ b/cleanrl/dqn_atari.py
@@ -164,6 +164,7 @@ if __name__ == "__main__":
         args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device, optimize_memory_usage=True
     )
     loss_fn = nn.MSELoss()
+    start_time = time.time()
 
     # TRY NOT TO MODIFY: start the game
     obs = envs.reset()
@@ -208,6 +209,9 @@ if __name__ == "__main__":
 
             if global_step % 100 == 0:
                 writer.add_scalar("losses/td_loss", loss, global_step)
+                writer.add_scalar("losses/q_values", old_val.mean().item(), global_step)
+                print("SPS:", int(global_step / (time.time() - start_time)))
+                writer.add_scalar("charts/SPS", int(global_step / (time.time() - start_time)), global_step)
 
             # optimize the model
             optimizer.zero_grad()

--- a/cleanrl/dqn_atari.py
+++ b/cleanrl/dqn_atari.py
@@ -8,6 +8,7 @@ import gym
 import numpy as np
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 import torch.optim as optim
 from stable_baselines3.common.atari_wrappers import (
     ClipRewardEnv,
@@ -163,7 +164,6 @@ if __name__ == "__main__":
     rb = ReplayBuffer(
         args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device, optimize_memory_usage=True
     )
-    loss_fn = nn.MSELoss()
     start_time = time.time()
 
     # TRY NOT TO MODIFY: start the game
@@ -205,7 +205,7 @@ if __name__ == "__main__":
                 target_max, _ = target_network.forward(data.next_observations).max(dim=1)
                 td_target = data.rewards.flatten() + args.gamma * target_max * (1 - data.dones.flatten())
             old_val = q_network.forward(data.observations).gather(1, data.actions).squeeze()
-            loss = loss_fn(td_target, old_val)
+            loss = F.mse_loss(td_target, old_val)
 
             if global_step % 100 == 0:
                 writer.add_scalar("losses/td_loss", loss, global_step)

--- a/cleanrl/offline/offline_dqn_atari_visual.py
+++ b/cleanrl/offline/offline_dqn_atari_visual.py
@@ -566,7 +566,7 @@ for global_step in range(args.total_timesteps):
     # ALGO LOGIC: put action logic here
     epsilon = linear_schedule(args.start_e, args.end_e, args.exploration_fraction * args.total_timesteps, global_step)
     obs = np.array(obs)
-    logits = q_network.forward(obs.reshape((1,) + obs.shape), device)
+    logits = q_network(obs.reshape((1,) + obs.shape), device)
     if args.capture_video:
         env.set_q_values(logits.tolist())
     if random.random() < epsilon:

--- a/cleanrl/offline/offline_dqn_atari_visual.py
+++ b/cleanrl/offline/offline_dqn_atari_visual.py
@@ -328,6 +328,7 @@ import matplotlib
 import numpy as np
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 import torch.optim as optim
 from gym.spaces import Discrete
 from gym.wrappers import Monitor
@@ -555,7 +556,6 @@ q_network = QNetwork(env).to(device)
 target_network = QNetwork(env).to(device)
 target_network.load_state_dict(q_network.state_dict())
 optimizer = optim.Adam(q_network.parameters(), lr=args.learning_rate)
-loss_fn = nn.MSELoss()
 data_loader = iter(torch.utils.data.DataLoader(ExperienceReplayDataset(), batch_size=args.batch_size, num_workers=2))
 print(device.__repr__())
 print(q_network)
@@ -606,7 +606,7 @@ for global_step in range(args.total_timesteps):
             target_max = torch.max(target_network.network(s_next_obses), dim=1)[0]
             td_target = s_rewards + args.gamma * target_max * (1 - s_dones)
         old_val = q_network.network(s_obs).gather(1, s_actions.long().view(-1, 1)).squeeze()
-        loss = loss_fn(td_target, old_val)
+        loss = F.mse_loss(td_target, old_val)
         writer.add_scalar("losses/td_loss", loss, global_step)
         writer.add_scalar("losses/average_q_values", old_val.mean().item(), global_step)
 

--- a/cleanrl/offline/offline_dqn_cql_atari_visual.py
+++ b/cleanrl/offline/offline_dqn_cql_atari_visual.py
@@ -570,7 +570,7 @@ for global_step in range(args.total_timesteps):
     # ALGO LOGIC: put action logic here
     epsilon = linear_schedule(args.start_e, args.end_e, args.exploration_fraction * args.total_timesteps, global_step)
     obs = np.array(obs)
-    logits = q_network.forward(obs.reshape((1,) + obs.shape), device)
+    logits = q_network(obs.reshape((1,) + obs.shape), device)
     if args.capture_video:
         env.set_q_values(logits.tolist())
     if random.random() < epsilon:

--- a/cleanrl/offline/offline_dqn_cql_atari_visual.py
+++ b/cleanrl/offline/offline_dqn_cql_atari_visual.py
@@ -328,6 +328,7 @@ import matplotlib
 import numpy as np
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 import torch.optim as optim
 from gym.spaces import Discrete
 from gym.wrappers import Monitor
@@ -558,7 +559,6 @@ q_network = QNetwork(env).to(device)
 target_network = QNetwork(env).to(device)
 target_network.load_state_dict(q_network.state_dict())
 optimizer = optim.Adam(q_network.parameters(), lr=args.learning_rate)
-loss_fn = nn.MSELoss()
 data_loader = iter(torch.utils.data.DataLoader(ExperienceReplayDataset(), batch_size=args.batch_size, num_workers=2))
 print(device.__repr__())
 print(q_network)
@@ -611,7 +611,7 @@ for global_step in range(args.total_timesteps):
             td_target = s_rewards + args.gamma * target_max * (1 - s_dones)
         old_qs = q_network.network(s_obs)
         old_val = old_qs.gather(1, s_actions.long().view(-1, 1)).squeeze()
-        loss = loss_fn(td_target, old_val)
+        loss = F.mse_loss(td_target, old_val)
         writer.add_scalar("losses/td_loss", loss, global_step)
 
         # CQL losses

--- a/cleanrl/sac_continuous_action.py
+++ b/cleanrl/sac_continuous_action.py
@@ -205,6 +205,7 @@ if __name__ == "__main__":
 
     envs.single_observation_space.dtype = np.float32
     rb = ReplayBuffer(args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device)
+    start_time = time.time()
 
     # TRY NOT TO MODIFY: start the game
     obs = envs.reset()
@@ -298,6 +299,9 @@ if __name__ == "__main__":
                 writer.add_scalar("losses/qf_loss", qf_loss.item(), global_step)
                 writer.add_scalar("losses/actor_loss", actor_loss.item(), global_step)
                 writer.add_scalar("losses/alpha", alpha, global_step)
+                writer.add_scalar("losses/qf1_values", qf1_a_values.mean().item(), global_step)
+                print("SPS:", int(global_step / (time.time() - start_time)))
+                writer.add_scalar("charts/SPS", int(global_step / (time.time() - start_time)), global_step)
                 if args.autotune:
                     writer.add_scalar("losses/alpha_loss", alpha_loss.item(), global_step)
 

--- a/cleanrl/sac_continuous_action.py
+++ b/cleanrl/sac_continuous_action.py
@@ -247,9 +247,6 @@ if __name__ == "__main__":
                 min_qf_next_target = torch.min(qf1_next_target, qf2_next_target) - alpha * next_state_log_pi
                 next_q_value = data.rewards.flatten() + (1 - data.dones.flatten()) * args.gamma * (min_qf_next_target).view(-1)
 
-            # NOTE: other potential refactors
-            # 1. using qf1() instead, which calls forward() by default
-            # 2. use F.mse_loss() instead of loss_fn = nn.MSELoss()
             qf1_a_values = qf1(data.observations, data.actions).view(-1)
             qf2_a_values = qf2(data.observations, data.actions).view(-1)
             qf1_loss = F.mse_loss(qf1_a_values, next_q_value)

--- a/cleanrl/td3_continuous_action.py
+++ b/cleanrl/td3_continuous_action.py
@@ -159,7 +159,6 @@ if __name__ == "__main__":
 
     envs.single_observation_space.dtype = np.float32
     rb = ReplayBuffer(args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device)
-    loss_fn = nn.MSELoss()
     start_time = time.time()
 
     # TRY NOT TO MODIFY: start the game
@@ -217,8 +216,8 @@ if __name__ == "__main__":
 
             qf1_a_values = qf1.forward(data.observations, data.actions).view(-1)
             qf2_a_values = qf2.forward(data.observations, data.actions).view(-1)
-            qf1_loss = loss_fn(qf1_a_values, next_q_value)
-            qf2_loss = loss_fn(qf2_a_values, next_q_value)
+            qf1_loss = F.mse_loss(qf1_a_values, next_q_value)
+            qf2_loss = F.mse_loss(qf2_a_values, next_q_value)
 
             # optimize the model
             q_optimizer.zero_grad()

--- a/cleanrl/td3_continuous_action.py
+++ b/cleanrl/td3_continuous_action.py
@@ -160,6 +160,7 @@ if __name__ == "__main__":
     envs.single_observation_space.dtype = np.float32
     rb = ReplayBuffer(args.buffer_size, envs.single_observation_space, envs.single_action_space, device=device)
     loss_fn = nn.MSELoss()
+    start_time = time.time()
 
     # TRY NOT TO MODIFY: start the game
     obs = envs.reset()
@@ -244,6 +245,9 @@ if __name__ == "__main__":
             if global_step % 100 == 0:
                 writer.add_scalar("losses/qf1_loss", qf1_loss.item(), global_step)
                 writer.add_scalar("losses/actor_loss", actor_loss.item(), global_step)
+                writer.add_scalar("losses/qf1_values", qf1_a_values.mean().item(), global_step)
+                print("SPS:", int(global_step / (time.time() - start_time)))
+                writer.add_scalar("charts/SPS", int(global_step / (time.time() - start_time)), global_step)
 
     envs.close()
     writer.close()

--- a/tests/test_atari.py
+++ b/tests/test_atari.py
@@ -17,9 +17,25 @@ def test_dqn():
     )
 
 
+def test_apex_dqn_atari():
+    subprocess.run(
+        "python cleanrl/apex_dqn_atari.py --learning-starts 10 --total-timesteps 16 --buffer-size 10 --batch-size 4",
+        shell=True,
+        check=True,
+    )
+
+
 def test_c51():
     subprocess.run(
         "python cleanrl/c51_atari.py --learning-starts 10 --total-timesteps 16 --buffer-size 10 --batch-size 4",
+        shell=True,
+        check=True,
+    )
+
+
+def test_rnd_ppo():
+    subprocess.run(
+        "python cleanrl/rnd_ppo.py --num-envs 1 --num-steps 64 --total-timesteps 256",
         shell=True,
         check=True,
     )

--- a/tests/test_atari.py
+++ b/tests/test_atari.py
@@ -17,25 +17,9 @@ def test_dqn():
     )
 
 
-def test_apex_dqn_atari():
-    subprocess.run(
-        "python cleanrl/apex_dqn_atari.py --learning-starts 10 --total-timesteps 16 --buffer-size 10 --batch-size 4",
-        shell=True,
-        check=True,
-    )
-
-
 def test_c51():
     subprocess.run(
         "python cleanrl/c51_atari.py --learning-starts 10 --total-timesteps 16 --buffer-size 10 --batch-size 4",
-        shell=True,
-        check=True,
-    )
-
-
-def test_rnd_ppo():
-    subprocess.run(
-        "python cleanrl/rnd_ppo.py --num-envs 1 --num-steps 64 --total-timesteps 256",
         shell=True,
         check=True,
     )


### PR DESCRIPTION
This PR adds SPS and q-values metrics for value methods. 

This PR also use `F.mse_loss()` instead of `loss_fn = nn.MSELoss()`

![image](https://user-images.githubusercontent.com/5555347/155913495-bdeaccd3-5f42-4bcd-bc09-674bdbe172d6.png)
![image](https://user-images.githubusercontent.com/5555347/155913836-0b2107de-8c02-4f65-bcdb-b3c521e8aad8.png)

@dosssman do you think we should also use `using qf1() instead, which calls forward() by default`?