### PR TITLE
Auto wandb tag with `benchmark.py`

### DIFF
--- a/benchmark/td3.sh
+++ b/benchmark/td3.sh
@@ -1,6 +1,6 @@
 poetry install --with mujoco,pybullet
 python -c "import mujoco_py"
-WANDB_TAGS=$(git describe --tags) OMP_NUM_THREADS=1 xvfb-run -a python -m cleanrl_utils.benchmark \
+OMP_NUM_THREADS=1 xvfb-run -a python -m cleanrl_utils.benchmark \
     --env-ids HalfCheetah-v2 Walker2d-v2 Hopper-v2 InvertedPendulum-v2 Humanoid-v2 Pusher-v2 \
     --command "poetry run python cleanrl/td3_continuous_action.py --track --capture-video" \
     --num-seeds 3 \
@@ -9,7 +9,7 @@ WANDB_TAGS=$(git describe --tags) OMP_NUM_THREADS=1 xvfb-run -a python -m cleanr
 poetry install --with mujoco,jax
 poetry run pip install --upgrade "jax[cuda]==0.3.17" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 poetry run python -c "import mujoco_py"
-WANDB_TAGS=$(git describe --tags) xvfb-run -a poetry run python -m cleanrl_utils.benchmark \
+xvfb-run -a poetry run python -m cleanrl_utils.benchmark \
     --env-ids HalfCheetah-v2 Walker2d-v2 Hopper-v2 \
     --command "poetry run python cleanrl/td3_continuous_action_jax.py --track --capture-video" \
     --num-seeds 3 \

--- a/cleanrl_utils/benchmark.py
+++ b/cleanrl_utils/benchmark.py
@@ -47,14 +47,12 @@ def autotag() -> str:
     git_commit = subprocess.check_output(["git", "rev-parse", "--verify", "HEAD"]).decode("ascii").strip()
     try:
         # try finding the pull request number on github
-        prs = requests.get(f"https://api.github.com/repos/vwxyzjn/cleanrl/commits/{git_commit}/pulls")
+        prs = requests.get(f"https://api.github.com/search/issues?q=repo:vwxyzjn/cleanrl+is:pr+{git_commit}")
         if prs.status_code == 200:
             prs = prs.json()
-            if len(prs) > 0:
-                pr = prs[0]
+            if len(prs["items"]) > 0:
+                pr = prs["items"][0]
                 pr_number = pr["number"]
-                pr["title"]
-                pr["html_url"]
                 wandb_tag += f",pr-{pr_number}"
         print(f"identified github pull request: {pr_number}")
     except Exception as e:

--- a/cleanrl_utils/benchmark.py
+++ b/cleanrl_utils/benchmark.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import shlex
 import subprocess
+from distutils.util import strtobool
 
 import requests
 
@@ -73,7 +74,7 @@ if __name__ == "__main__":
             os.environ["WANDB_TAGS"] = wandb_tag
 
     commands = []
-    for seed in range(0, args.num_seeds + 1):
+    for seed in range(0, args.num_seeds):
         for env_id in args.env_ids:
             commands += [" ".join([args.command, "--env-id", env_id, "--seed", str(args.start_seed + seed)])]
 

--- a/cleanrl_utils/benchmark.py
+++ b/cleanrl_utils/benchmark.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
             os.environ["WANDB_TAGS"] = wandb_tag
 
     commands = []
-    for seed in range(1, args.num_seeds + 1):
+    for seed in range(0, args.num_seeds + 1):
         for env_id in args.env_ids:
             commands += [" ".join([args.command, "--env-id", env_id, "--seed", str(args.start_seed + seed)])]
 


### PR DESCRIPTION
## Description
This PR aims to automatically add some version control tags to `benchmark.py`. It helps with #296 and #307 because the version control tags help us compare the performance of different codebase versions.

<img width="516" alt="image" src="https://user-images.githubusercontent.com/5555347/199108180-74816bb6-3556-45e6-b678-724de551ed30.png">



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [x] New feature
- [ ] New algorithm
- [ ] Documentation

