### PR TITLE
Introduce benchmark utilities

### DIFF
--- a/benchmark/ppo.sh
+++ b/benchmark/ppo.sh
@@ -4,7 +4,7 @@
 poetry install
 OMP_NUM_THREADS=1 python -m cleanrl_utils.benchmark \
     --env-ids CartPole-v1 Acrobot-v1 MountainCar-v0 \
-    --command "poetry run python cleanrl/ppo.py --track --cuda False" \
+    --command "poetry run python cleanrl/ppo.py --cuda False --track" \
     --num-seeds 3 \
     --workers 3
 
@@ -33,13 +33,13 @@ poetry install -E "mujoco pybullet"
 python -c "import mujoco_py"
 OMP_NUM_THREADS=1 python -m cleanrl_utils.benchmark \
     --env-ids HalfCheetah-v2 Walker2d-v2 Hopper-v2 \
-    --command "poetry run python cleanrl/ppo_continuous_action.py --track --cuda False" \
+    --command "poetry run python cleanrl/ppo_continuous_action.py --cuda False --track" \
     --num-seeds 3 \
     --workers 3
 
 poetry install -E procgen
 python -m cleanrl_utils.benchmark \
     --env-ids starpilot bossfight bigfish \
-    --command "poetry run python cleanrl/ppo_procgen.py --track --track" \
+    --command "poetry run python cleanrl/ppo_procgen.py --track" \
     --num-seeds 3 \
     --workers 1

--- a/benchmark/ppo.sh
+++ b/benchmark/ppo.sh
@@ -4,28 +4,28 @@
 poetry install
 OMP_NUM_THREADS=1 python -m cleanrl_utils.benchmark \
     --env-ids CartPole-v1 Acrobot-v1 MountainCar-v0 \
-    --command "poetry run python cleanrl/ppo.py --cuda False --track" \
+    --command "poetry run python cleanrl/ppo.py --cuda False --track --capture-video" \
+    --num-seeds 3 \
+    --workers 9
+
+poetry install -E atari
+OMP_NUM_THREADS=1 python -m cleanrl_utils.benchmark \
+    --env-ids PongNoFrameskip-v4 BeamRiderNoFrameskip-v4 BreakoutNoFrameskip-v4 \
+    --command "poetry run python cleanrl/ppo_atari.py --track --capture-video" \
     --num-seeds 3 \
     --workers 3
 
 poetry install -E atari
-python -m cleanrl_utils.benchmark \
+OMP_NUM_THREADS=1 python -m cleanrl_utils.benchmark \
     --env-ids PongNoFrameskip-v4 BeamRiderNoFrameskip-v4 BreakoutNoFrameskip-v4 \
-    --command "poetry run python cleanrl/ppo_atari.py --track" \
+    --command "poetry run python cleanrl/ppo_atari_lstm.py --track --capture-video" \
     --num-seeds 3 \
-    --workers 1
+    --workers 3
 
-poetry install -E atari
+poetry install -E envpool
 python -m cleanrl_utils.benchmark \
-    --env-ids PongNoFrameskip-v4 BeamRiderNoFrameskip-v4 BreakoutNoFrameskip-v4 \
-    --command "poetry run python cleanrl/ppo_atari_lstm.py --track" \
-    --num-seeds 3 \
-    --workers 1
-
-poetry install -E atari
-python -m cleanrl_utils.benchmark \
-    --env-ids PongNoFrameskip-v4 BeamRiderNoFrameskip-v4 BreakoutNoFrameskip-v4 \
-    --command "poetry run python cleanrl/ppo_atari_envpool.py --track" \
+    --env-ids Pong-v5 BeamRider-v5 Breakout-v5 \
+    --command "poetry run python cleanrl/ppo_atari_envpool.py --track --capture-video" \
     --num-seeds 3 \
     --workers 1
 
@@ -33,13 +33,13 @@ poetry install -E "mujoco pybullet"
 python -c "import mujoco_py"
 OMP_NUM_THREADS=1 python -m cleanrl_utils.benchmark \
     --env-ids HalfCheetah-v2 Walker2d-v2 Hopper-v2 \
