### PR TITLE
Refactor dqn word choice

### DIFF
--- a/cleanrl/dqn.py
+++ b/cleanrl/dqn.py
@@ -156,8 +156,8 @@ if __name__ == "__main__":
         if random.random() < epsilon:
             actions = np.array([envs.single_action_space.sample() for _ in range(envs.num_envs)])
         else:
-            logits = q_network(torch.Tensor(obs).to(device))
-            actions = torch.argmax(logits, dim=1).cpu().numpy()
+            q_values = q_network(torch.Tensor(obs).to(device))
+            actions = torch.argmax(q_values, dim=1).cpu().numpy()
 
         # TRY NOT TO MODIFY: execute the game and log data.
         next_obs, rewards, dones, infos = envs.step(actions)

--- a/cleanrl/dqn_atari.py
+++ b/cleanrl/dqn_atari.py
@@ -178,8 +178,8 @@ if __name__ == "__main__":
         if random.random() < epsilon:
             actions = np.array([envs.single_action_space.sample() for _ in range(envs.num_envs)])
         else:
-            logits = q_network(torch.Tensor(obs).to(device))
-            actions = torch.argmax(logits, dim=1).cpu().numpy()
+            q_values = q_network(torch.Tensor(obs).to(device))
+            actions = torch.argmax(q_values, dim=1).cpu().numpy()
 
         # TRY NOT TO MODIFY: execute the game and log data.
         next_obs, rewards, dones, infos = envs.step(actions)

--- a/cleanrl/dqn_atari_jax.py
+++ b/cleanrl/dqn_atari_jax.py
@@ -212,7 +212,6 @@ if __name__ == "__main__":
         if random.random() < epsilon:
             actions = np.array([envs.single_action_space.sample() for _ in range(envs.num_envs)])
         else:
-            # obs = jax.device_put(obs)
             q_values = q_network.apply(q_state.params, obs)
             actions = q_values.argmax(axis=-1)
             actions = jax.device_get(actions)

--- a/cleanrl/dqn_atari_jax.py
+++ b/cleanrl/dqn_atari_jax.py
@@ -213,8 +213,8 @@ if __name__ == "__main__":
             actions = np.array([envs.single_action_space.sample() for _ in range(envs.num_envs)])
         else:
             # obs = jax.device_put(obs)
-            logits = q_network.apply(q_state.params, obs)
-            actions = logits.argmax(axis=-1)
+            q_values = q_network.apply(q_state.params, obs)
+            actions = q_values.argmax(axis=-1)
             actions = jax.device_get(actions)
 
         # TRY NOT TO MODIFY: execute the game and log data.

--- a/cleanrl/dqn_jax.py
+++ b/cleanrl/dqn_jax.py
@@ -184,8 +184,8 @@ if __name__ == "__main__":
         if random.random() < epsilon:
             actions = np.array([envs.single_action_space.sample() for _ in range(envs.num_envs)])
         else:
-            logits = q_network.apply(q_state.params, obs)
-            actions = logits.argmax(axis=-1)
+            q_values = q_network.apply(q_state.params, obs)
+            actions = q_values.argmax(axis=-1)
             actions = jax.device_get(actions)
 
         # TRY NOT TO MODIFY: execute the game and log data.


### PR DESCRIPTION
## Description
This PR fixes a confusing word choice in our DQN implementation. Previously we had

`logits = q_network.apply(q_state.params, obs)`

However, the word logits usually refer to "unnormalized probabilities" (see [What is the meaning of the word logits in TensorFlow?](https://stackoverflow.com/questions/41455101/what-is-the-meaning-of-the-word-logits-in-tensorflow)). A more correct word of choice here is `q_values = q_network.apply(q_state.params, obs)`.

Given this is a **non-performance-impacting** refactor, re-running the benchmark is not required.

CC @santiontanon

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [ ] New algorithm
- [x] Documentation


