### PR TITLE
Enhancing Termination and Truncation Handling in CleanRL's PPO Algorithm

### DIFF
--- a/cleanrl/ppo_continuous_action.py
+++ b/cleanrl/ppo_continuous_action.py
@@ -209,7 +209,7 @@ if __name__ == "__main__":
 
         for step in range(0, args.num_steps):
             global_step += args.num_envs
-            
+
             ob = next_ob
             # ALGO LOGIC: action logic
             with torch.no_grad():
@@ -217,14 +217,14 @@ if __name__ == "__main__":
 
             # TRY NOT TO MODIFY: execute the game and log data.
             next_ob, reward, next_termination, next_truncation, info = envs.step(action.cpu().numpy())
-            
+
             # Correct next obervation (for vec gym)
             real_next_ob = next_ob.copy()
             for idx, trunc in enumerate(next_truncation):
                 if trunc:
                     real_next_ob[idx] = info["final_observation"][idx]
             next_ob = torch.Tensor(next_ob).to(device)
-            
+
             # Collect trajectory
             obs[step] = torch.Tensor(ob).to(device)
             next_obs[step] = torch.Tensor(real_next_ob).to(device)
@@ -234,7 +234,7 @@ if __name__ == "__main__":
             next_terminations[step] = torch.Tensor(next_termination).to(device)
             next_dones[step] = torch.Tensor(np.logical_or(next_termination, next_truncation)).to(device)
             rewards[step] = torch.tensor(reward).to(device).view(-1)
-            
+
             if "final_info" in info:
                 for info in info["final_info"]:
                     if info and "episode" in info:
@@ -253,7 +253,7 @@ if __name__ == "__main__":
                 else:
                     value_mask = next_dones[t].bool()
                     next_values[value_mask] = agent.get_value(next_obs[t][value_mask]).flatten()
-                    next_values[~value_mask] = values[t+1][~value_mask]
+                    next_values[~value_mask] = values[t + 1][~value_mask]
                 delta = rewards[t] + args.gamma * next_values * (1 - next_terminations[t]) - values[t]
                 advantages[t] = lastgaelam = delta + args.gamma * args.gae_lambda * (1 - next_dones[t]) * lastgaelam
             returns = advantages + values


### PR DESCRIPTION
## Description
I have noticed that the issues regarding termination and truncation in the PPO (Proximal Policy Optimization) algorithm have not been addressed and resolved. Therefore, I have incorporated relevant handling methods. Specifically, for a vector environment (vec env), when termination or truncation is received at the current time step, the actual next state will be provided in the `"final_observation"`, and we need to record this information. Also, here, `done = termination or truncation`.

On the other hand, when calculating delta and advantage using GAE (Generalized Advantage Estimation), delta should be computed using `termination`, while advantages should be computed with `done`. For more details, please refer to the PR (Pull Request) codes and comments I have provided.

Notes: 
- [x] Since we only next `dones[t+1]` and `terminations[t+1]` when computing advantages using GAE, I have make slight code adjustments to simplify the code logics.
- [x] Now we need to store `next_terminations` and `next_obs`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] New algorithm
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://docs.cleanrl.dev/contribution/) guide (**required**).
- [x] I have ensured `pre-commit run --all-files` passes (**required**).
- [ ] I have updated the tests accordingly (if applicable).
- [ ] I have updated the documentation and previewed the changes via `mkdocs serve`.
    - [x] I have explained note-worthy implementation details.
    - [ ] I have explained the logged metrics.
    - [ ] I have added links to the original paper and related papers.

If you need to run benchmark experiments for a performance-impacting changes:

- [ ] I have contacted @vwxyzjn to obtain access to the [openrlbenchmark W&B team](https://wandb.ai/openrlbenchmark).
- [ ] I have used the [benchmark utility](/get-started/benchmark-utility/) to submit the tracked experiments to the [openrlbenchmark/cleanrl](https://wandb.ai/openrlbenchmark/cleanrl) W&B project, optionally with `--capture_video`.
- [ ] I have performed RLops with `python -m openrlbenchmark.rlops`.
    - For new feature or bug fix:
        - [ ] I have used the RLops utility to understand the performance impact of the changes and confirmed there is no regression.
    - For new algorithm:
        - [ ] I have created a table comparing my results against those from reputable sources (i.e., the original paper or other reference implementation).
    - [ ] I have added the learning curves generated by the `python -m openrlbenchmark.rlops` utility to the documentation.
    - [ ] I have added links to the tracked experiments in W&B, generated by `python -m openrlbenchmark.rlops ....your_args... --report`,  to the documentation.

