### PR TITLE
Let `ppo_continuous_action.py`only run 1M steps

### DIFF
--- a/cleanrl/ppo_continuous_action.py
+++ b/cleanrl/ppo_continuous_action.py
@@ -37,7 +37,7 @@ def parse_args():
     # Algorithm specific arguments
     parser.add_argument("--env-id", type=str, default="HalfCheetahBulletEnv-v0",
         help="the id of the environment")
-    parser.add_argument("--total-timesteps", type=int, default=2000000,
+    parser.add_argument("--total-timesteps", type=int, default=1000000,
         help="total timesteps of the experiments")
     parser.add_argument("--learning-rate", type=float, default=3e-4,
         help="the learning rate of the optimizer")


### PR DESCRIPTION
## Description
This PR sets the `total-timesteps` of `ppo_continuous_action.py` to be 1M, which matches the same timesteps budget in the original paper. We will defer the documentation of this change when we do the ppo benchmark soon (see #121)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] New algorithm
- [ ] Documentation

