### PR TITLE
Point offline RL users to tinkoff-ai/CORL

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ CleanRL is a Deep Reinforcement Learning library that provides high-quality sing
 
 You can read more about CleanRL in our [JMLR paper](https://www.jmlr.org/papers/volume23/21-1342/21-1342.pdf) and [documentation](https://docs.cleanrl.dev/).
 
-Good luck have fun :rocket:
+CleanRL only contains implementations of **online** deep reinforcement learning algorithms. If you are looking for **offline** algorithms, please check out [tinkoff-ai/CORL](https://github.com/tinkoff-ai/CORL), which shares a similar design philosophy as CleanRL.
 
 > ⚠️ **NOTE**: CleanRL is *not* a modular library and therefore it is not meant to be imported. At the cost of duplicate code, we make all implementation details of a DRL algorithm variant easy to understand, so CleanRL comes with its own pros and cons. You should consider using CleanRL if you want to 1) understand all implementation details of an algorithm's varaint or 2) prototype advanced features that other modular DRL libraries do not support (CleanRL has minimal lines of code so it gives you great debugging experience and you don't have do a lot of subclassing like sometimes in modular DRL libraries).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ CleanRL is a Deep Reinforcement Learning library that provides high-quality sing
 
 You can read more about CleanRL in our [technical paper](https://arxiv.org/abs/2111.08819) and [documentation](https://docs.cleanrl.dev/).
 
-Good luck have fun :rocket:
+CleanRL only contains implementations of **online** deep reinforcement learning algorithms. If you are looking for **offline** algorithms, please check out [tinkoff-ai/CORL](https://github.com/tinkoff-ai/CORL), which shares a similar design philosophy as CleanRL.
 
 !!! warning
     


### PR DESCRIPTION
## Description
https://github.com/tinkoff-ai/CORL seems to be a great offline RL library that shares a similar design philosophy with us. Since we are not really developing offline RL algorithms, we should give a friendly pointer to them, especially given that they have done the same for us:

<img width="796" alt="image" src="https://user-images.githubusercontent.com/5555347/194158502-e65fa930-82b8-4b02-bb8c-cf7f3b6ce3c8.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [ ] New algorithm
- [x] Documentation
