### PR TITLE
Tweaks for PR 'add-sps-qvalues'

### DIFF
--- a/cleanrl/apex_dqn_atari.py
+++ b/cleanrl/apex_dqn_atari.py
@@ -1100,13 +1100,12 @@ if __name__ == "__main__":
             m = stats_queue.get()
             if m[0] == "charts/episodic_return":
                 r, l = m[1], m[2]
-                print(f"global_step={global_step}, episodic_return={r}")
                 writer.add_scalar("charts/episodic_return", r, global_step)
                 writer.add_scalar("charts/stats_queue_size", stats_queue.qsize(), global_step)
                 writer.add_scalar("charts/rollouts_queue_size", rollouts_queue.qsize(), global_step)
                 writer.add_scalar("charts/data_process_queue_size", data_process_queue.qsize(), global_step)
-                writer.add_scalar("charts/fps", (global_step.item() - start_global_step) / (timer() - start_time), global_step)
-                print("FPS: ", (global_step.item() - start_global_step) / (timer() - start_time))
+                writer.add_scalar("charts/SPS", (global_step.item() - start_global_step) / (timer() - start_time), global_step)
+                print("SPS: ", (global_step.item() - start_global_step) / (timer() - start_time))
             else:
                 # print(m[0], m[1], global_step)
                 writer.add_scalar(m[0], m[1], global_step)

--- a/cleanrl/rnd_ppo.py
+++ b/cleanrl/rnd_ppo.py
@@ -692,14 +692,14 @@ class Agent(nn.Module):
         return self.network(x)
 
     def get_action(self, x, action=None):
-        logits = self.actor(self.forward(x))
+        logits = self.actor(self(x))
         probs = Categorical(logits=logits)
         if action is None:
             action = probs.sample()
         return action, probs.log_prob(action), probs.entropy()
 
     def get_value(self, x):
-        features = self.forward(x)
+        features = self(x)
         return self.critic_ext(self.extra_layer(features) + features), self.critic_int(self.extra_layer(features) + features)
 
 
@@ -780,6 +780,7 @@ curiosity_rewards = torch.zeros((args.num_steps, args.num_envs)).to(device)
 dones = torch.zeros((args.num_steps, args.num_envs)).to(device)
 ext_values = torch.zeros((args.num_steps, args.num_envs)).to(device)
 int_values = torch.zeros((args.num_steps, args.num_envs)).to(device)
+start_time = time.time()
 
 # TRY NOT TO MODIFY: start the game
 global_step = 0
@@ -823,7 +824,7 @@ for update in range(1, num_updates + 1):
 
             # visualization
             if args.capture_video:
-                probs_list = np.array(Categorical(logits=agent.actor(agent.forward(obs[step]))).probs[0:1].tolist())
+                probs_list = np.array(Categorical(logits=agent.actor(agent(obs[step]))).probs[0:1].tolist())
                 envs.env_method("set_probs", probs_list, indices=0)
 
         actions[step] = action
@@ -1005,6 +1006,8 @@ for update in range(1, num_updates + 1):
     writer.add_scalar("losses/approx_kl", approx_kl.item(), global_step)
     if args.kle_stop or args.kle_rollback:
         writer.add_scalar("debug/pg_stop_iter", i_epoch_pi, global_step)
+    print("SPS:", int(global_step / (time.time() - start_time)))
+    writer.add_scalar("charts/SPS", int(global_step / (time.time() - start_time)), global_step)
 
 envs.close()
 writer.close()

--- a/cleanrl/sac_continuous_action.py
+++ b/cleanrl/sac_continuous_action.py
@@ -247,9 +247,6 @@ if __name__ == "__main__":
                 min_qf_next_target = torch.min(qf1_next_target, qf2_next_target) - alpha * next_state_log_pi
                 next_q_value = data.rewards.flatten() + (1 - data.dones.flatten()) * args.gamma * (min_qf_next_target).view(-1)
 
-            # NOTE: other potential refactors
-            # 1. using qf1() instead, which calls forward() by default
-            # 2. use F.mse_loss() instead of loss_fn = nn.MSELoss()
             qf1_a_values = qf1(data.observations, data.actions).view(-1)
             qf2_a_values = qf2(data.observations, data.actions).view(-1)
             qf1_loss = F.mse_loss(qf1_a_values, next_q_value)

--- a/tests/test_atari.py
+++ b/tests/test_atari.py
@@ -18,7 +18,7 @@ def test_dqn():
 
 def test_apex_dqn_atari():
     subprocess.run(
-        "python cleanrl/c51_atari.py --learning-starts 10 --total-timesteps 16 --buffer-size 10 --batch-size 4",
+        "python cleanrl/apex_dqn_atari.py --learning-starts 10 --total-timesteps 16 --buffer-size 10 --batch-size 4",
         shell=True,
         check=True,
     )

--- a/tests/test_atari.py
+++ b/tests/test_atari.py
@@ -16,6 +16,7 @@ def test_dqn():
         check=True,
     )
 
+
 def test_apex_dqn_atari():
     subprocess.run(
         "python cleanrl/apex_dqn_atari.py --learning-starts 10 --total-timesteps 16 --buffer-size 10 --batch-size 4",
@@ -23,12 +24,14 @@ def test_apex_dqn_atari():
         check=True,
     )
 
+
 def test_c51():
     subprocess.run(
         "python cleanrl/c51_atari.py --learning-starts 10 --total-timesteps 16 --buffer-size 10 --batch-size 4",
         shell=True,
         check=True,
     )
+
 
 def test_rnd_ppo():
     subprocess.run(

--- a/tests/test_atari.py
+++ b/tests/test_atari.py
@@ -16,10 +16,23 @@ def test_dqn():
         check=True,
     )
 
+def test_apex_dqn_atari():
+    subprocess.run(
+        "python cleanrl/c51_atari.py --learning-starts 10 --total-timesteps 16 --buffer-size 10 --batch-size 4",
+        shell=True,
+        check=True,
+    )
 
 def test_c51():
     subprocess.run(
         "python cleanrl/c51_atari.py --learning-starts 10 --total-timesteps 16 --buffer-size 10 --batch-size 4",
+        shell=True,
+        check=True,
+    )
+
+def test_rnd_ppo():
+    subprocess.run(
+        "python cleanrl/rnd_ppo.py --num-envs 1 --num-steps 64 --total-timesteps 256",
         shell=True,
         check=True,
     )


### PR DESCRIPTION
## Overview of the tweaks on top of #126 

###  apex_dqn_atari..py
- Added SPS logging to match other files in #126
- Added `apex_dqn_atari.py` to `test_atari.py`

### SAC Continuous
- Removed the comment pertaining to (1) using F.mse_loss() and (2) using qf1() instead of qf1.forward()

### rnd_ppo:
- removed `.forward()` calls to match the other files in #126 
- Added to `test_atari.py`