-    --command "poetry run python cleanrl/ppo_continuous_action.py --cuda False --track" \
+    --command "poetry run python cleanrl/ppo_continuous_action.py --cuda False --track --capture-video" \
     --num-seeds 3 \
-    --workers 3
+    --workers 9
 
 poetry install -E procgen
 python -m cleanrl_utils.benchmark \
     --env-ids starpilot bossfight bigfish \
-    --command "poetry run python cleanrl/ppo_procgen.py --track" \
+    --command "poetry run python cleanrl/ppo_procgen.py --track --capture-video" \
     --num-seeds 3 \
     --workers 1

--- a/benchmark/ppo.sh
+++ b/benchmark/ppo.sh
@@ -1,29 +1,29 @@
-# export WANDB_ENTITY=openrlbenchmark
-# export WANDB_PROJECT=cleanrl
+export WANDB_ENTITY=openrlbenchmark
+export WANDB_PROJECT=cleanrl
 
 poetry install
-OMP_NUM_THREADS=1 python -m cleanrl_utils.benchmark \
+OMP_NUM_THREADS=1 xvfb-run -a python -m cleanrl_utils.benchmark \
     --env-ids CartPole-v1 Acrobot-v1 MountainCar-v0 \
     --command "poetry run python cleanrl/ppo.py --cuda False --track --capture-video" \
     --num-seeds 3 \
-    --workers 9
+    --workers 1
 
 poetry install -E atari
-OMP_NUM_THREADS=1 python -m cleanrl_utils.benchmark \
+OMP_NUM_THREADS=1 xvfb-run -a python -m cleanrl_utils.benchmark \
     --env-ids PongNoFrameskip-v4 BeamRiderNoFrameskip-v4 BreakoutNoFrameskip-v4 \
     --command "poetry run python cleanrl/ppo_atari.py --track --capture-video" \
     --num-seeds 3 \
     --workers 3
 
 poetry install -E atari
-OMP_NUM_THREADS=1 python -m cleanrl_utils.benchmark \
+OMP_NUM_THREADS=1 xvfb-run -a python -m cleanrl_utils.benchmark \
     --env-ids PongNoFrameskip-v4 BeamRiderNoFrameskip-v4 BreakoutNoFrameskip-v4 \
     --command "poetry run python cleanrl/ppo_atari_lstm.py --track --capture-video" \
     --num-seeds 3 \
     --workers 3
 
 poetry install -E envpool
-python -m cleanrl_utils.benchmark \
+xvfb-run -a python -m cleanrl_utils.benchmark \
     --env-ids Pong-v5 BeamRider-v5 Breakout-v5 \
     --command "poetry run python cleanrl/ppo_atari_envpool.py --track --capture-video" \
     --num-seeds 3 \
@@ -31,14 +31,14 @@ python -m cleanrl_utils.benchmark \
 
 poetry install -E "mujoco pybullet"
 python -c "import mujoco_py"
-OMP_NUM_THREADS=1 python -m cleanrl_utils.benchmark \
+OMP_NUM_THREADS=1 xvfb-run -a python -m cleanrl_utils.benchmark \
     --env-ids HalfCheetah-v2 Walker2d-v2 Hopper-v2 \
     --command "poetry run python cleanrl/ppo_continuous_action.py --cuda False --track --capture-video" \
     --num-seeds 3 \
     --workers 9
 
 poetry install -E procgen
-python -m cleanrl_utils.benchmark \
+xvfb-run -a python -m cleanrl_utils.benchmark \
     --env-ids starpilot bossfight bigfish \
     --command "poetry run python cleanrl/ppo_procgen.py --track --capture-video" \
     --num-seeds 3 \

