### PR TITLE
Draft: DroQ and TD3+TQC jax implementation

### DIFF
--- a/cleanrl/td3_droq_continuous_action_jax.py
+++ b/cleanrl/td3_droq_continuous_action_jax.py
@@ -1,0 +1,322 @@
+# docs and experiment results can be found at https://docs.cleanrl.dev/rl-algorithms/td3/#td3_continuous_action_jaxpy
+import argparse
+import os
+import random
+import time
+from distutils.util import strtobool
+from typing import Sequence
+
+import flax
+import flax.linen as nn
+import gym
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+import pybullet_envs  # noqa
+from flax.training.train_state import TrainState
+from stable_baselines3.common.buffers import ReplayBuffer
+from torch.utils.tensorboard import SummaryWriter
+
+
+def parse_args():
+    # fmt: off
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
+        help="the name of this experiment")
+    parser.add_argument("--seed", type=int, default=1,
+        help="seed of the experiment")
+    parser.add_argument("--track", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="if toggled, this experiment will be tracked with Weights and Biases")
+    parser.add_argument("--wandb-project-name", type=str, default="cleanRL",
+        help="the wandb's project name")
+    parser.add_argument("--wandb-entity", type=str, default=None,
+        help="the entity (team) of wandb's project")
+    parser.add_argument("--capture-video", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="weather to capture videos of the agent performances (check out `videos` folder)")
+
+    # Algorithm specific arguments
+    parser.add_argument("--env-id", type=str, default="HalfCheetah-v2",
+        help="the id of the environment")
+    parser.add_argument("--total-timesteps", type=int, default=1000000,
+        help="total timesteps of the experiments")
+    parser.add_argument("--learning-rate", type=float, default=3e-4,
+        help="the learning rate of the optimizer")
+    parser.add_argument("--buffer-size", type=int, default=int(1e6),
+        help="the replay memory buffer size")
+    parser.add_argument("--gamma", type=float, default=0.99,
+        help="the discount factor gamma")
+    parser.add_argument("--tau", type=float, default=0.005,
+        help="target smoothing coefficient (default: 0.005)")
+    parser.add_argument("--policy-noise", type=float, default=0.2,
+        help="the scale of policy noise")
+    parser.add_argument("--batch-size", type=int, default=256,
+        help="the batch size of sample from the reply memory")
+    parser.add_argument("--exploration-noise", type=float, default=0.1,
+        help="the scale of exploration noise")
+    parser.add_argument("--learning-starts", type=int, default=25e3,
+        help="timestep to start learning")
+    parser.add_argument("--policy-frequency", type=int, default=2,
+        help="the frequency of training policy (delayed)")
+    parser.add_argument("--noise-clip", type=float, default=0.5,
+        help="noise clip parameter of the Target Policy Smoothing Regularization")
+    args = parser.parse_args()
+    # fmt: on
+    return args
+
+
+def make_env(env_id, seed, idx, capture_video, run_name):
+    def thunk():
+        env = gym.make(env_id)
+        env = gym.wrappers.RecordEpisodeStatistics(env)
+        if capture_video:
+            if idx == 0:
+                env = gym.wrappers.RecordVideo(env, f"videos/{run_name}")
+        env.seed(seed)
+        env.action_space.seed(seed)
+        env.observation_space.seed(seed)
+        return env
+
+    return thunk
+
+
+# ALGO LOGIC: initialize agent here:
+class QNetwork(nn.Module):
+    @nn.compact
+    def __call__(self, x: jnp.ndarray, a: jnp.ndarray):
+        x = jnp.concatenate([x, a], -1)
+        x = nn.Dense(256)(x)
+        x = nn.relu(x)
+        x = nn.Dense(256)(x)
+        x = nn.relu(x)
+        x = nn.Dense(1)(x)
+        return x
+
+
+class Actor(nn.Module):
+    action_dim: Sequence[int]
+    action_scale: Sequence[int]
+    action_bias: Sequence[int]
+
+    @nn.compact
+    def __call__(self, x):
+        x = nn.Dense(256)(x)
+        x = nn.relu(x)
+        x = nn.Dense(256)(x)
+        x = nn.relu(x)
+        x = nn.Dense(self.action_dim)(x)
+        x = nn.tanh(x)
+        x = x * self.action_scale + self.action_bias
+        return x
+
+
+class TrainState(TrainState):
+    target_params: flax.core.FrozenDict
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    run_name = f"{args.env_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    if args.track:
+        import wandb
+
+        wandb.init(
+            project=args.wandb_project_name,
+            entity=args.wandb_entity,
+            sync_tensorboard=True,
+            config=vars(args),
+            name=run_name,
+            monitor_gym=True,
+            save_code=True,
+        )
+    writer = SummaryWriter(f"runs/{run_name}")
+    writer.add_text(
+        "hyperparameters",
+        "|param|value|\n|-|-|\n%s" % ("\n".join([f"|{key}|{value}|" for key, value in vars(args).items()])),
+    )
+
+    # TRY NOT TO MODIFY: seeding
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    key = jax.random.PRNGKey(args.seed)
+    key, actor_key, qf1_key, qf2_key = jax.random.split(key, 4)
+
+    # env setup
+    envs = gym.vector.SyncVectorEnv([make_env(args.env_id, args.seed, 0, args.capture_video, run_name)])
+    assert isinstance(envs.single_action_space, gym.spaces.Box), "only continuous action space is supported"
+
+    max_action = float(envs.single_action_space.high[0])
+    envs.single_observation_space.dtype = np.float32
+    rb = ReplayBuffer(
+        args.buffer_size,
+        envs.single_observation_space,
+        envs.single_action_space,
+        device="cpu",
+        handle_timeout_termination=True,
+    )
+
+    # TRY NOT TO MODIFY: start the game
+    obs = envs.reset()
+    actor = Actor(
+        action_dim=np.prod(envs.single_action_space.shape),
+        action_scale=jnp.array((envs.action_space.high - envs.action_space.low) / 2.0),
+        action_bias=jnp.array((envs.action_space.high + envs.action_space.low) / 2.0),
+    )
+    actor_state = TrainState.create(
+        apply_fn=actor.apply,
+        params=actor.init(actor_key, obs),
+        target_params=actor.init(actor_key, obs),
+        tx=optax.adam(learning_rate=args.learning_rate),
+    )
+    qf = QNetwork()
+    qf1_state = TrainState.create(
+        apply_fn=qf.apply,
+        params=qf.init(qf1_key, obs, envs.action_space.sample()),
+        target_params=qf.init(qf1_key, obs, envs.action_space.sample()),
+        tx=optax.adam(learning_rate=args.learning_rate),
+    )
+    qf2_state = TrainState.create(
+        apply_fn=qf.apply,
+        params=qf.init(qf2_key, obs, envs.action_space.sample()),
+        target_params=qf.init(qf2_key, obs, envs.action_space.sample()),
+        tx=optax.adam(learning_rate=args.learning_rate),
+    )
+    actor.apply = jax.jit(actor.apply)
+    qf.apply = jax.jit(qf.apply)
+
+    @jax.jit
+    def update_critic(
+        actor_state: TrainState,
+        qf1_state: TrainState,
+        qf2_state: TrainState,
+        observations: np.ndarray,
+        actions: np.ndarray,
+        next_observations: np.ndarray,
+        rewards: np.ndarray,
+        dones: np.ndarray,
+        key: jnp.ndarray,
+    ):
+        # TODO Maybe pre-generate a lot of random keys
+        # also check https://jax.readthedocs.io/en/latest/jax.random.html
+        key, noise_key = jax.random.split(key, 2)
+        clipped_noise = jnp.clip(
+            (jax.random.normal(noise_key, actions[0].shape) * args.policy_noise),
+            -args.noise_clip,
+            args.noise_clip,
+        )
+        next_state_actions = jnp.clip(
+            actor.apply(actor_state.target_params, next_observations) + clipped_noise,
+            envs.single_action_space.low[0],
+            envs.single_action_space.high[0],
+        )
+        qf1_next_target = qf.apply(qf1_state.target_params, next_observations, next_state_actions).reshape(-1)
+        qf2_next_target = qf.apply(qf2_state.target_params, next_observations, next_state_actions).reshape(-1)
+        min_qf_next_target = jnp.minimum(qf1_next_target, qf2_next_target)
+        next_q_value = (rewards + (1 - dones) * args.gamma * (min_qf_next_target)).reshape(-1)
+
+        def mse_loss(params):
+            qf_a_values = qf.apply(params, observations, actions).squeeze()
+            return ((qf_a_values - next_q_value) ** 2).mean(), qf_a_values.mean()
+
+        (qf1_loss_value, qf1_a_values), grads1 = jax.value_and_grad(mse_loss, has_aux=True)(qf1_state.params)
+        (qf2_loss_value, qf2_a_values), grads2 = jax.value_and_grad(mse_loss, has_aux=True)(qf2_state.params)
+        qf1_state = qf1_state.apply_gradients(grads=grads1)
+        qf2_state = qf2_state.apply_gradients(grads=grads2)
+
+        return (qf1_state, qf2_state), (qf1_loss_value, qf2_loss_value), (qf1_a_values, qf2_a_values), key
+
+    @jax.jit
+    def update_actor(
+        actor_state: TrainState,
+        qf1_state: TrainState,
+        qf2_state: TrainState,
+        observations: np.ndarray,
+    ):
+        def actor_loss(params):
+            return -qf.apply(qf1_state.params, observations, actor.apply(params, observations)).mean()
+
+        actor_loss_value, grads = jax.value_and_grad(actor_loss)(actor_state.params)
+        actor_state = actor_state.apply_gradients(grads=grads)
+        actor_state = actor_state.replace(
+            target_params=optax.incremental_update(actor_state.params, actor_state.target_params, args.tau)
+        )
+
+        qf1_state = qf1_state.replace(
+            target_params=optax.incremental_update(qf1_state.params, qf1_state.target_params, args.tau)
+        )
+        qf2_state = qf2_state.replace(
+            target_params=optax.incremental_update(qf2_state.params, qf2_state.target_params, args.tau)
+        )
+        return actor_state, (qf1_state, qf2_state), actor_loss_value
+
+    start_time = time.time()
+    for global_step in range(args.total_timesteps):
+        # ALGO LOGIC: put action logic here
+        if global_step < args.learning_starts:
+            actions = np.array([envs.single_action_space.sample() for _ in range(envs.num_envs)])
+        else:
+            actions = actor.apply(actor_state.params, obs)
+            actions = np.array(
+                [
+                    (
+                        jax.device_get(actions)[0]
+                        + np.random.normal(0, max_action * args.exploration_noise, size=envs.single_action_space.shape[0])
+                    ).clip(envs.single_action_space.low, envs.single_action_space.high)
+                ]
+            )
+
+        # TRY NOT TO MODIFY: execute the game and log data.
+        next_obs, rewards, dones, infos = envs.step(actions)
+
+        # TRY NOT TO MODIFY: record rewards for plotting purposes
+        for info in infos:
+            if "episode" in info.keys():
+                print(f"global_step={global_step}, episodic_return={info['episode']['r']}")
+                writer.add_scalar("charts/episodic_return", info["episode"]["r"], global_step)
+                writer.add_scalar("charts/episodic_length", info["episode"]["l"], global_step)
+                break
+
+        # TRY NOT TO MODIFY: save data to replay buffer; handle `terminal_observation`
+        real_next_obs = next_obs.copy()
+        for idx, d in enumerate(dones):
+            if d:
+                real_next_obs[idx] = infos[idx]["terminal_observation"]
+        rb.add(obs, real_next_obs, actions, rewards, dones, infos)
+
+        # TRY NOT TO MODIFY: CRUCIAL step easy to overlook
+        obs = next_obs
+
+        # ALGO LOGIC: training.
+        if global_step > args.learning_starts:
+            data = rb.sample(args.batch_size)
+
+            (qf1_state, qf2_state), (qf1_loss_value, qf2_loss_value), (qf1_a_values, qf2_a_values), key = update_critic(
+                actor_state,
+                qf1_state,
+                qf2_state,
+                data.observations.numpy(),
+                data.actions.numpy(),
+                data.next_observations.numpy(),
+                data.rewards.flatten().numpy(),
+                data.dones.flatten().numpy(),
+                key,
+            )
+
+            if global_step % args.policy_frequency == 0:
+                actor_state, (qf1_state, qf2_state), actor_loss_value = update_actor(
+                    actor_state,
+                    qf1_state,
+                    qf2_state,
+                    data.observations.numpy(),
+                )
+            if global_step % 100 == 0:
+                writer.add_scalar("losses/qf1_loss", qf1_loss_value.item(), global_step)
+                writer.add_scalar("losses/qf2_loss", qf2_loss_value.item(), global_step)
+                writer.add_scalar("losses/qf1_values", qf1_a_values.item(), global_step)
+                writer.add_scalar("losses/qf2_values", qf2_a_values.item(), global_step)
+                writer.add_scalar("losses/actor_loss", actor_loss_value.item(), global_step)
+                print("SPS:", int(global_step / (time.time() - start_time)))
+                writer.add_scalar("charts/SPS", int(global_step / (time.time() - start_time)), global_step)
+
+    envs.close()
+    writer.close()

