### PR TITLE
Dqn atari jax

### DIFF
--- a/cleanrl/dqn_atari_jax.py
+++ b/cleanrl/dqn_atari_jax.py
@@ -1,0 +1,241 @@
+import argparse
+import functools
+import os
+import time
+from distutils.util import strtobool
+
+import gym
+import numpy as np
+
+import flax.linen as nn
+import jax
+import jax.numpy as jnp
+import optax
+from torch.utils.tensorboard import SummaryWriter
+
+from stable_baselines3.common.atari_wrappers import (
+    ClipRewardEnv,
+    EpisodicLifeEnv,
+    FireResetEnv,
+    MaxAndSkipEnv,
+    NoopResetEnv,
+)
+from stable_baselines3.common.buffers import ReplayBuffer
+
+def parse_args():
+    # fmt: off
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
+        help="the name of this experiment")
+    parser.add_argument("--seed", type=int, default=1,
+        help="seed of the experiment")
+    parser.add_argument("--torch-deterministic", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
+        help="if toggled, `torch.backends.cudnn.deterministic=False`")
+    parser.add_argument("--cuda", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
+        help="if toggled, cuda will be enabled by default")
+    parser.add_argument("--track", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="if toggled, this experiment will be tracked with Weights and Biases")
+    parser.add_argument("--wandb-project-name", type=str, default="cleanRL",
+        help="the wandb's project name")
+    parser.add_argument("--wandb-entity", type=str, default=None,
+        help="the entity (team) of wandb's project")
+    parser.add_argument("--capture-video", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="weather to capture videos of the agent performances (check out `videos` folder)")
+
+    # Algorithm specific arguments
+    parser.add_argument("--env-id", type=str, default="BreakoutNoFrameskip-v4",
+        help="the id of the environment")
+    parser.add_argument("--total-timesteps", type=int, default=10000000,
+        help="total timesteps of the experiments")
+    parser.add_argument("--learning-rate", type=float, default=1e-4,
+        help="the learning rate of the optimizer")
+    parser.add_argument("--buffer-size", type=int, default=1000000,
+        help="the replay memory buffer size")
+    parser.add_argument("--gamma", type=float, default=0.99,
+        help="the discount factor gamma")
+    parser.add_argument("--target-network-frequency", type=int, default=1000,
+        help="the timesteps it takes to update the target network")
+    parser.add_argument("--max-grad-norm", type=float, default=0.5,
+        help="the maximum norm for the gradient clipping")
+    parser.add_argument("--batch-size", type=int, default=32,
+        help="the batch size of sample from the reply memory")
+    parser.add_argument("--start-e", type=float, default=1,
+        help="the starting epsilon for exploration")
+    parser.add_argument("--end-e", type=float, default=0.01,
+        help="the ending epsilon for exploration")
+    parser.add_argument("--exploration-fraction", type=float, default=0.10,
+        help="the fraction of `total-timesteps` it takes from start-e to go end-e")
+    parser.add_argument("--learning-starts", type=int, default=80000,
+        help="timestep to start learning")
+    parser.add_argument("--train-frequency", type=int, default=4,
+        help="the frequency of training")
+    parser.add_argument("--mico-weight", type=float, default=0.01,
+        help="the weight for mico loss")
+
+    args = parser.parse_args()
+    # fmt: on
+    return args
+
+def make_env(env_id, seed, idx, capture_video, run_name):
+    def thunk():
+        env = gym.make(env_id)
+        env = gym.wrappers.RecordEpisodeStatistics(env)
+        if capture_video:
+            if idx == 0:
+                env = gym.wrappers.RecordVideo(env, f"videos/{run_name}")
+        env = NoopResetEnv(env, noop_max=30)
+        env = MaxAndSkipEnv(env, skip=4)
+        env = EpisodicLifeEnv(env)
+        if "FIRE" in env.unwrapped.get_action_meanings():
+            env = FireResetEnv(env)
+        env = ClipRewardEnv(env)
+        env = gym.wrappers.ResizeObservation(env, (84, 84))
+        env = gym.wrappers.GrayScaleObservation(env)
+        env = gym.wrappers.FrameStack(env, 4)
+        env.seed(seed)
+        env.action_space.seed(seed)
+        env.observation_space.seed(seed)
+        return env
+
+    return thunk
+
+# ALGO LOGIC: initialize agent here:
+class QNetwork(nn.Module):
+    action_dim: int
+    initializer: callable 
+    @nn.compact
+    def __call__(self, x: jnp.ndarray):
+        x = jnp.transpose(x, (1, 2, 0))
+        x = x.astype(jnp.float32) / 255.
+        x = nn.Conv(features=32, kernel_size=(8, 8), strides=(4, 4),
+                    kernel_init=self.initializer, padding='VALID')(x)
+        x = nn.relu(x)
+        x = nn.Conv(features=64, kernel_size=(4, 4), strides=(2, 2),
+                    kernel_init=self.initializer, padding='VALID')(x)
+        x = nn.relu(x)
+        x = nn.Conv(features=64, kernel_size=(3, 3), strides=(1, 1),
+                    kernel_init=self.initializer, padding='VALID')(x)
+        x = nn.relu(x)
+        x = x.reshape(-1)  # flatten
+        x = nn.Dense(features=512, kernel_init=self.initializer)(x)
+        x = nn.relu(x)
+        q_values = nn.Dense(features=self.action_dim,
+                            kernel_init=self.initializer)(x)
+        return q_values
+    
+@functools.partial(jax.jit, static_argnums=(1,))
+def linear_schedule(start_e: float, end_e: float, duration: int, t: int):
+    slope = (end_e - start_e) / duration
+    return jnp.maximum(slope * t + start_e, end_e)
+
+def mse(target, prediction):
+    return jnp.power((target-prediction), 2)
+
+@functools.partial(jax.jit, static_argnums=(0, 3, 10))
+def train(network_def, online_params, target_params, optimizer, optimizer_state, next_obs, obs, rewards, dones, actions, gamma):
+    def loss_fn(online_params, target_params, next_obs, obs, rewards, dones, actions):
+        def q_val_fn(observations):
+            return network_def.apply(online_params, observations)
+        def t_val_fn(observations):
+            return network_def.apply(target_params, observations)
+
+        target_max = jnp.max(jax.vmap(t_val_fn)(next_obs), axis=1)
+        td_target = jax.lax.stop_gradient(rewards + gamma * target_max * (1 - dones))
+        q_val = jax.vmap(q_val_fn)(obs)
+        old_val = jax.vmap(lambda x, y: x[y])(q_val, actions)
+        return jnp.mean(jax.vmap(mse)(td_target, old_val)), old_val
+
+    # optimize the model
+    grad_fn = jax.value_and_grad(loss_fn, has_aux=True)
+    (loss, old_val), grad = grad_fn(online_params, target_params, next_obs, obs, rewards, dones, actions)
+    updates, optimizer_state = optimizer.update(grad, optimizer_state, params=online_params)
+    online_params = optax.apply_updates(online_params, updates)
+    return loss, old_val, online_params, optimizer_state
+
+@functools.partial(jax.jit, static_argnums=(2, 3))
+def select_action(rng_seed, epsilon, num_actions, network_def, online_params, obs):
+    rng, rng_1, rng_2 = jax.random.split(rng_seed, 3)
+    return rng, jnp.where(jax.random.uniform(rng_1) < epsilon, jax.random.randint(rng_2, (), 0, num_actions), jnp.argmax(network_def.apply(online_params, obs)))
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    run_name = f"{args.env_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    if args.track:
+        import wandb
+
+        wandb.init(
+            project=args.wandb_project_name,
+            entity=args.wandb_entity,
+            sync_tensorboard=True,
+            config=vars(args),
+            name=run_name,
+            monitor_gym=True,
+            save_code=True,
+        )
+    writer = SummaryWriter(f"runs/{run_name}")
+    writer.add_text(
+        "hyperparameters",
+        "|param|value|\n|-|-|\n%s" % ("\n".join([f"|{key}|{value}|" for key, value in vars(args).items()])),
+    )
+
+    # TRY NOT TO MODIFY: seeding
+    key = jax.random.PRNGKey(args.seed)
+    q_network_seed, t_network_seed, rng_seed = jax.random.split(key, num=3)
+
+    # env setup
+    envs = gym.vector.SyncVectorEnv([make_env(args.env_id, args.seed, 0, args.capture_video, run_name)])
+    assert isinstance(envs.single_action_space, gym.spaces.Discrete), "only discrete action space is supported"
+    obs = envs.reset()
+    network_def = QNetwork(envs.single_action_space.n, nn.initializers.xavier_uniform())
+    q_network_params = network_def.init(q_network_seed, x=obs.squeeze())
+    optimizer = optax.adam(args.learning_rate,  b1=0.99, b2=0.999)
+    optimizer_state = optimizer.init(q_network_params)
+    target_network_params = q_network_params
+
+    rb = ReplayBuffer(
+        args.buffer_size, envs.single_observation_space, envs.single_action_space, optimize_memory_usage=True
+    )
+    start_time = time.time()
+
+    # TRY NOT TO MODIFY: start the game
+    for global_step in range(args.total_timesteps):
+        # ALGO LOGIC: put action logic here
+        epsilon = linear_schedule(args.start_e, args.end_e, args.exploration_fraction * args.total_timesteps, global_step)
+        rng_seed, actions = select_action(rng_seed, epsilon, envs.single_action_space.n, network_def, q_network_params, obs.squeeze())
+        actions = np.array([actions])
+        # TRY NOT TO MODIFY: execute the game and log data.
+        next_obs, rewards, dones, infos = envs.step(actions)
+        # TRY NOT TO MODIFY: record rewards for plotting purposes
+        for info in infos:
+            if "episode" in info.keys():
+                print(f"global_step={global_step}, episodic_return={info['episode']['r']}")
+                writer.add_scalar("charts/episodic_return", info["episode"]["r"], global_step)
+                writer.add_scalar("charts/epsilon", np.asarray(epsilon), global_step)
+                break
+        # TRY NOT TO MODIFY: save data to reply buffer; handle `terminal_observation`
+        real_next_obs = next_obs.copy()
+        for idx, d in enumerate(dones):
+            if d:
+                real_next_obs[idx] = infos[idx]["terminal_observation"]
+        rb.add(obs, real_next_obs, actions, rewards, dones, infos)
+
+        # TRY NOT TO MODIFY: CRUCIAL step easy to overlook
+        obs = next_obs
+        # ALGO LOGIC: training.            
+        if global_step > args.learning_starts and global_step % args.train_frequency == 0:
+            data = rb.sample(args.batch_size)
+            loss, old_vals, q_network_params, optimizer_state = train(network_def, q_network_params, target_network_params, optimizer, optimizer_state, data.next_observations.numpy(), data.observations.numpy(), data.rewards.flatten().numpy(), data.dones.flatten().numpy(), data.actions.numpy(), args.gamma)
+            if global_step % 100 == 0:
+                writer.add_scalar("losses/td_loss", np.asarray(loss), global_step)
+                writer.add_scalar("losses/q_values", np.asarray(old_vals).mean(), global_step)
+                print("SPS:", int(global_step / (time.time() - start_time)))
+                writer.add_scalar("charts/SPS", int(global_step / (time.time() - start_time)), global_step)
+            # update the target network
+            if global_step % args.target_network_frequency == 0:
+                target_network_params = q_network_params
+
+    envs.close()
+    writer.close()
+
+

