### PR TITLE
[Enhancement] Log mean/max KL across PPO update phase

### DIFF
--- a/cleanrl/ppo.py
+++ b/cleanrl/ppo.py
@@ -241,6 +241,10 @@ if __name__ == "__main__":
         # Optimizing the policy and value network
         b_inds = np.arange(args.batch_size)
         clipfracs = []
+
+        # tracking KL vals
+        old_kl_vals = []
+        kl_vals = []
         for epoch in range(args.update_epochs):
             np.random.shuffle(b_inds)
             for start in range(0, args.batch_size, args.minibatch_size):
@@ -256,6 +260,8 @@ if __name__ == "__main__":
                     old_approx_kl = (-logratio).mean()
                     approx_kl = ((ratio - 1) - logratio).mean()
                     clipfracs += [((ratio - 1.0).abs() > args.clip_coef).float().mean().item()]
+                    old_kl_vals.append(old_approx_kl)
+                    kl_vals.append(approx_kl)
 
                 mb_advantages = b_advantages[mb_inds]
                 if args.norm_adv:
@@ -303,6 +309,15 @@ if __name__ == "__main__":
         writer.add_scalar("losses/entropy", entropy_loss.item(), global_step)
         writer.add_scalar("losses/old_approx_kl", old_approx_kl.item(), global_step)
         writer.add_scalar("losses/approx_kl", approx_kl.item(), global_step)
+        # Aggregate KL stats across minibatches/epochs
+        if old_kl_vals:
+            _old_kl = torch.stack(old_kl_vals)
+            writer.add_scalar("losses/old_approx_kl_mean", _old_kl.mean().item(), global_step)
+            writer.add_scalar("losses/old_approx_kl_max", _old_kl.max().item(), global_step)
+        if kl_vals:
+            _kl = torch.stack(kl_vals)
+            writer.add_scalar("losses/approx_kl_mean", _kl.mean().item(), global_step)
+            writer.add_scalar("losses/approx_kl_max", _kl.max().item(), global_step)
         writer.add_scalar("losses/clipfrac", np.mean(clipfracs), global_step)
         writer.add_scalar("losses/explained_variance", explained_var, global_step)
         print("SPS:", int(global_step / (time.time() - start_time)))

--- a/cleanrl/ppo_continuous_action.py
+++ b/cleanrl/ppo_continuous_action.py
@@ -256,6 +256,10 @@ if __name__ == "__main__":
         # Optimizing the policy and value network
         b_inds = np.arange(args.batch_size)
         clipfracs = []
+
+        # tracking KL vals
+        old_kl_vals = []
+        kl_vals = []
         for epoch in range(args.update_epochs):
             np.random.shuffle(b_inds)
             for start in range(0, args.batch_size, args.minibatch_size):
@@ -271,6 +275,8 @@ if __name__ == "__main__":
                     old_approx_kl = (-logratio).mean()
                     approx_kl = ((ratio - 1) - logratio).mean()
                     clipfracs += [((ratio - 1.0).abs() > args.clip_coef).float().mean().item()]
+                    old_kl_vals.append(old_approx_kl)
+                    kl_vals.append(approx_kl)
 
                 mb_advantages = b_advantages[mb_inds]
                 if args.norm_adv:
@@ -318,6 +324,15 @@ if __name__ == "__main__":
         writer.add_scalar("losses/entropy", entropy_loss.item(), global_step)
         writer.add_scalar("losses/old_approx_kl", old_approx_kl.item(), global_step)
         writer.add_scalar("losses/approx_kl", approx_kl.item(), global_step)
+        # Aggregate KL stats across minibatches/epochs
+        if old_kl_vals:
+            _old_kl = torch.stack(old_kl_vals)
+            writer.add_scalar("losses/old_approx_kl_mean", _old_kl.mean().item(), global_step)
+            writer.add_scalar("losses/old_approx_kl_max", _old_kl.max().item(), global_step)
+        if kl_vals:
+            _kl = torch.stack(kl_vals)
+            writer.add_scalar("losses/approx_kl_mean", _kl.mean().item(), global_step)
+            writer.add_scalar("losses/approx_kl_max", _kl.max().item(), global_step)
         writer.add_scalar("losses/clipfrac", np.mean(clipfracs), global_step)
         writer.add_scalar("losses/explained_variance", explained_var, global_step)
         print("SPS:", int(global_step / (time.time() - start_time)))


### PR DESCRIPTION
## Description
In ppo.py (and ppo_continuous_action.py), losses/approx_kl and losses/old_approx_kl reflect the last minibatch of the final epoch in each update. This proposes logging simple aggregates over the PPO update phase:

- losses/approx_kl_mean (mean over all minibatches/epochs in the update)
- losses/approx_kl_max (max over all minibatches/epochs)
- losses/old_approx_kl_mean
- losses/old_approx_kl_max
This is non-performance-impacting, small quality-of-life improvement: these aggregates can make KL trends easier to read in noisier settings. No behavior changes, logging only.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [x] New feature
- [ ] New algorithm
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://docs.cleanrl.dev/contribution/) guide (**required**).
- [x] I have ensured `pre-commit run --all-files` passes (**required**).
- [x] I have updated the tests accordingly (if applicable).
- [x] I have updated the documentation and previewed the changes via `mkdocs serve`.
    - [x] I have explained note-worthy implementation details.
    - [x] I have explained the logged metrics.
    - [x] I have added links to the original paper and related papers.

If you need to run benchmark experiments for a performance-impacting changes:

- [ ] I have contacted @vwxyzjn to obtain access to the [openrlbenchmark W&B team](https://wandb.ai/openrlbenchmark).
- [ ] I have used the [benchmark utility](/get-started/benchmark-utility/) to submit the tracked experiments to the [openrlbenchmark/cleanrl](https://wandb.ai/openrlbenchmark/cleanrl) W&B project, optionally with `--capture_video`.
- [ ] I have performed RLops with `python -m openrlbenchmark.rlops`.
    - For new feature or bug fix:
        - [ ] I have used the RLops utility to understand the performance impact of the changes and confirmed there is no regression.
    - For new algorithm:
        - [ ] I have created a table comparing my results against those from reputable sources (i.e., the original paper or other reference implementation).
    - [ ] I have added the learning curves generated by the `python -m openrlbenchmark.rlops` utility to the documentation.
    - [ ] I have added links to the tracked experiments in W&B, generated by `python -m openrlbenchmark.rlops ....your_args... --report`,  to the documentation.