--- a/cleanrl/td3_droq_continuous_action_jax.py
+++ b/cleanrl/td3_droq_continuous_action_jax.py
@@ -343,20 +343,6 @@ def main():
             )
         )
 
-        # qf1_state = qf1_state.replace(
-        #     target_params=optax.incremental_update(
-        #         qf1_state.params, qf1_state.target_params, args.tau
-        #     )
-        # )
-        # qf2_state = qf2_state.replace(
-        #     target_params=optax.incremental_update(
-        #         qf2_state.params, qf2_state.target_params, args.tau
-        #     )
-        # )
-        return actor_state, (qf1_state, qf2_state), actor_loss_value, key
-
-    @jax.jit
-    def update_q_target_networks(qf1_state, qf2_state):
         qf1_state = qf1_state.replace(
             target_params=optax.incremental_update(
                 qf1_state.params, qf1_state.target_params, args.tau
@@ -367,7 +353,7 @@ def main():
                 qf2_state.params, qf2_state.target_params, args.tau
             )
         )
-        return qf1_state, qf2_state
+        return actor_state, (qf1_state, qf2_state), actor_loss_value, key
 
     start_time = time.time()
     n_updates = 0
@@ -446,9 +432,6 @@ def main():
                     data.dones.flatten().numpy(),
                     key,
                 )
-
-                # TODO: check if we need to update actor target too
-                qf1_state, qf2_state = update_q_target_networks(qf1_state, qf2_state)
 
                 if n_updates % args.policy_frequency == 0:
                     (

--- a/cleanrl/td3_droq_continuous_action_jax.py
+++ b/cleanrl/td3_droq_continuous_action_jax.py
@@ -369,54 +369,6 @@ def main():
         )
         return qf1_state, qf2_state
 