--- a/cleanrl/ppo_rnd.py
+++ b/cleanrl/ppo_rnd.py
@@ -1,0 +1,568 @@
+import argparse
+import os
+import random
+import time
+from distutils.util import strtobool
+
+import gym
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from gym.wrappers.normalize import RunningMeanStd
+from torch.distributions.categorical import Categorical
+from torch.utils.tensorboard import SummaryWriter
+
+from stable_baselines3.common.atari_wrappers import (  # isort:skip
+    ClipRewardEnv,
+    EpisodicLifeEnv,
+    FireResetEnv,
+    MaxAndSkipEnv,
+    NoopResetEnv,
+)
+
+
+def parse_args():
+    # fmt: off
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
+        help="the name of this experiment")
+    parser.add_argument("--seed", type=int, default=1,
+        help="seed of the experiment")
+    parser.add_argument("--torch-deterministic", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
+        help="if toggled, `torch.backends.cudnn.deterministic=False`")
+    parser.add_argument("--cuda", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
+        help="if toggled, cuda will be enabled by default")
+    parser.add_argument("--track", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="if toggled, this experiment will be tracked with Weights and Biases")
+    parser.add_argument("--wandb-project-name", type=str, default="cleanRL",
+        help="the wandb's project name")
+    parser.add_argument("--wandb-entity", type=str, default=None,
+        help="the entity (team) of wandb's project")
+    parser.add_argument("--capture-video", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="weather to capture videos of the agent performances (check out `videos` folder)")
+    parser.add_argument(
+        "--video-interval",
+        type=int,
+        default=50,
+        help="the episode interval for capturing video",
+    )
+
+    # Algorithm specific arguments
+    parser.add_argument("--env-id", type=str, default="BreakoutNoFrameskip-v4",
+        help="the id of the environment")
+    parser.add_argument("--total-timesteps", type=int, default=10000000,
+        help="total timesteps of the experiments")
+    parser.add_argument("--learning-rate", type=float, default=2.5e-4,
+        help="the learning rate of the optimizer")
+    parser.add_argument("--num-envs", type=int, default=8,
+        help="the number of parallel game environments")
+    parser.add_argument("--num-steps", type=int, default=128,
+        help="the number of steps to run in each environment per policy rollout")
+    parser.add_argument("--anneal-lr", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
+        help="Toggle learning rate annealing for policy and value networks")
+    parser.add_argument("--gae", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
+        help="Use GAE for advantage computation")
+    parser.add_argument("--gamma", type=float, default=0.999,
+        help="the discount factor gamma")
+    parser.add_argument("--gae-lambda", type=float, default=0.95,
+        help="the lambda for the general advantage estimation")
+    parser.add_argument("--num-minibatches", type=int, default=4,
+        help="the number of mini-batches")
+    parser.add_argument("--update-epochs", type=int, default=4,
+        help="the K epochs to update the policy")
+    parser.add_argument("--norm-adv", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
+        help="Toggles advantages normalization")
+    parser.add_argument("--clip-coef", type=float, default=0.1,
+        help="the surrogate clipping coefficient")
+    parser.add_argument("--clip-vloss", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
+        help="Toggles whether or not to use a clipped loss for the value function, as per the paper.")
+    parser.add_argument("--ent-coef", type=float, default=0.01,
+        help="coefficient of the entropy")
+    parser.add_argument("--vf-coef", type=float, default=0.5,
+        help="coefficient of the value function")
+    parser.add_argument("--max-grad-norm", type=float, default=0.5,
+        help="the maximum norm for the gradient clipping")
+    parser.add_argument("--target-kl", type=float, default=None,
+        help="the target KL divergence threshold")
+    parser.add_argument("--sticky-action", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
+        help="Toggles whether or not to use sticky action.",
+    )
+
+    # RND arguments
+    parser.add_argument(
+        "--update-proportion", type=float, default=0.25,
+        help="proportion of exp used for predictor update",
+    )
+    parser.add_argument(
+        "--int-coef", type=float, default=1.0,
+        help="coefficient of extrinsic reward"
+    )
+    parser.add_argument(
+        "--ext-coef", type=float, default=2.0,
+        help="coefficient of intrinsic reward"
+    )
+    parser.add_argument(
+        "--int-gamma", type=float, default=0.99,
+        help="Intrinsic reward discount rate"
+    )
+
+    args = parser.parse_args()
+    args.batch_size = int(args.num_envs * args.num_steps)
+    args.minibatch_size = int(args.batch_size // args.num_minibatches)
+    # fmt: on
+    return args
+
+
+def make_env(env_id, seed, idx, capture_video, run_name):
+    def thunk():
+        env = gym.make(env_id)
+        env = gym.wrappers.RecordEpisodeStatistics(env)
+        if capture_video:
+            if idx == 0:
+                env = gym.wrappers.RecordVideo(env, f"videos/{run_name}")
+        env = NoopResetEnv(env, noop_max=30)
+        env = MaxAndSkipEnv(env, skip=4)
+        if args.sticky_action:
+            env = StickyAction(env)
+        env = EpisodicLifeEnv(env)
+        if "FIRE" in env.unwrapped.get_action_meanings():
+            env = FireResetEnv(env)
+        env = ClipRewardEnv(env)
+        env = gym.wrappers.ResizeObservation(env, 84)
+        env = gym.wrappers.GrayScaleObservation(env)
+        env = gym.wrappers.FrameStack(env, 4)
+        env.seed(seed)
+        env.action_space.seed(seed)
+        env.observation_space.seed(seed)
+        return env
+
+    return thunk
+
+
+# ALGO LOGIC: initialize agent here:
+class Scale(nn.Module):
+    def __init__(self, scale):
+        super().__init__()
+        self.scale = scale
+
+    def forward(self, x):
+        return x * self.scale
+
+
+def layer_init(layer, std=np.sqrt(2), bias_const=0.0):
+    torch.nn.init.orthogonal_(layer.weight, std)
+    torch.nn.init.constant_(layer.bias, bias_const)
+    return layer
+
+
+class Agent(nn.Module):
+    def __init__(self, envs, frames=4):
+        super().__init__()
+        self.network = nn.Sequential(
+            Scale(1 / 255),
+            layer_init(nn.Conv2d(frames, 32, 8, stride=4)),
+            nn.ReLU(),
+            layer_init(nn.Conv2d(32, 64, 4, stride=2)),
+            nn.ReLU(),
+            layer_init(nn.Conv2d(64, 64, 3, stride=1)),
+            nn.ReLU(),
+            nn.Flatten(),
+            layer_init(nn.Linear(3136, 256)),
+            nn.ReLU(),
+            layer_init(nn.Linear(256, 448)),
+            nn.ReLU(),
+        )
+        self.extra_layer = nn.Sequential(layer_init(nn.Linear(448, 448), std=0.1), nn.ReLU())
+        self.actor = nn.Sequential(
+            layer_init(nn.Linear(448, 448), std=0.01),
+            nn.ReLU(),
+            layer_init(nn.Linear(448, envs.single_action_space.n), std=0.01),
+        )
+        self.critic_ext = layer_init(nn.Linear(448, 1), std=0.01)
+        self.critic_int = layer_init(nn.Linear(448, 1), std=0.01)
+
+    def forward(self, x):
+        return self.network(x)
+
+    def get_action_and_value(self, x, action=None):
+        logits = self.actor(self.forward(x))
+        probs = Categorical(logits=logits)
+        if action is None:
+            action = probs.sample()
+        return action, probs.log_prob(action), probs.entropy(), self.get_value(x)
+
+    def get_value(self, x):
+        features = self.forward(x)
+        return self.critic_ext(self.extra_layer(features) + features), self.critic_int(self.extra_layer(features) + features)
+
+
+class RNDModel(nn.Module):
+    def __init__(self, input_size, output_size):
+        super().__init__()
+
+        self.input_size = input_size
+        self.output_size = output_size
+
+        feature_output = 7 * 7 * 64
+
+        # Prediction network
+        self.predictor = nn.Sequential(
+            layer_init(nn.Conv2d(in_channels=1, out_channels=32, kernel_size=8, stride=4)),
+            nn.LeakyReLU(),
+            layer_init(nn.Conv2d(in_channels=32, out_channels=64, kernel_size=4, stride=2)),
+            nn.LeakyReLU(),
+            layer_init(nn.Conv2d(in_channels=64, out_channels=64, kernel_size=3, stride=1)),
+            nn.LeakyReLU(),
+            nn.Flatten(),
+            layer_init(nn.Linear(feature_output, 512)),
+            nn.ReLU(),
+            layer_init(nn.Linear(512, 512)),
+            nn.ReLU(),
+            layer_init(nn.Linear(512, 512)),
+        )
+
+        # Target network
+        self.target = nn.Sequential(
+            layer_init(nn.Conv2d(in_channels=1, out_channels=32, kernel_size=8, stride=4)),
+            nn.LeakyReLU(),
+            layer_init(nn.Conv2d(in_channels=32, out_channels=64, kernel_size=4, stride=2)),
+            nn.LeakyReLU(),
+            layer_init(nn.Conv2d(in_channels=64, out_channels=64, kernel_size=3, stride=1)),
+            nn.LeakyReLU(),
+            nn.Flatten(),
+            layer_init(nn.Linear(feature_output, 512)),
+        )
+
+        # Set that target network is not trainable
+        for param in self.target.parameters():
+            param.requires_grad = False
+
+    def forward(self, next_obs):
+        target_feature = self.target(next_obs)
+        predict_feature = self.predictor(next_obs)
+
+        return predict_feature, target_feature
+
+
+class RewardForwardFilter:
+    def __init__(self, gamma):
+        self.rewems = None
+        self.gamma = gamma
+
+    def update(self, rews):
+        if self.rewems is None:
+            self.rewems = rews
+        else:
+            self.rewems = self.rewems * self.gamma + rews
+        return self.rewems
+
+
+class StickyAction(gym.Wrapper):
+    def __init__(self, env, sticky_action=True, p=0.25):
+        gym.Wrapper.__init__(self, env)
+        self.sticky_action = sticky_action
+        self.last_action = 0
+        self.p = p
+
+    def step(self, action):
+        if self.sticky_action:
+            if np.random.rand() <= self.p:
+                action = self.last_action
+            self.last_action = action
+        return self.env.step(action)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    run_name = f"{args.env_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    if args.track:
+        import wandb
+
+        wandb.init(
+            project=args.wandb_project_name,
+            entity=args.wandb_entity,
+            sync_tensorboard=True,
+            config=vars(args),
+            name=run_name,
+            monitor_gym=True,
+            save_code=True,
+        )
+    writer = SummaryWriter(f"runs/{run_name}")
+    writer.add_text(
+        "hyperparameters",
+        "|param|value|\n|-|-|\n%s" % ("\n".join([f"|{key}|{value}|" for key, value in vars(args).items()])),
+    )
+
+    # TRY NOT TO MODIFY: seeding
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.backends.cudnn.deterministic = args.torch_deterministic
+
+    device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
+
+    envs = gym.vector.SyncVectorEnv(
+        [make_env(args.env_id, args.seed + i, i, args.capture_video, run_name) for i in range(args.num_envs)]
+    )
+    assert isinstance(envs.single_action_space, gym.spaces.Discrete), "only discrete action space is supported"
+
+    agent = Agent(envs).to(device)
+    rnd_model = RNDModel(4, envs.single_action_space.n).to(device)
+    optimizer = optim.Adam(
+        list(agent.parameters()) + list(rnd_model.predictor.parameters()),
+        lr=args.learning_rate,
+        eps=1e-5,
+    )
+
+    reward_rms = RunningMeanStd()
+    obs_rms = RunningMeanStd(shape=(1, 1, 84, 84))
+    discounted_reward = RewardForwardFilter(args.gamma)
+
+    # ALGO Logic: Storage setup
+    obs = torch.zeros((args.num_steps, args.num_envs) + envs.single_observation_space.shape).to(device)
+    actions = torch.zeros((args.num_steps, args.num_envs) + envs.single_action_space.shape).to(device)
+    logprobs = torch.zeros((args.num_steps, args.num_envs)).to(device)
+    rewards = torch.zeros((args.num_steps, args.num_envs)).to(device)
+    curiosity_rewards = torch.zeros((args.num_steps, args.num_envs)).to(device)
+    dones = torch.zeros((args.num_steps, args.num_envs)).to(device)
+    ext_values = torch.zeros((args.num_steps, args.num_envs)).to(device)
+    int_values = torch.zeros((args.num_steps, args.num_envs)).to(device)
+
+    # TRY NOT TO MODIFY: start the game
+    global_step = 0
+    start_time = time.time()
+    next_obs = torch.Tensor(envs.reset()).to(device)
+    next_done = torch.zeros(args.num_envs).to(device)
+    num_updates = args.total_timesteps // args.batch_size
+
+    print("Start to initialize observation normalization parameter.....")
+    next_ob = []
+    for step in range(args.num_steps * 50):
+        acs = torch.from_numpy(np.random.randint(0, envs.single_action_space.n, size=(args.num_envs,)))
+        s, r, d, _ = envs.step(acs)
+        next_ob += s[:, 3, :, :].reshape([-1, 1, 84, 84]).tolist()
+
+        if len(next_ob) % (args.num_steps * args.num_envs) == 0:
+            next_ob = np.stack(next_ob)
+            obs_rms.update(next_ob)
+            next_ob = []
+    print("End to initialize...")
+
+    for update in range(1, num_updates + 1):
+        # Annealing the rate if instructed to do so.
+        if args.anneal_lr:
+            frac = 1.0 - (update - 1.0) / num_updates
+            lrnow = frac * args.learning_rate
+            optimizer.param_groups[0]["lr"] = lrnow
+
+        for step in range(0, args.num_steps):
+            global_step += 1 * args.num_envs
+            obs[step] = next_obs
+            dones[step] = next_done
+
+            # ALGO LOGIC: action logic
+            with torch.no_grad():
+                value_ext, value_int = agent.get_value(obs[step])
+                ext_values[step], int_values[step] = (
+                    value_ext.flatten(),
+                    value_int.flatten(),
+                )
+                action, logprob, _, _ = agent.get_action_and_value(obs[step])
+
+            actions[step] = action
+            logprobs[step] = logprob
+
+            # TRY NOT TO MODIFY: execute the game and log data.
+            next_obs, reward, done, info = envs.step(action.cpu().numpy())
+            rewards[step] = torch.tensor(reward).to(device).view(-1)
+            next_obs, next_done = torch.Tensor(next_obs).to(device), torch.Tensor(done).to(device)
+            rnd_next_obs = (
+                (
+                    (next_obs[:, 3, :, :].reshape(args.num_envs, 1, 84, 84) - torch.from_numpy(obs_rms.mean).to(device))
+                    / torch.sqrt(torch.from_numpy(obs_rms.var).to(device))
+                ).clip(-5, 5)
+            ).float()
+            target_next_feature = rnd_model.target(rnd_next_obs)
+            predict_next_feature = rnd_model.predictor(rnd_next_obs)
+            curiosity_rewards[step] = ((target_next_feature - predict_next_feature).pow(2).sum(1) / 2).data
+            for idx, item in enumerate(info):
+                if "episode" in item.keys():
+                    print(
+                        f"global_step={global_step}, episodic_return={item['episode']['r']}, curiosity_reward={np.mean(curiosity_rewards[step].cpu().numpy())}"
+                    )
+                    writer.add_scalar("charts/episodic_return", item["episode"]["r"], global_step)
+                    writer.add_scalar(
+                        "charts/episode_curiosity_reward",
+                        curiosity_rewards[step][idx],
+                        global_step,
+                    )
+                    writer.add_scalar("charts/episodic_length", item["episode"]["l"], global_step)
+                    break
+
+        curiosity_reward_per_env = np.array(
+            [discounted_reward.update(reward_per_step) for reward_per_step in curiosity_rewards.cpu().data.numpy().T]
+        )
+        mean, std, count = (
+            np.mean(curiosity_reward_per_env),
+            np.std(curiosity_reward_per_env),
+            len(curiosity_reward_per_env),
+        )
+        reward_rms.update_from_moments(mean, std**2, count)
+
+        curiosity_rewards /= np.sqrt(reward_rms.var)
+
+        # bootstrap reward if not done. reached the batch limit
+        with torch.no_grad():
+            last_value_ext, last_value_int = agent.get_value(next_obs.to(device))
+            last_value_ext, last_value_int = last_value_ext.reshape(1, -1), last_value_int.reshape(1, -1)
+            if args.gae:
+                ext_advantages = torch.zeros_like(rewards).to(device)
+                int_advantages = torch.zeros_like(curiosity_rewards).to(device)
+                ext_lastgaelam = 0
+                int_lastgaelam = 0
+                for t in reversed(range(args.num_steps)):
+                    if t == args.num_steps - 1:
+                        ext_nextnonterminal = 1.0 - next_done
+                        int_nextnonterminal = 1.0
+                        ext_nextvalues = last_value_ext
+                        int_nextvalues = last_value_int
+                    else:
+                        ext_nextnonterminal = 1.0 - dones[t + 1]
+                        int_nextnonterminal = 1.0
+                        ext_nextvalues = ext_values[t + 1]
+                        int_nextvalues = int_values[t + 1]
+                    ext_delta = rewards[t] + args.gamma * ext_nextvalues * ext_nextnonterminal - ext_values[t]
+                    int_delta = curiosity_rewards[t] + args.int_gamma * int_nextvalues * int_nextnonterminal - int_values[t]
+                    ext_advantages[t] = ext_lastgaelam = (
+                        ext_delta + args.gamma * args.gae_lambda * ext_nextnonterminal * ext_lastgaelam
+                    )
+                    int_advantages[t] = int_lastgaelam = (
+                        int_delta + args.int_gamma * args.gae_lambda * int_nextnonterminal * int_lastgaelam
+                    )
+                ext_returns = ext_advantages + ext_values
+                int_returns = int_advantages + int_values
+            else:
+                ext_returns = torch.zeros_like(rewards).to(device)
+                int_returns = torch.zeros_like(curiosity_rewards).to(device)
+                for t in reversed(range(args.num_steps)):
+                    if t == args.num_steps - 1:
+                        ext_nextnonterminal = 1.0 - next_done
+                        int_nextnonterminal = 1.0
+                        ext_next_return = last_value_ext
+                        int_next_return = last_value_int
+                    else:
+                        ext_nextnonterminal = 1.0 - dones[t + 1]
+                        int_nextnonterminal = 1.0
+                        ext_next_return = ext_returns[t + 1]
+                        int_next_return = int_returns[t + 1]
+                    ext_returns[t] = rewards[t] + args.gamma * ext_nextnonterminal * ext_next_return
+                    int_returns[t] = curiosity_rewards[t] + args.int_gamma * int_nextnonterminal * int_next_return
+                ext_advantages = ext_returns - ext_values
+                int_advantages = int_returns - int_values
+
+        # flatten the batch
+        b_obs = obs.reshape((-1,) + envs.single_observation_space.shape)
+        b_logprobs = logprobs.reshape(-1)
+        b_actions = actions.reshape(-1)
+        b_ext_advantages = ext_advantages.reshape(-1)
+        b_int_advantages = int_advantages.reshape(-1)
+        b_ext_returns = ext_returns.reshape(-1)
+        b_int_returns = int_returns.reshape(-1)
+        b_ext_values = ext_values.reshape(-1)
+
+        b_advantages = b_int_advantages * args.int_coef + b_ext_advantages * args.ext_coef
+
+        obs_rms.update(b_obs[:, 3, :, :].reshape(-1, 1, 84, 84).cpu().numpy())
+
+        # Optimizing the policy and value network
+        forward_mse = nn.MSELoss(reduction="none")
+        b_inds = np.arange(args.batch_size)
+
+        rnd_next_obs = (
+            (
+                (b_obs[:, 3, :, :].reshape(-1, 1, 84, 84) - torch.from_numpy(obs_rms.mean).to(device))
+                / torch.sqrt(torch.from_numpy(obs_rms.var).to(device))
+            ).clip(-5, 5)
+        ).float()
+
+        clipfracs = []
+        for epoch in range(args.update_epochs):
+            np.random.shuffle(b_inds)
+            for start in range(0, args.batch_size, args.minibatch_size):
+                end = start + args.minibatch_size
+                mb_inds = b_inds[start:end]
+
+                predict_next_state_feature, target_next_state_feature = rnd_model(rnd_next_obs[mb_inds])
+                forward_loss = forward_mse(predict_next_state_feature, target_next_state_feature.detach()).mean(-1)
+
+                mask = torch.rand(len(forward_loss)).to(device)
+                mask = (mask < args.update_proportion).type(torch.FloatTensor).to(device)
+                forward_loss = (forward_loss * mask).sum() / torch.max(mask.sum(), torch.Tensor([1]).to(device))
+
+                _, newlogprob, entropy, newvalue = agent.get_action_and_value(b_obs[mb_inds], b_actions.long()[mb_inds])
+                logratio = newlogprob - b_logprobs[mb_inds]
+                ratio = logratio.exp()
+
+                with torch.no_grad():
+                    # calculate approx_kl http://joschu.net/blog/kl-approx.html
+                    old_approx_kl = (-logratio).mean()
+                    approx_kl = ((ratio - 1) - logratio).mean()
+                    clipfracs += [((ratio - 1.0).abs() > args.clip_coef).float().mean().item()]
+
+                mb_advantages = b_advantages[mb_inds]
+                if args.norm_adv:
+                    mb_advantages = (mb_advantages - mb_advantages.mean()) / (mb_advantages.std() + 1e-8)
+
+                # Policy loss
+                pg_loss1 = -mb_advantages * ratio
+                pg_loss2 = -mb_advantages * torch.clamp(ratio, 1 - args.clip_coef, 1 + args.clip_coef)
+                pg_loss = torch.max(pg_loss1, pg_loss2).mean()
+
+                # Value loss
+                new_ext_values, new_int_values = newvalue
+                new_ext_values, new_int_values = new_ext_values.view(-1), new_int_values.view(-1)
+                if args.clip_vloss:
+                    ext_v_loss_unclipped = (new_ext_values - b_ext_returns[mb_inds]) ** 2
+                    ext_v_clipped = b_ext_values[mb_inds] + torch.clamp(
+                        new_ext_values - b_ext_values[mb_inds],
+                        -args.clip_coef,
+                        args.clip_coef,
+                    )
+                    ext_v_loss_clipped = (ext_v_clipped - b_ext_returns[mb_inds]) ** 2
+                    ext_v_loss_max = torch.max(ext_v_loss_unclipped, ext_v_loss_clipped)
+                    ext_v_loss = 0.5 * ext_v_loss_max.mean()
+                else:
+                    ext_v_loss = 0.5 * ((new_ext_values - b_ext_returns[mb_inds]) ** 2).mean()
+
+                int_v_loss = 0.5 * ((new_int_values - b_int_returns[mb_inds]) ** 2).mean()
+                v_loss = ext_v_loss + int_v_loss
+                entropy_loss = entropy.mean()
+                loss = pg_loss - args.ent_coef * entropy_loss + v_loss * args.vf_coef + forward_loss
+
+                optimizer.zero_grad()
+                loss.backward()
+                if args.max_grad_norm:
+                    nn.utils.clip_grad_norm_(
+                        list(agent.parameters()) + list(rnd_model.predictor.parameters()),
+                        args.max_grad_norm,
+                    )
+                optimizer.step()
+
+            if args.target_kl is not None:
+                if approx_kl > args.target_kl:
+                    break
+
+        # TRY NOT TO MODIFY: record rewards for plotting purposes
+        writer.add_scalar("charts/learning_rate", optimizer.param_groups[0]["lr"], global_step)
+        writer.add_scalar("losses/value_loss", v_loss.item(), global_step)
+        writer.add_scalar("losses/policy_loss", pg_loss.item(), global_step)
+        writer.add_scalar("losses/entropy", entropy_loss.item(), global_step)
+        writer.add_scalar("losses/old_approx_kl", old_approx_kl.item(), global_step)
+        writer.add_scalar("losses/fwd_loss", forward_loss.item(), global_step)
+        writer.add_scalar("losses/entropy", entropy.mean().item(), global_step)
+        writer.add_scalar("losses/approx_kl", approx_kl.item(), global_step)
+        writer.add_scalar("charts/SPS", int(global_step / (time.time() - start_time)), global_step)
+
+    envs.close()
+    writer.close()

--- a/docs/rl-algorithms/rnd.md
+++ b/docs/rl-algorithms/rnd.md
@@ -1,0 +1,18 @@
+# Random Network Distillation (RND)
+
+
+## Overview
+
+RND is an exploration bonus for RL methods that's easy to implement and enables significant progress in some hard exploration Atari games such as Montezuma's Revenge. We use [Proximal Policy Gradient](/rl-algorithms/ppo/#ppopy) as our RL method as used by original paper's [implementation](https://github.com/openai/random-network-distillation)
+
+
+Original paper: 
+
+* [Exploration by Random Network Distillation](https://arxiv.org/abs/1810.12894)
+
+Our single-file implementations of DQN:
+
+* [ppo_rnd.py](https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/ppo_rnd.py)
+    * For playing Atari games. It uses convolutional layers and common atari-based pre-processing techniques.
+    * Works with the Atari's pixel `Box` observation space of shape `(210, 160, 3)`
+    * Works with the `Discerete` action space


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in here-->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [x] New feature
- [ ] New algorithm
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/vwxyzjn/cleanrl/blob/master/CONTRIBUTING.md) guide (**required**).
- [ ] I have ensured `pre-commit run --all-files` passes (**required**).
- [ ] I have updated the documentation and previewed the changes via `mkdocs serve`.
- [ ] I have updated the tests accordingly (if applicable).

If you are adding new algorithms or your change could result in performance difference, you may need to (re-)run tracked experiments. See https://github.com/vwxyzjn/cleanrl/pull/137 as an example PR. 
- [ ] I have contacted [vwxyzjn](https://github.com/vwxyzjn) to obtain access to the [openrlbenchmark W&B team](https://wandb.ai/openrlbenchmark) (**required**).
- [ ] I have tracked applicable experiments in [openrlbenchmark/cleanrl](https://wandb.ai/openrlbenchmark/cleanrl) with `--capture-video` flag toggled on (**required**).
- [ ] I have added additional documentation and previewed the changes via `mkdocs serve`.
    - [ ] I have explained note-worthy implementation details.
    - [ ] I have explained the logged metrics.
    - [ ] I have added links to the original paper and related papers (if applicable).
    - [ ] I have added links to the PR related to the algorithm.
    - [ ] I have created a table comparing my results against those from reputable sources (i.e., the original paper or other reference implementation).
    - [ ] I have added the learning curves (in PNG format with `width=500` and `height=300`).
    - [ ] I have added links to the tracked experiments.
- [ ] I have updated the tests accordingly (if applicable).

