### PR TITLE
Removing the unused noise_clip from sac_continuous_actions.py

### DIFF
--- a/cleanrl/sac_continuous_action.py
+++ b/cleanrl/sac_continuous_action.py
@@ -57,8 +57,6 @@ class Args:
     """the frequency of training policy (delayed)"""
     target_network_frequency: int = 1  # Denis Yarats' implementation delays this by 2.
     """the frequency of updates for the target nerworks"""
-    noise_clip: float = 0.5
-    """noise clip parameter of the Target Policy Smoothing Regularization"""
     alpha: float = 0.2
     """Entropy regularization coefficient."""
     autotune: bool = True


### PR DESCRIPTION
Removing the unused `noise_clip` from `sac_continuous_actions.py` (probably a relic from TD3)