### PR TITLE
Fix the default wandb project name in `ppo_atari_envpool.py`

### DIFF
--- a/cleanrl/ppo_atari_envpool.py
+++ b/cleanrl/ppo_atari_envpool.py
@@ -28,7 +28,7 @@ def parse_args():
         help="if toggled, cuda will be enabled by default")
     parser.add_argument("--track", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
         help="if toggled, this experiment will be tracked with Weights and Biases")
-    parser.add_argument("--wandb-project-name", type=str, default="ppo-implementation-details",
+    parser.add_argument("--wandb-project-name", type=str, default="cleanRL",
         help="the wandb's project name")
     parser.add_argument("--wandb-entity", type=str, default=None,
         help="the entity (team) of wandb's project")


### PR DESCRIPTION
## Description
This PR provides a minor fix for the default wandb project name for `ppo_atari_envpool.py`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [ ] New algorithm
- [x] Documentation
