### PR TITLE
Change `ppo.py`'s default timesteps

### DIFF
--- a/cleanrl/ppo.py
+++ b/cleanrl/ppo.py
@@ -39,7 +39,7 @@ def parse_args():
     # Algorithm specific arguments
     parser.add_argument("--env-id", type=str, default="CartPole-v1",
         help="the id of the environment")
-    parser.add_argument("--total-timesteps", type=int, default=25000,
+    parser.add_argument("--total-timesteps", type=int, default=500000,
         help="total timesteps of the experiments")
     parser.add_argument("--learning-rate", type=float, default=2.5e-4,
         help="the learning rate of the optimizer")


### PR DESCRIPTION
## Description
This PR changes the default `total-timesteps` in `ppo.py` from 25000 to 500000. With 25000 steps, `ppo.py` cannot perfectly solve CartPole-v1, whereas with 500k steps `ppo.py` can. Going to add documentation in #163. Merging this now.

## Types of changes
- [x] Bug fix
- [ ] New feature
- [ ] New algorithm
- [ ] Documentation

