### PR TITLE
Upload the ubuntu image for github action

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         python-version: [3.8]
         poetry-version: [1.2]
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -53,7 +53,7 @@ jobs:
       matrix:
         python-version: [3.8]
         poetry-version: [1.2]
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -85,7 +85,7 @@ jobs:
       matrix:
         python-version: [3.8]
         poetry-version: [1.2]
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -113,7 +113,7 @@ jobs:
       matrix:
         python-version: [3.8]
         poetry-version: [1.2]
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -140,7 +140,7 @@ jobs:
       matrix:
         python-version: [3.8]
         poetry-version: [1.2]
-        os: [ubuntu-18.04]
+        os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -179,7 +179,7 @@ jobs:
       matrix:
         python-version: [3.8]
         poetry-version: [1.2]
-        os: [ubuntu-18.04]
+        os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -205,7 +205,7 @@ jobs:
       matrix:
         python-version: [3.8]
         poetry-version: [1.2]
-        os: [ubuntu-18.04]
+        os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -231,7 +231,7 @@ jobs:
       matrix:
         python-version: [3.8]
         poetry-version: [1.2]
-        os: [ubuntu-18.04, macos-latest]
+        os: [ubuntu-22.04, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/utils_test.yaml
+++ b/.github/workflows/utils_test.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         python-version: [3.8]
         poetry-version: [1.2]
-        os: [ubuntu-18.04]
+        os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Description
This PR addresses https://github.com/actions/runner-images/issues/6002. TLDR; the `ubuntu-18.04` is getting deprecated by GitHub action and we are replacing our CI image with `ubuntu-22.04`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] New algorithm
- [ ] Documentation