-    @jax.jit
-    def train(qf1_state, qf2_state, actor_state, key, n_updates):
-        for _ in range(args.gradient_steps):
-            n_updates += 1
-            data = rb.sample(args.batch_size)
-
-            (
-                (qf1_state, qf2_state),
-                (qf1_loss_value, qf2_loss_value),
-                (qf1_a_values, qf2_a_values),
-                key,
-            ) = update_critic(
-                actor_state,
-                qf1_state,
-                qf2_state,
-                data.observations.numpy(),
-                data.actions.numpy(),
-                data.next_observations.numpy(),
-                data.rewards.flatten().numpy(),
-                data.dones.flatten().numpy(),
-                key,
-            )
-
-            # TODO: check if we need to update actor target too
-            qf1_state, qf2_state = update_q_target_networks(qf1_state, qf2_state)
-
-        (
-            actor_state,
-            (qf1_state, qf2_state),
-            actor_loss_value,
-            key,
-        ) = update_actor(
-            actor_state,
-            qf1_state,
-            qf2_state,
-            data.observations.numpy(),
-            key,
-        )
-        return (
-            n_updates,
-            (qf1_state, qf2_state),
-            actor_state,
-            key,
-            (qf1_loss_value, qf2_loss_value),
-            actor_loss_value,
-            (qf1_a_values, qf2_a_values),
-        )
-
     start_time = time.time()
     n_updates = 0
     for global_step in tqdm(range(args.total_timesteps)):
@@ -474,18 +426,45 @@ def main():
 
         # ALGO LOGIC: training.
         if global_step > args.learning_starts:
-            (
-                n_updates,
-                (qf1_state, qf2_state),
-                actor_state,
-                key,
-                (qf1_loss_value, qf2_loss_value),
-                actor_loss_value,
-                (qf1_a_values, qf2_a_values),
-            ) = train(qf1_state, qf2_state, actor_state, key, n_updates)
+            for _ in range(args.gradient_steps):
+                n_updates += 1
+                data = rb.sample(args.batch_size)
+
+                (
+                    (qf1_state, qf2_state),
+                    (qf1_loss_value, qf2_loss_value),
+                    (qf1_a_values, qf2_a_values),
+                    key,
+                ) = update_critic(
+                    actor_state,
+                    qf1_state,
+                    qf2_state,
+                    data.observations.numpy(),
+                    data.actions.numpy(),
+                    data.next_observations.numpy(),
+                    data.rewards.flatten().numpy(),
+                    data.dones.flatten().numpy(),
+                    key,
+                )
+
+                # TODO: check if we need to update actor target too
+                qf1_state, qf2_state = update_q_target_networks(qf1_state, qf2_state)
+
+                if n_updates % args.policy_frequency == 0:
+                    (
+                        actor_state,
+                        (qf1_state, qf2_state),
+                        actor_loss_value,
+                        key,
+                    ) = update_actor(
+                        actor_state,
+                        qf1_state,
+                        qf2_state,
+                        data.observations.numpy(),
+                        key,
+                    )
 
             fps = int(global_step / (time.time() - start_time))
