### PR TITLE
Leverage CI to speed up poetry lock

### DIFF
--- a/.github/workflows/poetry-lock-export.yaml
+++ b/.github/workflows/poetry-lock-export.yaml
@@ -1,0 +1,62 @@
+name: Poetry lock and export
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  create-macos-lock-file:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        python-version: [3.9]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Create virtualenv
+        run: |
+          which python
+          python -m venv venv
+          source venv/bin/activate
+          python -m pip install --constraint=.github/workflows/constraints.txt --upgrade pip
+          which python
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          export PATH="/Users/runner/.local/bin:$PATH"
+          poetry --version
+          poetry config virtualenvs.in-project true
+          poetry config virtualenvs.create false
+          poetry config virtualenvs.path venv
+          source venv/bin/activate
+          which python
+
+      - name: Run Poetry update
+        run: |
+          source venv/bin/activate
+          export PATH="/Users/runner/.local/bin:$PATH"
+          rm poetry.lock
+          poetry update isaacgym
+          poetry lock --no-update
+          poetry export -f requirements.txt --output requirements.txt
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: Update poetry.lock and requirements.txt
+          title: Update poetry.lock and requirements.txt
+          body: Update poetry.lock and requirements.txt
+          branch: poetry-lock-and-export


### PR DESCRIPTION
## Description
Sometimes `poetry add` or `poetry lock` results in a significant amount of lock time

<img width="750" alt="image" src="https://user-images.githubusercontent.com/5555347/179852646-5f3b6297-309d-4665-8dde-5108711695c3.png">
 
This PR adds a CI workflow to leverage the CI's fast network to speed up poetry lock. See https://github.com/john-sandall/poetry-speed-test on how this is done.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [x] New feature
- [ ] New algorithm
- [ ] Documentation
