### PR TITLE
Add docs header

### DIFF
--- a/cleanrl/c51.py
+++ b/cleanrl/c51.py
@@ -1,3 +1,4 @@
+# docs and experiment results can be found at https://docs.cleanrl.dev/rl-algorithms/c51/#c51py
 import argparse
 import os
 import random

--- a/cleanrl/c51_atari.py
+++ b/cleanrl/c51_atari.py
@@ -1,3 +1,4 @@
+# docs and experiment results can be found at https://docs.cleanrl.dev/rl-algorithms/c51/#c51_ataripy
 import argparse
 import os
 import random

--- a/cleanrl/ddpg_continuous_action.py
+++ b/cleanrl/ddpg_continuous_action.py
@@ -1,3 +1,4 @@
+# docs and experiment results can be found at https://docs.cleanrl.dev/rl-algorithms/ddpg/#ddpg_continuous_actionpy
 # docs and experiment results can be found at
 # https://docs.cleanrl.dev/rl-algorithms/ddpg/#ddpg_continuous_actionpy
 

--- a/cleanrl/dqn.py
+++ b/cleanrl/dqn.py
@@ -1,3 +1,4 @@
+# docs and experiment results can be found at https://docs.cleanrl.dev/rl-algorithms/dqn/#dqnpy
 import argparse
 import os
 import random

--- a/cleanrl/dqn_atari.py
+++ b/cleanrl/dqn_atari.py
@@ -1,3 +1,4 @@
+# docs and experiment results can be found at https://docs.cleanrl.dev/rl-algorithms/dqn/#dqn_ataripy
 import argparse
 import os
 import random

--- a/cleanrl/ppo.py
+++ b/cleanrl/ppo.py
@@ -1,6 +1,4 @@
 # docs and experiment results can be found at https://docs.cleanrl.dev/rl-algorithms/ppo/#ppopy
-# docs and experiment results can be found at
-# https://docs.cleanrl.dev/rl-algorithms/ppo/#ppopy
 
 import argparse
 import os

--- a/cleanrl/ppo.py
+++ b/cleanrl/ppo.py
@@ -1,3 +1,4 @@
+# docs and experiment results can be found at https://docs.cleanrl.dev/rl-algorithms/ppo/#ppopy
 # docs and experiment results can be found at
 # https://docs.cleanrl.dev/rl-algorithms/ppo/#ppopy
 

--- a/cleanrl/ppo_atari.py
+++ b/cleanrl/ppo_atari.py
@@ -1,3 +1,4 @@
+# docs and experiment results can be found at https://docs.cleanrl.dev/rl-algorithms/ppo/#ppo_ataripy
 import argparse
 import os
 import random

--- a/cleanrl/ppo_atari_envpool.py
+++ b/cleanrl/ppo_atari_envpool.py
@@ -1,3 +1,4 @@
+# docs and experiment results can be found at https://docs.cleanrl.dev/rl-algorithms/ppo/#ppo_atari_envpoolpy
 import argparse
 import os
 import random

--- a/cleanrl/ppo_atari_lstm.py
+++ b/cleanrl/ppo_atari_lstm.py
@@ -1,3 +1,4 @@
+# docs and experiment results can be found at https://docs.cleanrl.dev/rl-algorithms/ppo/#ppo_atari_lstmpy
 import argparse
 import os
 import random

--- a/cleanrl/ppo_continuous_action.py
+++ b/cleanrl/ppo_continuous_action.py
@@ -1,3 +1,4 @@
+# docs and experiment results can be found at https://docs.cleanrl.dev/rl-algorithms/ppo/#ppo_continuous_actionpy
 import argparse
 import os
 import random

--- a/cleanrl/ppo_pettingzoo.py
+++ b/cleanrl/ppo_pettingzoo.py
@@ -1,3 +1,4 @@
+# docs and experiment results can be found at https://docs.cleanrl.dev/rl-algorithms/ppo/#ppo_pettingzoopy
 import argparse
 import os
 import random

--- a/cleanrl/ppo_procgen.py
+++ b/cleanrl/ppo_procgen.py
@@ -1,3 +1,4 @@
+# docs and experiment results can be found at https://docs.cleanrl.dev/rl-algorithms/ppo/#ppo_procgenpy
 import argparse
 import os
 import random