-
             if args.eval_freq > 0 and global_step % args.eval_freq == 0:
                 mean_reward, std_reward = evaluate_policy(eval_envs, actor, actor_state)
                 print(

--- a/cleanrl/td3_droq_continuous_action_jax.py
+++ b/cleanrl/td3_droq_continuous_action_jax.py
@@ -17,6 +17,7 @@ import pybullet_envs  # noqa
 from flax.training.train_state import TrainState
 from stable_baselines3.common.buffers import ReplayBuffer
 from torch.utils.tensorboard import SummaryWriter
+from stable_baselines3.common.vec_env import DummyVecEnv
 
 
 def parse_args():
@@ -38,9 +39,9 @@ def parse_args():
     # Algorithm specific arguments
     parser.add_argument("--env-id", type=str, default="HalfCheetah-v2",
         help="the id of the environment")
-    parser.add_argument("--total-timesteps", type=int, default=1000000,
+    parser.add_argument("-n", "--total-timesteps", type=int, default=1000000,
         help="total timesteps of the experiments")
-    parser.add_argument("--learning-rate", type=float, default=3e-4,
+    parser.add_argument("-lr", "--learning-rate", type=float, default=3e-4,
         help="the learning rate of the optimizer")
     parser.add_argument("--buffer-size", type=int, default=int(1e6),
         help="the replay memory buffer size")
@@ -54,8 +55,10 @@ def parse_args():
         help="the batch size of sample from the reply memory")
     parser.add_argument("--exploration-noise", type=float, default=0.1,
         help="the scale of exploration noise")
-    parser.add_argument("--learning-starts", type=int, default=25e3,
+    parser.add_argument("--learning-starts", type=int, default=1000,
         help="timestep to start learning")
+    parser.add_argument("--gradient-steps", type=int, default=1,
+        help="Number of gradient steps to perform after each rollout")    
     parser.add_argument("--policy-frequency", type=int, default=2,
         help="the frequency of training policy (delayed)")
     parser.add_argument("--noise-clip", type=float, default=0.5,
@@ -95,8 +98,8 @@ class QNetwork(nn.Module):
 
 class Actor(nn.Module):
     action_dim: Sequence[int]
-    action_scale: Sequence[int]
-    action_bias: Sequence[int]
+    action_scale: float
+    action_bias: float
 
     @nn.compact
     def __call__(self, x):
@@ -110,11 +113,11 @@ class Actor(nn.Module):
         return x
 
 
-class TrainState(TrainState):
+class RLTrainState(TrainState):
     target_params: flax.core.FrozenDict
 
 
-if __name__ == "__main__":
+def main():
     args = parse_args()
     run_name = f"{args.env_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
     if args.track:
@@ -132,7 +135,8 @@ if __name__ == "__main__":
     writer = SummaryWriter(f"runs/{run_name}")
     writer.add_text(
         "hyperparameters",
-        "|param|value|\n|-|-|\n%s" % ("\n".join([f"|{key}|{value}|" for key, value in vars(args).items()])),
+        "|param|value|\n|-|-|\n%s"
+        % ("\n".join([f"|{key}|{value}|" for key, value in vars(args).items()])),
     )
 
     # TRY NOT TO MODIFY: seeding
@@ -142,15 +146,21 @@ if __name__ == "__main__":
     key, actor_key, qf1_key, qf2_key = jax.random.split(key, 4)
 
     # env setup
-    envs = gym.vector.SyncVectorEnv([make_env(args.env_id, args.seed, 0, args.capture_video, run_name)])
-    assert isinstance(envs.single_action_space, gym.spaces.Box), "only continuous action space is supported"
+    envs = DummyVecEnv(
+        [make_env(args.env_id, args.seed, 0, args.capture_video, run_name)]
+    )
+    assert isinstance(
+        envs.action_space, gym.spaces.Box
+    ), "only continuous action space is supported"
 
-    max_action = float(envs.single_action_space.high[0])
-    envs.single_observation_space.dtype = np.float32
+    # Assume that all dimensions share the same bound
+    min_action = float(envs.action_space.low[0])
+    max_action = float(envs.action_space.high[0])
+    envs.observation_space.dtype = np.float32
     rb = ReplayBuffer(
         args.buffer_size,
-        envs.single_observation_space,
-        envs.single_action_space,
+        envs.observation_space,
+        envs.action_space,
         device="cpu",
         handle_timeout_termination=True,
     )
@@ -158,27 +168,27 @@ if __name__ == "__main__":
     # TRY NOT TO MODIFY: start the game
     obs = envs.reset()
     actor = Actor(
-        action_dim=np.prod(envs.single_action_space.shape),
-        action_scale=jnp.array((envs.action_space.high - envs.action_space.low) / 2.0),
-        action_bias=jnp.array((envs.action_space.high + envs.action_space.low) / 2.0),
+        action_dim=np.prod(envs.action_space.shape),
+        action_scale=(max_action - min_action) / 2.0,
+        action_bias=(max_action + min_action) / 2.0,
     )
-    actor_state = TrainState.create(
+    actor_state = RLTrainState.create(
         apply_fn=actor.apply,
         params=actor.init(actor_key, obs),
         target_params=actor.init(actor_key, obs),
         tx=optax.adam(learning_rate=args.learning_rate),
     )
     qf = QNetwork()
-    qf1_state = TrainState.create(
+    qf1_state = RLTrainState.create(
         apply_fn=qf.apply,
-        params=qf.init(qf1_key, obs, envs.action_space.sample()),
-        target_params=qf.init(qf1_key, obs, envs.action_space.sample()),
+        params=qf.init(qf1_key, obs, jnp.array([envs.action_space.sample()])),
+        target_params=qf.init(qf1_key, obs, jnp.array([envs.action_space.sample()])),
         tx=optax.adam(learning_rate=args.learning_rate),
     )
-    qf2_state = TrainState.create(
+    qf2_state = RLTrainState.create(
         apply_fn=qf.apply,
-        params=qf.init(qf2_key, obs, envs.action_space.sample()),
-        target_params=qf.init(qf2_key, obs, envs.action_space.sample()),
+        params=qf.init(qf2_key, obs, jnp.array([envs.action_space.sample()])),
+        target_params=qf.init(qf2_key, obs, jnp.array([envs.action_space.sample()])),
         tx=optax.adam(learning_rate=args.learning_rate),
     )
     actor.apply = jax.jit(actor.apply)
@@ -186,9 +196,9 @@ if __name__ == "__main__":
 
     @jax.jit
     def update_critic(
-        actor_state: TrainState,
-        qf1_state: TrainState,
-        qf2_state: TrainState,
+        actor_state: RLTrainState,
+        qf1_state: RLTrainState,
+        qf2_state: RLTrainState,
         observations: np.ndarray,
         actions: np.ndarray,
         next_observations: np.ndarray,
@@ -206,62 +216,92 @@ if __name__ == "__main__":
         )
         next_state_actions = jnp.clip(
             actor.apply(actor_state.target_params, next_observations) + clipped_noise,
-            envs.single_action_space.low[0],
-            envs.single_action_space.high[0],
+            envs.action_space.low[0],
+            envs.action_space.high[0],
         )
-        qf1_next_target = qf.apply(qf1_state.target_params, next_observations, next_state_actions).reshape(-1)
-        qf2_next_target = qf.apply(qf2_state.target_params, next_observations, next_state_actions).reshape(-1)
+        qf1_next_target = qf.apply(
+            qf1_state.target_params, next_observations, next_state_actions
+        ).reshape(-1)
+        qf2_next_target = qf.apply(
+            qf2_state.target_params, next_observations, next_state_actions
+        ).reshape(-1)
         min_qf_next_target = jnp.minimum(qf1_next_target, qf2_next_target)
-        next_q_value = (rewards + (1 - dones) * args.gamma * (min_qf_next_target)).reshape(-1)
+        next_q_value = (
+            rewards + (1 - dones) * args.gamma * (min_qf_next_target)
+        ).reshape(-1)
 
         def mse_loss(params):
             qf_a_values = qf.apply(params, observations, actions).squeeze()
             return ((qf_a_values - next_q_value) ** 2).mean(), qf_a_values.mean()
 
-        (qf1_loss_value, qf1_a_values), grads1 = jax.value_and_grad(mse_loss, has_aux=True)(qf1_state.params)
-        (qf2_loss_value, qf2_a_values), grads2 = jax.value_and_grad(mse_loss, has_aux=True)(qf2_state.params)
+        (qf1_loss_value, qf1_a_values), grads1 = jax.value_and_grad(
+            mse_loss, has_aux=True
+        )(qf1_state.params)
+        (qf2_loss_value, qf2_a_values), grads2 = jax.value_and_grad(
+            mse_loss, has_aux=True
+        )(qf2_state.params)
         qf1_state = qf1_state.apply_gradients(grads=grads1)
         qf2_state = qf2_state.apply_gradients(grads=grads2)
 
-        return (qf1_state, qf2_state), (qf1_loss_value, qf2_loss_value), (qf1_a_values, qf2_a_values), key
+        return (
+            (qf1_state, qf2_state),
+            (qf1_loss_value, qf2_loss_value),
+            (qf1_a_values, qf2_a_values),
+            key,
+        )
 
     @jax.jit
     def update_actor(
-        actor_state: TrainState,
-        qf1_state: TrainState,
-        qf2_state: TrainState,
+        actor_state: RLTrainState,
+        qf1_state: RLTrainState,
+        qf2_state: RLTrainState,
         observations: np.ndarray,
     ):
         def actor_loss(params):
-            return -qf.apply(qf1_state.params, observations, actor.apply(params, observations)).mean()
+            return -qf.apply(
+                qf1_state.params, observations, actor.apply(params, observations)
+            ).mean()
 
         actor_loss_value, grads = jax.value_and_grad(actor_loss)(actor_state.params)
         actor_state = actor_state.apply_gradients(grads=grads)
         actor_state = actor_state.replace(
-            target_params=optax.incremental_update(actor_state.params, actor_state.target_params, args.tau)
+            target_params=optax.incremental_update(
+                actor_state.params, actor_state.target_params, args.tau
+            )
         )
 
         qf1_state = qf1_state.replace(
-            target_params=optax.incremental_update(qf1_state.params, qf1_state.target_params, args.tau)
+            target_params=optax.incremental_update(
+                qf1_state.params, qf1_state.target_params, args.tau
+            )
         )
         qf2_state = qf2_state.replace(
-            target_params=optax.incremental_update(qf2_state.params, qf2_state.target_params, args.tau)
+            target_params=optax.incremental_update(
+                qf2_state.params, qf2_state.target_params, args.tau
+            )
         )
         return actor_state, (qf1_state, qf2_state), actor_loss_value
 
     start_time = time.time()
+    n_updates = 0
     for global_step in range(args.total_timesteps):
         # ALGO LOGIC: put action logic here
         if global_step < args.learning_starts:
-            actions = np.array([envs.single_action_space.sample() for _ in range(envs.num_envs)])
+            actions = np.array(
+                [envs.action_space.sample() for _ in range(envs.num_envs)]
+            )
         else:
             actions = actor.apply(actor_state.params, obs)
             actions = np.array(
                 [
                     (
                         jax.device_get(actions)[0]
-                        + np.random.normal(0, max_action * args.exploration_noise, size=envs.single_action_space.shape[0])
-                    ).clip(envs.single_action_space.low, envs.single_action_space.high)
+                        + np.random.normal(
+                            0,
+                            max_action * args.exploration_noise,
+                            size=envs.action_space.shape[0],
+                        )
+                    ).clip(envs.action_space.low, envs.action_space.high)
                 ]
             )
 
@@ -271,16 +311,26 @@ if __name__ == "__main__":
         # TRY NOT TO MODIFY: record rewards for plotting purposes
         for info in infos:
             if "episode" in info.keys():
-                print(f"global_step={global_step}, episodic_return={info['episode']['r']}")
-                writer.add_scalar("charts/episodic_return", info["episode"]["r"], global_step)
-                writer.add_scalar("charts/episodic_length", info["episode"]["l"], global_step)
+                print(
+                    f"global_step={global_step + 1}, episodic_return={info['episode']['r']:.2f}"
+                )
+                writer.add_scalar(
+                    "charts/episodic_return", info["episode"]["r"], global_step
+                )
+                writer.add_scalar(
+                    "charts/episodic_length", info["episode"]["l"], global_step
+                )
                 break
 
         # TRY NOT TO MODIFY: save data to replay buffer; handle `terminal_observation`
         real_next_obs = next_obs.copy()
-        for idx, d in enumerate(dones):
-            if d:
+        for idx, done in enumerate(dones):
+            if done:
                 real_next_obs[idx] = infos[idx]["terminal_observation"]
+            # Timeout handling done inside the replay buffer
+            # if infos[idx].get("TimeLimit.truncated", False) == True:
+            #     real_dones[idx] = False
+
         rb.add(obs, real_next_obs, actions, rewards, dones, infos)
 
         # TRY NOT TO MODIFY: CRUCIAL step easy to overlook
@@ -288,35 +338,60 @@ if __name__ == "__main__":
 
         # ALGO LOGIC: training.
         if global_step > args.learning_starts:
-            data = rb.sample(args.batch_size)
+            for _ in range(args.gradient_steps):
+                n_updates += 1
+                data = rb.sample(args.batch_size)
 
-            (qf1_state, qf2_state), (qf1_loss_value, qf2_loss_value), (qf1_a_values, qf2_a_values), key = update_critic(
-                actor_state,
-                qf1_state,
-                qf2_state,
-                data.observations.numpy(),
-                data.actions.numpy(),
-                data.next_observations.numpy(),
-                data.rewards.flatten().numpy(),
-                data.dones.flatten().numpy(),
-                key,
-            )
-
-            if global_step % args.policy_frequency == 0:
-                actor_state, (qf1_state, qf2_state), actor_loss_value = update_actor(
+                (
+                    (qf1_state, qf2_state),
+                    (qf1_loss_value, qf2_loss_value),
+                    (qf1_a_values, qf2_a_values),
+                    key,
+                ) = update_critic(
                     actor_state,
                     qf1_state,
                     qf2_state,
                     data.observations.numpy(),
+                    data.actions.numpy(),
+                    data.next_observations.numpy(),
+                    data.rewards.flatten().numpy(),
+                    data.dones.flatten().numpy(),
+                    key,
                 )
+
+                if n_updates % args.policy_frequency == 0:
+                    (
+                        actor_state,
+                        (qf1_state, qf2_state),
+                        actor_loss_value,
+                    ) = update_actor(
+                        actor_state,
+                        qf1_state,
+                        qf2_state,
+                        data.observations.numpy(),
+                    )
             if global_step % 100 == 0:
                 writer.add_scalar("losses/qf1_loss", qf1_loss_value.item(), global_step)
                 writer.add_scalar("losses/qf2_loss", qf2_loss_value.item(), global_step)
                 writer.add_scalar("losses/qf1_values", qf1_a_values.item(), global_step)
                 writer.add_scalar("losses/qf2_values", qf2_a_values.item(), global_step)
-                writer.add_scalar("losses/actor_loss", actor_loss_value.item(), global_step)
-                print("SPS:", int(global_step / (time.time() - start_time)))
-                writer.add_scalar("charts/SPS", int(global_step / (time.time() - start_time)), global_step)
+                writer.add_scalar(
+                    "losses/actor_loss", actor_loss_value.item(), global_step
+                )
+                print("FPS:", int(global_step / (time.time() - start_time)))
+                writer.add_scalar(
+                    "charts/SPS",
+                    int(global_step / (time.time() - start_time)),
+                    global_step,
+                )
 
     envs.close()
     writer.close()
+
+
+if __name__ == "__main__":
+
+    try:
+        main()
+    except KeyboardInterrupt:
+        pass

--- a/cleanrl/td3_droq_continuous_action_jax.py
+++ b/cleanrl/td3_droq_continuous_action_jax.py
@@ -373,8 +373,8 @@ def main():
     def train(qf1_state, qf2_state, actor_state, key, n_updates):
         for _ in range(args.gradient_steps):
             n_updates += 1
+            # TODO: replace with jitable replay buffer, currently buggy (same samples are returned)
             data = rb.sample(args.batch_size)
-
             (
                 (qf1_state, qf2_state),
                 (qf1_loss_value, qf2_loss_value),
@@ -407,6 +407,54 @@ def main():
             data.observations.numpy(),
             key,
         )
+        return (
+            n_updates,
+            (qf1_state, qf2_state),
+            actor_state,
+            key,
+            (qf1_loss_value, qf2_loss_value),
+            actor_loss_value,
+            (qf1_a_values, qf2_a_values),
+        )
+
+    def train_no_jit(qf1_state, qf2_state, actor_state, key, n_updates):
+        actor_loss_value = 0.0
+        for _ in range(args.gradient_steps):
+            n_updates += 1
+            data = rb.sample(args.batch_size)
+
+            (
+                (qf1_state, qf2_state),
+                (qf1_loss_value, qf2_loss_value),
+                (qf1_a_values, qf2_a_values),
+                key,
+            ) = update_critic(
+                actor_state,
+                qf1_state,
+                qf2_state,
+                data.observations.numpy(),
+                data.actions.numpy(),
+                data.next_observations.numpy(),
+                data.rewards.flatten().numpy(),
+                data.dones.flatten().numpy(),
+                key,
+            )
+
+            # TODO: check if we need to update actor target too
+            qf1_state, qf2_state = update_q_target_networks(qf1_state, qf2_state)
+            if n_updates % args.policy_frequency == 0:
+                (
+                    actor_state,
+                    (qf1_state, qf2_state),
+                    actor_loss_value,
+                    key,
+                ) = update_actor(
+                    actor_state,
+                    qf1_state,
+                    qf2_state,
+                    data.observations.numpy(),
+                    key,
+                )
         return (
             n_updates,
             (qf1_state, qf2_state),
@@ -474,6 +522,9 @@ def main():
 
         # ALGO LOGIC: training.
         if global_step > args.learning_starts:
+            # TODO: fix when train_freq > 1
+            train_fn = train if args.policy_frequency == args.gradient_steps else train_no_jit
+
             (
                 n_updates,
                 (qf1_state, qf2_state),
@@ -482,7 +533,7 @@ def main():
                 (qf1_loss_value, qf2_loss_value),
                 actor_loss_value,
                 (qf1_a_values, qf2_a_values),
-            ) = train(qf1_state, qf2_state, actor_state, key, n_updates)
+            ) = train_fn(qf1_state, qf2_state, actor_state, key, n_updates)
 
             fps = int(global_step / (time.time() - start_time))
 

--- a/cleanrl/tqc_td3_jax.py
+++ b/cleanrl/tqc_td3_jax.py
@@ -1,0 +1,525 @@
+# docs and experiment results can be found at https://docs.cleanrl.dev/rl-algorithms/td3/#td3_continuous_action_jaxpy
+import argparse
+import os
+import random
+import time
+from distutils.util import strtobool
+from typing import Optional, Sequence
+
+import flax
+import flax.linen as nn
+import gym
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+import pybullet_envs  # noqa
+from flax.training.train_state import TrainState
+from stable_baselines3.common.buffers import ReplayBuffer
+from stable_baselines3.common.vec_env import DummyVecEnv
+from torch.utils.tensorboard import SummaryWriter
+from tqdm.rich import tqdm
+
+
+def parse_args():
+    # fmt: off
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
+        help="the name of this experiment")
+    parser.add_argument("--seed", type=int, default=1,
+        help="seed of the experiment")
+    parser.add_argument("--track", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="if toggled, this experiment will be tracked with Weights and Biases")
+    parser.add_argument("--wandb-project-name", type=str, default="cleanRL",
+        help="the wandb's project name")
+    parser.add_argument("--wandb-entity", type=str, default=None,
+        help="the entity (team) of wandb's project")
+    parser.add_argument("--capture-video", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="weather to capture videos of the agent performances (check out `videos` folder)")
+
+    # Algorithm specific arguments
+    parser.add_argument("--env-id", type=str, default="HalfCheetah-v2",
+        help="the id of the environment")
+    parser.add_argument("-n", "--total-timesteps", type=int, default=1000000,
+        help="total timesteps of the experiments")
+    parser.add_argument("-lr", "--learning-rate", type=float, default=3e-4,
+        help="the learning rate of the optimizer")
+    parser.add_argument("--buffer-size", type=int, default=int(1e6),
+        help="the replay memory buffer size")
+    parser.add_argument("--gamma", type=float, default=0.99,
+        help="the discount factor gamma")
+    parser.add_argument("--tau", type=float, default=0.005,
+        help="target smoothing coefficient (default: 0.005)")
+    parser.add_argument("--policy-noise", type=float, default=0.2,
+        help="the scale of policy noise")
+    parser.add_argument("--batch-size", type=int, default=256,
+        help="the batch size of sample from the reply memory")
+    parser.add_argument("--exploration-noise", type=float, default=0.1,
+        help="the scale of exploration noise")
+    parser.add_argument("--learning-starts", type=int, default=1000,
+        help="timestep to start learning")
+    parser.add_argument("--gradient-steps", type=int, default=1,
+        help="Number of gradient steps to perform after each rollout")
+    # Argument for dropout rate
+    parser.add_argument("--dropout-rate", type=float, default=0.0)
+    # Argument for layer normalization
+    parser.add_argument("--layer-norm", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True)
+    parser.add_argument("--policy-frequency", type=int, default=2,
+        help="the frequency of training policy (delayed)")
+    parser.add_argument("--eval-freq", type=int, default=-1)
+    parser.add_argument("--n-eval-envs", type=int, default=1)
+    parser.add_argument("--n-eval-episodes", type=int, default=10)
+    parser.add_argument("--verbose", type=int, default=1)
+
+    parser.add_argument("--noise-clip", type=float, default=0.5,
+        help="noise clip parameter of the Target Policy Smoothing Regularization")
+    args = parser.parse_args()
+    # fmt: on
+    return args
+
+
+def make_env(env_id, seed, idx, capture_video=False, run_name=""):
+    def thunk():
+        env = gym.make(env_id)
+        env = gym.wrappers.RecordEpisodeStatistics(env)
+        if capture_video:
+            if idx == 0:
+                env = gym.wrappers.RecordVideo(env, f"videos/{run_name}")
+        env.seed(seed)
+        env.action_space.seed(seed)
+        env.observation_space.seed(seed)
+        return env
+
+    return thunk
+
+
+# ALGO LOGIC: initialize agent here:
+class QNetwork(nn.Module):
+    use_layer_norm: bool = False
+    dropout_rate: Optional[float] = None
+    n_quantiles: int = 25
+
+    @nn.compact
+    def __call__(self, x: jnp.ndarray, a: jnp.ndarray, training: bool = False):
+        x = jnp.concatenate([x, a], -1)
+        x = nn.Dense(256)(x)
+        if self.dropout_rate is not None and self.dropout_rate > 0:
+            x = nn.Dropout(rate=self.dropout_rate)(x, deterministic=False)
+        if self.use_layer_norm:
+            x = nn.LayerNorm()(x)
+        x = nn.relu(x)
+        x = nn.Dense(256)(x)
+        if self.dropout_rate is not None and self.dropout_rate > 0:
+            x = nn.Dropout(rate=self.dropout_rate)(x, deterministic=False)
+        if self.use_layer_norm:
+            x = nn.LayerNorm()(x)
+        x = nn.relu(x)
+        x = nn.Dense(self.n_quantiles)(x)
+        return x
+
+
+class Actor(nn.Module):
+    action_dim: Sequence[int]
+    action_scale: float
+    action_bias: float
+
+    @nn.compact
+    def __call__(self, x):
+        x = nn.Dense(256)(x)
+        x = nn.relu(x)
+        x = nn.Dense(256)(x)
+        x = nn.relu(x)
+        x = nn.Dense(self.action_dim)(x)
+        x = nn.tanh(x)
+        x = x * self.action_scale + self.action_bias
+        return x
+
+
+class RLTrainState(TrainState):
+    target_params: flax.core.FrozenDict
+
+
+def evaluate_policy(eval_env, actor, actor_state, n_eval_episodes: int = 10):
+    eval_episode_rewards = []
+    for _ in range(n_eval_episodes):
+        obs = eval_env.reset()
+        done = False
+        episode_reward = 0
+        while not done:
+            action = np.array(actor.apply(actor_state.params, obs))
+            obs, reward, done, _ = eval_env.step(action)
+            episode_reward += reward
+        eval_episode_rewards.append(episode_reward)
+    return np.mean(eval_episode_rewards), np.std(eval_episode_rewards)
+
+
+def main():
+    args = parse_args()
+    run_name = f"{args.env_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    if args.track:
+        import wandb
+
+        wandb.init(
+            project=args.wandb_project_name,
+            entity=args.wandb_entity,
+            sync_tensorboard=True,
+            config=vars(args),
+            name=run_name,
+            monitor_gym=True,
+            save_code=True,
+        )
+    writer = SummaryWriter(f"runs/{run_name}")
+    writer.add_text(
+        "hyperparameters",
+        "|param|value|\n|-|-|\n%s"
+        % ("\n".join([f"|{key}|{value}|" for key, value in vars(args).items()])),
+    )
+
+    # TRY NOT TO MODIFY: seeding
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    key = jax.random.PRNGKey(args.seed)
+    key, actor_key, qf1_key, qf2_key = jax.random.split(key, 4)
+    key, dropout_key1, dropout_key2 = jax.random.split(key, 3)
+
+    # env setup
+    envs = DummyVecEnv(
+        [make_env(args.env_id, args.seed, 0, args.capture_video, run_name)]
+    )
+    eval_envs = DummyVecEnv([make_env(args.env_id, args.seed + 1, 0)])
+
+    assert isinstance(
+        envs.action_space, gym.spaces.Box
+    ), "only continuous action space is supported"
+
+    # Assume that all dimensions share the same bound
+    min_action = float(envs.action_space.low[0])
+    max_action = float(envs.action_space.high[0])
+    envs.observation_space.dtype = np.float32
+    rb = ReplayBuffer(
+        args.buffer_size,
+        envs.observation_space,
+        envs.action_space,
+        device="cpu",
+        handle_timeout_termination=True,
+    )
+
+    # Sort and drop top k quantiles to control overestimation.
+    n_quantiles = 25
+    n_critics = 2
+    quantiles_total = n_quantiles * n_critics
+    top_quantiles_to_drop_per_net = 2
+    n_target_quantiles = quantiles_total - top_quantiles_to_drop_per_net * n_critics
+
+    # TRY NOT TO MODIFY: start the game
+    obs = envs.reset()
+    actor = Actor(
+        action_dim=np.prod(envs.action_space.shape),
+        action_scale=(max_action - min_action) / 2.0,
+        action_bias=(max_action + min_action) / 2.0,
+    )
+    actor_state = RLTrainState.create(
+        apply_fn=actor.apply,
+        params=actor.init(actor_key, obs),
+        target_params=actor.init(actor_key, obs),
+        tx=optax.adam(learning_rate=args.learning_rate),
+    )
+    qf = QNetwork(dropout_rate=args.dropout_rate, use_layer_norm=args.layer_norm)
+    qf1_state = RLTrainState.create(
+        apply_fn=qf.apply,
+        params=qf.init(
+            {"params": qf1_key, "dropout": dropout_key1},
+            obs,
+            jnp.array([envs.action_space.sample()]),
+        ),
+        target_params=qf.init(
+            {"params": qf1_key, "dropout": dropout_key1},
+            obs,
+            jnp.array([envs.action_space.sample()]),
+        ),
+        tx=optax.adam(learning_rate=args.learning_rate),
+    )
+    qf2_state = RLTrainState.create(
+        apply_fn=qf.apply,
+        params=qf.init(
+            {"params": qf2_key, "dropout": dropout_key2},
+            obs,
+            jnp.array([envs.action_space.sample()]),
+        ),
+        target_params=qf.init(
+            {"params": qf2_key, "dropout": dropout_key2},
+            obs,
+            jnp.array([envs.action_space.sample()]),
+        ),
+        tx=optax.adam(learning_rate=args.learning_rate),
+    )
+    actor.apply = jax.jit(actor.apply)
+    qf.apply = jax.jit(qf.apply, static_argnames=("dropout_rate", "use_layer_norm"))
+
+    @jax.jit
+    def update_critic(
+        actor_state: RLTrainState,
+        qf1_state: RLTrainState,
+        qf2_state: RLTrainState,
+        observations: np.ndarray,
+        actions: np.ndarray,
+        next_observations: np.ndarray,
+        rewards: np.ndarray,
+        dones: np.ndarray,
+        key: jnp.ndarray,
+    ):
+        # TODO Maybe pre-generate a lot of random keys
+        # also check https://jax.readthedocs.io/en/latest/jax.random.html
+        key, noise_key, dropout_key_1, dropout_key_2 = jax.random.split(key, 4)
+        key, dropout_key_3, dropout_key_4 = jax.random.split(key, 3)
+
+        clipped_noise = jnp.clip(
+            (jax.random.normal(noise_key, actions[0].shape) * args.policy_noise),
+            -args.noise_clip,
+            args.noise_clip,
+        )
+        next_state_actions = jnp.clip(
+            actor.apply(actor_state.target_params, next_observations) + clipped_noise,
+            envs.action_space.low[0],
+            envs.action_space.high[0],
+        )
+        qf1_next_quantiles = qf.apply(
+            qf1_state.target_params,
+            next_observations,
+            next_state_actions,
+            True,
+            rngs={"dropout": dropout_key_1},
+        )
+        qf2_next_quantiles = qf.apply(
+            qf2_state.target_params,
+            next_observations,
+            next_state_actions,
+            True,
+            rngs={"dropout": dropout_key_2},
+        )
+
+        # Concatenate quantiles from both critics to get a single tensor
+        # batch x quantiles
+        qf_next_quantiles = jnp.concatenate((qf1_next_quantiles, qf2_next_quantiles), axis=1)
+
+        # sort next quantiles with jax
+        next_quantiles = jnp.sort(qf_next_quantiles)
+        # Keep only the quantiles we need
+        next_target_quantiles = next_quantiles[:, :n_target_quantiles]
+        
+
+        target_quantiles = (
+            rewards.reshape(-1, 1) + (1 - dones.reshape(-1, 1)) * args.gamma * (next_target_quantiles)
+        )
+
+        # Make target_quantiles broadcastable to (batch_size, n_quantiles, n_target_quantiles).
+        target_quantiles = jnp.expand_dims(target_quantiles, axis=1)
+
+
+        def huber_quantile_loss(params, noise_key):
+            # Compute huber quantile loss
+            current_quantiles = qf.apply(
+                params, observations, actions, True, rngs={"dropout": noise_key}
+            )
+            # convert to shape: (batch_size, n_quantiles, 1)
+            current_quantiles = jnp.expand_dims(current_quantiles, axis=-1)
+
+            # Cumulative probabilities to calculate quantiles.
+            # shape: (n_quantiles,)
+            cum_prob = (jnp.arange(n_quantiles, dtype=jnp.float32) + 0.5) / n_quantiles
+            # convert to shape: (1, n_quantiles, 1)
+            cum_prob = jnp.expand_dims(cum_prob, axis=(0, -1))
+            
+            # TQC
+            # target_quantiles: (batch_size, 1, n_target_quantiles) -> (batch_size, 1, 1, n_target_quantiles)
+            # current_quantiles: (batch_size, n_critics, n_quantiles) -> (batch_size, n_critics, n_quantiles, 1)
+            # pairwise_delta: (batch_size, n_critics, n_quantiles, n_target_quantiles)
+            # Note: in both cases, the loss has the same shape as pairwise_delta
+
+            pairwise_delta = target_quantiles - current_quantiles
+            abs_pairwise_delta = jnp.abs(pairwise_delta)
+            huber_loss = jnp.where(abs_pairwise_delta > 1, abs_pairwise_delta - 0.5, pairwise_delta**2 * 0.5)
+            loss = jnp.abs(cum_prob - (pairwise_delta < 0).astype(jnp.float32)) * huber_loss
+            return loss.mean()
+
+        qf1_loss_value, grads1 = jax.value_and_grad(
+            huber_quantile_loss, has_aux=False
+        )(qf1_state.params, dropout_key_3)
+        qf2_loss_value, grads2 = jax.value_and_grad(
+            huber_quantile_loss, has_aux=False
+        )(qf2_state.params, dropout_key_4)
+        qf1_state = qf1_state.apply_gradients(grads=grads1)
+        qf2_state = qf2_state.apply_gradients(grads=grads2)
+
+        return (
+            (qf1_state, qf2_state),
+            (qf1_loss_value, qf2_loss_value),
+            key,
+        )
+
+    @jax.jit
+    def update_actor(
+        actor_state: RLTrainState,
+        qf1_state: RLTrainState,
+        qf2_state: RLTrainState,
+        observations: np.ndarray,
+        key: jnp.ndarray,
+    ):
+        key, dropout_key = jax.random.split(key, 2)
+
+        def actor_loss(params):
+            return -qf.apply(
+                qf1_state.params,
+                observations,
+                actor.apply(params, observations),
+                True,
+                rngs={"dropout": dropout_key},
+            ).mean()
+
+        actor_loss_value, grads = jax.value_and_grad(actor_loss)(actor_state.params)
+        actor_state = actor_state.apply_gradients(grads=grads)
+        actor_state = actor_state.replace(
+            target_params=optax.incremental_update(
+                actor_state.params, actor_state.target_params, args.tau
+            )
+        )
+
+        qf1_state = qf1_state.replace(
+            target_params=optax.incremental_update(
+                qf1_state.params, qf1_state.target_params, args.tau
+            )
+        )
+        qf2_state = qf2_state.replace(
+            target_params=optax.incremental_update(
+                qf2_state.params, qf2_state.target_params, args.tau
+            )
+        )
+        return actor_state, (qf1_state, qf2_state), actor_loss_value, key
+
+    start_time = time.time()
+    n_updates = 0
+    for global_step in tqdm(range(args.total_timesteps)):
+    # for global_step in range(args.total_timesteps):
+        # ALGO LOGIC: put action logic here
+        if global_step < args.learning_starts:
+            actions = np.array(
+                [envs.action_space.sample() for _ in range(envs.num_envs)]
+            )
+        else:
+            actions = actor.apply(actor_state.params, obs)
+            actions = np.array(
+                [
+                    (
+                        jax.device_get(actions)[0]
+                        + np.random.normal(
+                            0,
+                            max_action * args.exploration_noise,
+                            size=envs.action_space.shape[0],
+                        )
+                    ).clip(envs.action_space.low, envs.action_space.high)
+                ]
+            )
+
+        # TRY NOT TO MODIFY: execute the game and log data.
+        next_obs, rewards, dones, infos = envs.step(actions)
+
+        # TRY NOT TO MODIFY: record rewards for plotting purposes
+        for info in infos:
+            if "episode" in info.keys():
+                if args.verbose >= 2:
+                    print(
+                        f"global_step={global_step + 1}, episodic_return={info['episode']['r']:.2f}"
+                    )
+                writer.add_scalar(
+                    "charts/episodic_return", info["episode"]["r"], global_step
+                )
+                writer.add_scalar(
+                    "charts/episodic_length", info["episode"]["l"], global_step
+                )
+                break
+
+        # TRY NOT TO MODIFY: save data to replay buffer; handle `terminal_observation`
+        real_next_obs = next_obs.copy()
+        for idx, done in enumerate(dones):
+            if done:
+                real_next_obs[idx] = infos[idx]["terminal_observation"]
+            # Timeout handling done inside the replay buffer
+            # if infos[idx].get("TimeLimit.truncated", False) == True:
+            #     real_dones[idx] = False
+
+        rb.add(obs, real_next_obs, actions, rewards, dones, infos)
+
+        # TRY NOT TO MODIFY: CRUCIAL step easy to overlook
+        obs = next_obs
+
+        # ALGO LOGIC: training.
+        if global_step > args.learning_starts:
+            for _ in range(args.gradient_steps):
+                n_updates += 1
+                data = rb.sample(args.batch_size)
+
+                (
+                    (qf1_state, qf2_state),
+                    (qf1_loss_value, qf2_loss_value),
+                    key,
+                ) = update_critic(
+                    actor_state,
+                    qf1_state,
+                    qf2_state,
+                    data.observations.numpy(),
+                    data.actions.numpy(),
+                    data.next_observations.numpy(),
+                    data.rewards.flatten().numpy(),
+                    data.dones.flatten().numpy(),
+                    key,
+                )
+
+                if n_updates % args.policy_frequency == 0:
+                    (
+                        actor_state,
+                        (qf1_state, qf2_state),
+                        actor_loss_value,
+                        key,
+                    ) = update_actor(
+                        actor_state,
+                        qf1_state,
+                        qf2_state,
+                        data.observations.numpy(),
+                        key,
+                    )
+
+            fps = int(global_step / (time.time() - start_time))
+            if args.eval_freq > 0 and global_step % args.eval_freq == 0:
+                mean_reward, std_reward = evaluate_policy(eval_envs, actor, actor_state)
+                print(
+                    f"global_step={global_step}, mean_eval_reward={mean_reward:.2f} +/- {std_reward:.2f} - {fps} fps"
+                )
+                writer.add_scalar("charts/mean_eval_reward", mean_reward, global_step)
+                writer.add_scalar("charts/std_eval_reward", std_reward, global_step)
+
+            if global_step % 100 == 0:
+                writer.add_scalar("losses/qf1_loss", qf1_loss_value.item(), global_step)
+                writer.add_scalar("losses/qf2_loss", qf2_loss_value.item(), global_step)
+                # writer.add_scalar("losses/qf1_values", qf1_a_values.item(), global_step)
+                # writer.add_scalar("losses/qf2_values", qf2_a_values.item(), global_step)
+                writer.add_scalar(
+                    "losses/actor_loss", actor_loss_value.item(), global_step
+                )
+                if args.verbose >= 2:
+                    print("FPS:", fps)
+                writer.add_scalar(
+                    "charts/SPS",
+                    int(global_step / (time.time() - start_time)),
+                    global_step,
+                )
+
+    envs.close()
+    writer.close()
+
+
+if __name__ == "__main__":
+
+    try:
+        main()
+    except KeyboardInterrupt:
+        pass


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in here-->

FYI: unpolished jax implementation of TD3+DroQ and TD3+TQC implementations.
Related to #262 #258 
My plan is to try to have sac in jax, but currently jax rely on tensorflow for probability distributions :/
So I adapted TD3 instead.
I also want to make it even faster but would need to tweak a bit the way the replay buffer is used.

Reference:
- jax: https://github.com/ikostrikov/walk_in_the_park
- original: https://github.com/TakuyaHiraoka/Dropout-Q-Functions-for-Doubly-Efficient-Reinforcement-Learning/tree/main/KUCodebase/code
- SB3: https://github.com/Stable-Baselines-Team/stable-baselines3-contrib/pull/100

Known difference with original implementation: qf are updated at the same time of the actor instead of after each gradient step.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [ ] New algorithm
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've read the [CONTRIBUTION](https://github.com/vwxyzjn/cleanrl/blob/master/CONTRIBUTING.md) guide (**required**).
- [ ] I have ensured `pre-commit run --all-files` passes (**required**).
- [ ] I have updated the documentation and previewed the changes via `mkdocs serve`.
- [ ] I have updated the tests accordingly (if applicable).

If you are adding new algorithms or your change could result in performance difference, you may need to (re-)run tracked experiments. See https://github.com/vwxyzjn/cleanrl/pull/137 as an example PR. 
- [ ] I have contacted [vwxyzjn](https://github.com/vwxyzjn) to obtain access to the [openrlbenchmark W&B team](https://wandb.ai/openrlbenchmark) (**required**).
- [ ] I have tracked applicable experiments in [openrlbenchmark/cleanrl](https://wandb.ai/openrlbenchmark/cleanrl) with `--capture-video` flag toggled on (**required**).
- [ ] I have added additional documentation and previewed the changes via `mkdocs serve`.
    - [ ] I have explained note-worthy implementation details.
    - [ ] I have explained the logged metrics.
    - [ ] I have added links to the original paper and related papers (if applicable).
    - [ ] I have added links to the PR related to the algorithm.
    - [ ] I have created a table comparing my results against those from reputable sources (i.e., the original paper or other reference implementation).
    - [ ] I have added the learning curves (in PNG format with `width=500` and `height=300`).
    - [ ] I have added links to the tracked experiments.
    - [ ] I have updated the overview sections at the [docs](https://docs.cleanrl.dev/rl-algorithms/overview/) and the [repo](https://github.com/vwxyzjn/cleanrl#overview)
- [ ] I have updated the tests accordingly (if applicable).

