### PR TITLE
handle num_envs > 1 in DQN

### DIFF
--- a/cleanrl/dqn.py
+++ b/cleanrl/dqn.py
@@ -72,7 +72,6 @@ def parse_args():
         help="the frequency of training")
     args = parser.parse_args()
     # fmt: on
-    assert args.num_envs == 1, "vectorized envs are not supported at the moment"
 
     return args
 
@@ -167,6 +166,7 @@ poetry run pip install "stable_baselines3==2.0.0a1"
         envs.single_observation_space,
         envs.single_action_space,
         device,
+        n_envs=args.num_envs,
         handle_timeout_termination=False,
     )
     start_time = time.time()
@@ -189,7 +189,7 @@ poetry run pip install "stable_baselines3==2.0.0a1"
         if "final_info" in infos:
             for info in infos["final_info"]:
                 # Skip the envs that are not done
-                if "episode" not in info:
+                if info is None or "episode" not in info:
                     continue
                 print(f"global_step={global_step}, episodic_return={info['episode']['r']}")
                 writer.add_scalar("charts/episodic_return", info["episode"]["r"], global_step)


### PR DESCRIPTION
## Description
We remove the requirement that `num_envs=1` in the DQN implementation. See discussion in:
https://github.com/vwxyzjn/cleanrl/pull/370#issuecomment-1577698962

## Types of changes
- [ x ] Bug fix
- [ ] New feature
- [ ] New algorithm
- [ ] Documentation

## Checklist:
- [ x ] I've read the [CONTRIBUTION](https://docs.cleanrl.dev/contribution/) guide (**required**).
- [ ] I have ensured `pre-commit run --all-files` passes (**required**).
- [ ] I have updated the tests accordingly (if applicable).
- [ ] I have updated the documentation and previewed the changes via `mkdocs serve`.
    - [ ] I have explained note-worthy implementation details.
    - [ ] I have explained the logged metrics.
    - [ ] I have added links to the original paper and related papers.