--- a/cleanrl/rnd_ppo.py
+++ b/cleanrl/rnd_ppo.py
@@ -1,3 +1,4 @@
+# docs and experiment results can be found at https://docs.cleanrl.dev/rl-algorithms/rnd/#rnd_ppopy
 # https://github.com/facebookresearch/torchbeast/blob/master/torchbeast/core/environment.py
 
 import time

--- a/cleanrl/rnd_ppo.py
+++ b/cleanrl/rnd_ppo.py
@@ -1,4 +1,3 @@
-# docs and experiment results can be found at https://docs.cleanrl.dev/rl-algorithms/rnd/#rnd_ppopy
 # https://github.com/facebookresearch/torchbeast/blob/master/torchbeast/core/environment.py
 
 import time

--- a/cleanrl/sac_continuous_action.py
+++ b/cleanrl/sac_continuous_action.py
@@ -1,3 +1,4 @@
+# docs and experiment results can be found at https://docs.cleanrl.dev/rl-algorithms/sac/#sac_continuous_actionpy
 import argparse
 import os
 import random

--- a/cleanrl/td3_continuous_action.py
+++ b/cleanrl/td3_continuous_action.py
@@ -1,3 +1,4 @@
+# docs and experiment results can be found at https://docs.cleanrl.dev/rl-algorithms/td3/#td3_continuous_actionpy
 import argparse
 import os
 import random

--- a/cleanrl_utils/add_header.py
+++ b/cleanrl_utils/add_header.py
@@ -1,0 +1,26 @@
+import os
+
+def add_header(dirname: str):
+    """
+    Add a header string with documentation link
+    to each file in the directory `dirname`.
+    """
+    
+    for filename in os.listdir(dirname):
+        if filename.endswith('.py'):
+            with open(os.path.join(dirname, filename), 'r') as f:
+                lines = f.readlines()
+            
+            # hacky bit
+            exp_name = filename.split(".")[0]
+            algo_name = exp_name.split("_")[0]
+            header_string = f"# docs and experiment results can be found at https://docs.cleanrl.dev/rl-algorithms/{algo_name}/#{exp_name}py"
+
+            if not lines[0].startswith(header_string):
+                print(f"adding headers for {filename}")
+                lines.insert(0, header_string + '\n')
+                with open(os.path.join(dirname, filename), 'w') as f:
+                    f.writelines(lines)
+
+if __name__=='__main__':
+    add_header("cleanrl")

--- a/cleanrl_utils/add_header.py
+++ b/cleanrl_utils/add_header.py
@@ -1,16 +1,17 @@
 import os
 
+
 def add_header(dirname: str):
     """
     Add a header string with documentation link
     to each file in the directory `dirname`.
     """
-    
+
     for filename in os.listdir(dirname):
-        if filename.endswith('.py'):
-            with open(os.path.join(dirname, filename), 'r') as f:
+        if filename.endswith(".py"):
+            with open(os.path.join(dirname, filename)) as f:
                 lines = f.readlines()
-            
+
             # hacky bit
             exp_name = filename.split(".")[0]
             algo_name = exp_name.split("_")[0]
@@ -18,9 +19,10 @@ def add_header(dirname: str):
 
             if not lines[0].startswith(header_string):
                 print(f"adding headers for {filename}")
-                lines.insert(0, header_string + '\n')
-                with open(os.path.join(dirname, filename), 'w') as f:
+                lines.insert(0, header_string + "\n")
+                with open(os.path.join(dirname, filename), "w") as f:
                     f.writelines(lines)
 
-if __name__=='__main__':
+
+if __name__ == "__main__":
     add_header("cleanrl")


### PR DESCRIPTION
## Description
This PR adds a header string pointing users to the documentation site.

Wrote a utility script to help do so by `poetry run python -m cleanrl_utils.add_header`, which generates:

```
# docs and experiment results can be found at https://docs.cleanrl.dev/rl-algorithms/ppo/#ppopy
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/vwxyzjn/cleanrl/blob/master/CONTRIBUTING.md) guide (**required**).
- [x] I have ensured `pre-commit run --all-files` passes (**required**).
- [x] I have updated the documentation and previewed the changes via `mkdocs serve`.
- [x] I have updated the tests accordingly (if applicable).