--- a/benchmark/ppo.sh
+++ b/benchmark/ppo.sh
@@ -1,0 +1,45 @@
+# export WANDB_ENTITY=openrlbenchmark
+# export WANDB_PROJECT=cleanrl
+
+poetry install
+OMP_NUM_THREADS=1 python -m cleanrl_utils.benchmark \
+    --env-ids CartPole-v1 Acrobot-v1 MountainCar-v0 \
+    --command "poetry run python cleanrl/ppo.py --track --cuda False" \
+    --num-seeds 3 \
+    --workers 3
+
+poetry install -E atari
+python -m cleanrl_utils.benchmark \
+    --env-ids PongNoFrameskip-v4 BeamRiderNoFrameskip-v4 BreakoutNoFrameskip-v4 \
+    --command "poetry run python cleanrl/ppo_atari.py --track" \
+    --num-seeds 3 \
+    --workers 1
+
+poetry install -E atari
+python -m cleanrl_utils.benchmark \
+    --env-ids PongNoFrameskip-v4 BeamRiderNoFrameskip-v4 BreakoutNoFrameskip-v4 \
+    --command "poetry run python cleanrl/ppo_atari_lstm.py --track" \
+    --num-seeds 3 \
+    --workers 1
+
+poetry install -E atari
+python -m cleanrl_utils.benchmark \
+    --env-ids PongNoFrameskip-v4 BeamRiderNoFrameskip-v4 BreakoutNoFrameskip-v4 \
+    --command "poetry run python cleanrl/ppo_atari_envpool.py --track" \
+    --num-seeds 3 \
+    --workers 1
+
+poetry install -E "mujoco pybullet"
+python -c "import mujoco_py"
+OMP_NUM_THREADS=1 python -m cleanrl_utils.benchmark \
+    --env-ids HalfCheetah-v2 Walker2d-v2 Hopper-v2 \
+    --command "poetry run python cleanrl/ppo_continuous_action.py --track --cuda False" \
+    --num-seeds 3 \
+    --workers 3
+
+poetry install -E procgen
+python -m cleanrl_utils.benchmark \
+    --env-ids starpilot bossfight bigfish \
+    --command "poetry run python cleanrl/ppo_procgen.py --track --track" \
+    --num-seeds 3 \
+    --workers 1

--- a/benchmark/ppo.sh
+++ b/benchmark/ppo.sh
@@ -6,7 +6,7 @@ OMP_NUM_THREADS=1 xvfb-run -a python -m cleanrl_utils.benchmark \
     --env-ids CartPole-v1 Acrobot-v1 MountainCar-v0 \
     --command "poetry run python cleanrl/ppo.py --cuda False --track --capture-video" \
     --num-seeds 3 \
-    --workers 1
+    --workers 9
 
 poetry install -E atari
 OMP_NUM_THREADS=1 xvfb-run -a python -m cleanrl_utils.benchmark \

--- a/cleanrl_utils/benchmark.py
+++ b/cleanrl_utils/benchmark.py
@@ -1,0 +1,45 @@
+import argparse
+import shlex
+import subprocess
+
+
+def parse_args():
+    # fmt: off
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--env-ids", nargs="+", default=["CartPole-v1", "Acrobot-v1", "MountainCar-v0"],
+        help="the ids of the environment to benchmark")
+    parser.add_argument("--command", type=str, default="poetry run python cleanrl/ppo.py",
+        help="the command to run")
+    parser.add_argument("--num-seeds", type=int, default=3,
+        help="the number of random seeds")
+    parser.add_argument('--workers', type=int, default=0,
+        help='the number of eval workers to run benchmark experimenets (skips evaluation when set to 0)')
+    args = parser.parse_args()
+    # fmt: on
+    return args
+
+
+def run_evaluation(command: str):
+    command_list = shlex.split(command)
+    print(f"running {command}")
+    fd = subprocess.Popen(command_list)
+    return_code = fd.wait()
+    assert return_code == 0
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    commands = []
+    for seed in range(1, args.num_seeds + 1):
+        for env_id in args.env_ids:
+            commands += [" ".join([args.command, "--env-id", env_id, "--seed", str(seed)])]
+
+    print(commands)
+
+    if args.workers > 0:
+        from concurrent.futures import ThreadPoolExecutor
+
+        executor = ThreadPoolExecutor(max_workers=args.workers, thread_name_prefix="cleanrl-benchmark-worker-")
+        for command in commands:
+            executor.submit(run_evaluation, command)
+        executor.shutdown(wait=True, cancel_futures=False)

--- a/cleanrl_utils/benchmark.py
+++ b/cleanrl_utils/benchmark.py
@@ -19,7 +19,7 @@ def parse_args():
     return args
 
 
