### PR TITLE
Use the training `end_e` as the `evaluation(..., epsilon=end_e)` for atari

### DIFF
--- a/cleanrl/c51_atari.py
+++ b/cleanrl/c51_atari.py
@@ -303,7 +303,7 @@ poetry run pip install "stable_baselines3==2.0.0a1" "gymnasium[atari,accept-rom-
             run_name=f"{run_name}-eval",
             Model=QNetwork,
             device=device,
-            epsilon=0.05,
+            epsilon=args.end_e,
         )
         for idx, episodic_return in enumerate(episodic_returns):
             writer.add_scalar("eval/episodic_return", episodic_return, idx)

--- a/cleanrl/c51_atari_jax.py
+++ b/cleanrl/c51_atari_jax.py
@@ -343,7 +343,7 @@ poetry run pip install "stable_baselines3==2.0.0a1" "gymnasium[atari,accept-rom-
             eval_episodes=10,
             run_name=f"{run_name}-eval",
             Model=QNetwork,
-            epsilon=0.05,
+            epsilon=args.end_e,
         )
         for idx, episodic_return in enumerate(episodic_returns):
             writer.add_scalar("eval/episodic_return", episodic_return, idx)

--- a/cleanrl/dqn_atari.py
+++ b/cleanrl/dqn_atari.py
@@ -272,7 +272,7 @@ poetry run pip install "stable_baselines3==2.0.0a1" "gymnasium[atari,accept-rom-
             run_name=f"{run_name}-eval",
             Model=QNetwork,
             device=device,
-            epsilon=0.05,
+            epsilon=args.end_e,
         )
         for idx, episodic_return in enumerate(episodic_returns):
             writer.add_scalar("eval/episodic_return", episodic_return, idx)

--- a/cleanrl/dqn_atari_jax.py
+++ b/cleanrl/dqn_atari_jax.py
@@ -301,7 +301,7 @@ poetry run pip install "stable_baselines3==2.0.0a1" "gymnasium[atari,accept-rom-
             eval_episodes=10,
             run_name=f"{run_name}-eval",
             Model=QNetwork,
-            epsilon=0.05,
+            epsilon=args.end_e,
         )
         for idx, episodic_return in enumerate(episodic_returns):
             writer.add_scalar("eval/episodic_return", episodic_return, idx)

--- a/cleanrl/qdagger_dqn_atari_impalacnn.py
+++ b/cleanrl/qdagger_dqn_atari_impalacnn.py
@@ -265,7 +265,7 @@ poetry run pip install "stable_baselines3==2.0.0a1" "gymnasium[atari,accept-rom-
         eval_episodes=args.teacher_eval_episodes,
         run_name=f"{run_name}-teacher-eval",
         Model=TeacherModel,
-        epsilon=0.05,
+        epsilon=args.end_e,
         capture_video=False,
     )
     writer.add_scalar("charts/teacher/avg_episodic_return", np.mean(teacher_episodic_returns), 0)
@@ -344,7 +344,7 @@ poetry run pip install "stable_baselines3==2.0.0a1" "gymnasium[atari,accept-rom-
                 run_name=f"{run_name}-eval",
                 Model=QNetwork,
                 device=device,
-                epsilon=0.05,
+                epsilon=args.end_e,
             )
             print(episodic_returns)
             writer.add_scalar("charts/offline/avg_episodic_return", np.mean(episodic_returns), global_step)
@@ -461,7 +461,7 @@ poetry run pip install "stable_baselines3==2.0.0a1" "gymnasium[atari,accept-rom-
             run_name=f"{run_name}-eval",
             Model=QNetwork,
             device=device,
-            epsilon=0.05,
+            epsilon=args.end_e,
         )
         for idx, episodic_return in enumerate(episodic_returns):
             writer.add_scalar("eval/episodic_return", episodic_return, idx)

--- a/cleanrl/qdagger_dqn_atari_jax_impalacnn.py
+++ b/cleanrl/qdagger_dqn_atari_jax_impalacnn.py
@@ -264,7 +264,7 @@ poetry run pip install "stable_baselines3==2.0.0a1" "gymnasium[atari,accept-rom-
         eval_episodes=args.teacher_eval_episodes,
         run_name=f"{run_name}-teacher-eval",
         Model=TeacherModel,
-        epsilon=0.05,
+        epsilon=args.end_e,
         capture_video=False,
     )
     writer.add_scalar("charts/teacher/avg_episodic_return", np.mean(teacher_episodic_returns), 0)
@@ -363,7 +363,7 @@ poetry run pip install "stable_baselines3==2.0.0a1" "gymnasium[atari,accept-rom-
                 eval_episodes=10,
                 run_name=f"{run_name}-eval",
                 Model=QNetwork,
-                epsilon=0.05,
+                epsilon=args.end_e,
             )
             print(episodic_returns)
             writer.add_scalar("charts/offline/avg_episodic_return", np.mean(episodic_returns), global_step)
@@ -471,7 +471,7 @@ poetry run pip install "stable_baselines3==2.0.0a1" "gymnasium[atari,accept-rom-
             eval_episodes=10,
             run_name=f"{run_name}-eval",
             Model=QNetwork,
-            epsilon=0.05,
+            epsilon=args.end_e,
         )
         for idx, episodic_return in enumerate(episodic_returns):
             writer.add_scalar("eval/episodic_return", episodic_return, idx)


### PR DESCRIPTION
## Description
Bug fix for https://github.com/vwxyzjn/cleanrl/issues/429
I could repeat this for all DQN, C51 agents that have an `end_e` argument to prevent this issue in the future
 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] New algorithm
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://docs.cleanrl.dev/contribution/) guide (**required**).
- [ ] I have ensured `pre-commit run --all-files` passes (**required**).
- [x] I have updated the tests accordingly (if applicable).
- [ ] I have updated the documentation and previewed the changes via `mkdocs serve`.
    - [ ] I have explained note-worthy implementation details.
    - [ ] I have explained the logged metrics.
    - [ ] I have added links to the original paper and related papers.

If you need to run benchmark experiments for a performance-impacting changes:

- [ ] I have contacted @vwxyzjn to obtain access to the [openrlbenchmark W&B team](https://wandb.ai/openrlbenchmark).
- [ ] I have used the [benchmark utility](/get-started/benchmark-utility/) to submit the tracked experiments to the [openrlbenchmark/cleanrl](https://wandb.ai/openrlbenchmark/cleanrl) W&B project, optionally with `--capture-video`.
- [ ] I have performed RLops with `python -m openrlbenchmark.rlops`.
    - For new feature or bug fix:
        - [ ] I have used the RLops utility to understand the performance impact of the changes and confirmed there is no regression.
    - For new algorithm:
        - [ ] I have created a table comparing my results against those from reputable sources (i.e., the original paper or other reference implementation).
    - [ ] I have added the learning curves generated by the `python -m openrlbenchmark.rlops` utility to the documentation.
    - [ ] I have added links to the tracked experiments in W&B, generated by `python -m openrlbenchmark.rlops ....your_args... --report`,  to the documentation.