-def run_evaluation(command: str):
+def run_experiment(command: str):
     command_list = shlex.split(command)
     print(f"running {command}")
     fd = subprocess.Popen(command_list)
@@ -41,5 +41,5 @@ if __name__ == "__main__":
 
         executor = ThreadPoolExecutor(max_workers=args.workers, thread_name_prefix="cleanrl-benchmark-worker-")
         for command in commands:
-            executor.submit(run_evaluation, command)
+            executor.submit(run_experiment, command)
         executor.shutdown(wait=True, cancel_futures=False)

--- a/docs/get-started/benchmark-utility.md
+++ b/docs/get-started/benchmark-utility.md
@@ -1,0 +1,75 @@
+# Benchmark Utility
+
+CleanRL comes with a utility module `cleanrl_utils.benchmark` to help schedule and run benchmark experiments on your local machine.
+
+## Usage
+
+Try running `python -m cleanrl_utils.benchmark --help` to get the help text.
+
+```bash
+python -m cleanrl_utils.benchmark --help
+usage: benchmark.py [-h] [--env-ids ENV_IDS [ENV_IDS ...]]
+                    [--command COMMAND] [--num-seeds NUM_SEEDS]
+                    [--workers WORKERS]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --env-ids ENV_IDS [ENV_IDS ...]
+                        the ids of the environment to benchmark
+  --command COMMAND     the command to run
+  --num-seeds NUM_SEEDS
+                        the number of random seeds
+  --workers WORKERS     the number of eval workers to run benchmark
+                        experimenets (skips evaluation when set to 0)
+```
+
+## Examples
+
+The following example demonstrates how to run classic control benchmark experiments.
+
+```bash
+OMP_NUM_THREADS=1 xvfb-run -a python -m cleanrl_utils.benchmark \
+    --env-ids CartPole-v1 Acrobot-v1 MountainCar-v0 \
+    --command "poetry run python cleanrl/ppo.py --cuda False --track --capture-video" \
+    --num-seeds 3 \
+    --workers 5
+```
+
+What just happened here? In principle the helps run the following commands in 5 subprocesses:
+
+```bash
+poetry run python cleanrl/ppo.py --cuda False --track --capture-video --env-id CartPole-v1 --seed 1
+poetry run python cleanrl/ppo.py --cuda False --track --capture-video --env-id Acrobot-v1 --seed 1
+poetry run python cleanrl/ppo.py --cuda False --track --capture-video --env-id MountainCar-v0 --seed 1
+poetry run python cleanrl/ppo.py --cuda False --track --capture-video --env-id CartPole-v1 --seed 2
+poetry run python cleanrl/ppo.py --cuda False --track --capture-video --env-id Acrobot-v1 --seed 2
+poetry run python cleanrl/ppo.py --cuda False --track --capture-video --env-id MountainCar-v0 --seed 2
+poetry run python cleanrl/ppo.py --cuda False --track --capture-video --env-id CartPole-v1 --seed 3
+poetry run python cleanrl/ppo.py --cuda False --track --capture-video --env-id Acrobot-v1 --seed 3
+poetry run python cleanrl/ppo.py --cuda False --track --capture-video --env-id MountainCar-v0 --seed 3
+```
+
+More specifically:
+
+1. `--env-ids CartPole-v1 Acrobot-v1 MountainCar-v0` specifies that running experiments against these three environments
+1. `--command "poetry run python cleanrl/ppo.py --cuda False --track --capture-video"` suggests running `ppo.py` with these settings:
+    * turn off GPU usage via `--cuda False`: because `ppo.py` has such as small neural network it often runs faster on CPU only
+    * track the experiments via `--track`
+    * render the agent gameplay videos via `--capture-video`; these videos algo get saved to the tracked experiments
+        * ` xvfb-run -a` virtualizes a display for video recording, enabling these commands on a headless linux system
+1. `--num-seeds 3` suggests running the the command with 3 random seeds for each `env-id`
+1. `--workers 5` suggests at maximum using 5 subprocesses to run the experiments
+    * `OMP_NUM_THREADS=1` suggests `torch` to use only 1 thread for each subprocesses; this way we don't have processes fighting each other.
+
+
+Note that when you run with high-throughput environments such as `envpool` or `procgen`, it's recommended to set `--workers 1` to maximuize SPS (steps per second), such as
+
+```bash
+xvfb-run -a python -m cleanrl_utils.benchmark \
+    --env-ids Pong-v5 BeamRider-v5 Breakout-v5 \
+    --command "poetry run python cleanrl/ppo_atari_envpool.py --track --capture-video" \
+    --num-seeds 3 \
+    --workers 1
+```
+
+For more example usage, see [https://github.com/vwxyzjn/cleanrl/blob/master/benchmark/ppo.sh](https://github.com/vwxyzjn/cleanrl/blob/master/benchmark/ppo.sh)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
     - get-started/basic-usage.md
     - get-started/experiment-tracking.md
     - get-started/examples.md
+    - get-started/benchmark-utility.md
   - Cloud Integration: 
     - cloud/installation.md
     - cloud/submit-experiments.md


### PR DESCRIPTION
## Description
This PR introduces utilities that help us to run the benchmark experiments more smoothly.

Previously, we relied on a very simple mechanism for conducting benchmark experiments such as 

https://github.com/vwxyzjn/cleanrl/blob/443bb141afd26db41f14ede4a5f2026a62a16756/benchmark/sac/mujoco.sh#L3-L7

Such bash script usage is pretty straightforward but lacks flexibility and configurability. This PR introduce a command such as 

```bash
OMP_NUM_THREADS=1 python -m cleanrl_utils.benchmark \
    --env-ids CartPole-v1 Acrobot-v1 MountainCar-v0 \
    --command "poetry run python cleanrl/ppo.py --track --cuda False" \
    --num-seeds 3 \
    --workers 3
```

which will automatically run experiments with`workers=3` subprocesses. A full example can be seen here:

```
# export WANDB_ENTITY=openrlbenchmark
# export WANDB_PROJECT=cleanrl

OMP_NUM_THREADS=1 python -m cleanrl_utils.benchmark \
    --env-ids CartPole-v1 Acrobot-v1 MountainCar-v0 \
    --command "poetry run python cleanrl/ppo.py --track --cuda False" \
    --num-seeds 3 \
    --workers 3

poetry install -E atari
python -m cleanrl_utils.benchmark \
    --env-ids PongNoFrameskip-v4 BeamRiderNoFrameskip-v4 BreakoutNoFrameskip-v4 \
    --command "poetry run python cleanrl/ppo_atari.py --track" \
    --num-seeds 3 \
    --workers 1

python -m cleanrl_utils.benchmark \
    --env-ids PongNoFrameskip-v4 BeamRiderNoFrameskip-v4 BreakoutNoFrameskip-v4 \
    --command "poetry run python cleanrl/ppo_atari_lstm.py --track" \
    --num-seeds 3 \
    --workers 1

python -m cleanrl_utils.benchmark \
    --env-ids PongNoFrameskip-v4 BeamRiderNoFrameskip-v4 BreakoutNoFrameskip-v4 \
    --command "poetry run python cleanrl/ppo_atari_envpool.py --track" \
    --num-seeds 3 \
    --workers 1

poetry install -E "mujoco pybullet"
python -c "import mujoco_py"
OMP_NUM_THREADS=1 python -m cleanrl_utils.benchmark \
    --env-ids HalfCheetah-v2 Walker2d-v2 Hopper-v2 \
    --command "poetry run python cleanrl/ppo_continuous_action.py --track --cuda False" \
    --num-seeds 3 \
    --workers 3

poetry install -E procgen
python -m cleanrl_utils.benchmark \
    --env-ids starpilot bossfight bigfish \
    --command "poetry run python cleanrl/ppo_procgen.py --track --track" \
    --num-seeds 3 \
    --workers 1
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [x] New feature
- [ ] New algorithm
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/vwxyzjn/cleanrl/blob/master/CONTRIBUTING.md) guide (**required**).
- [x] I have ensured `pre-commit run --all-files` passes (**required**).
- [ ] I have updated the documentation and previewed the changes via `mkdocs serve`.
