### PR TITLE
feat: Add ES-C51 (Expected SARSA based C51) algorithm implementation

### DIFF
--- a/ES_C51_README.md
+++ b/ES_C51_README.md
@@ -1,0 +1,171 @@
+# ES-C51: Expected Sarsa Based C51 Distributional Reinforcement Learning
+
+This directory contains implementations of ES-C51 (Expected Sarsa based C51) and modified C51 algorithms with softmax action selection, as described in our paper submitted to Neurocomputing.
+
+## Paper Reference
+
+**Title**: ES-C51: Expected Sarsa Based C51 Distributional Reinforcement Learning Algorithm  
+**Authors**: Rijul Tandon, Peter Vamplew, Cameron Foale  
+**Submitted to**: Neurocomputing  
+**ArXiv Link**: [To be added upon publication]
+
+## Overview
+
+This work presents ES-C51, a modification of the standard C51 distributional reinforcement learning algorithm that replaces the greedy Q-learning update with an Expected Sarsa update. The key innovation is using a softmax-weighted expectation over all possible next actions rather than relying solely on the greedy action selection.
+
+## Key Contributions
+
+1. **Algorithmic Innovation**: Introduction of ES-C51 that uses Expected Sarsa updates in distributional RL
+2. **Fair Comparison**: Modified standard C51 to use softmax exploration (QL-C51) for fair comparison
+3. **Comprehensive Evaluation**: Tested on Gym classic control and Atari-10 environments
+4. **Performance Analysis**: Demonstrated superior performance of ES-C51 over QL-C51 across multiple environments
+
+## Files Description
+
+### Core Algorithm Files
+
+- **`c51_expected_sarsa.py`**: ES-C51 implementation for Gym environments
+- **`c51_atari_expected_sarsa.py`**: ES-C51 implementation for Atari environments
+- **`c51.py`**: Modified C51 with softmax action selection (QL-C51) for Gym environments
+- **`c51_atari.py`**: Modified C51 with softmax action selection (QL-C51) for Atari environments
+
+### Key Modifications
+
+#### 1. Action Selection Policy
+Both ES-C51 and QL-C51 use **softmax action selection** instead of ε-greedy:
+```python
+# Softmax policy with temperature τ
+policy = torch.softmax(q_values / tau, dim=1)
+actions = torch.multinomial(policy, 1).squeeze(1).cpu().numpy()
+```
+
+#### 2. Target Distribution Construction (ES-C51 vs QL-C51)
+
+**Standard QL-C51 (Greedy Bellman Backup)**:
+```python
+_, next_pmfs = target_network.get_action(data.next_observations)  # Greedy action
+```
+
+**ES-C51 (Expected Sarsa Backup)**:
+```python
+# Compute all action distributions
+pmfs_all = torch.softmax(logits.view(batch_size, n_actions, n_atoms), dim=2)
+q_values = (pmfs_all * atoms).sum(2)
+
+# Use softmax policy to weight all actions
+policy = torch.softmax(q_values / tau, dim=1)
+expected_next_pmfs = (policy.unsqueeze(2) * pmfs_all).sum(1)  # Expected distribution
+```
+
+#### 3. Temperature Decay
+Both algorithms use decaying temperature for exploration-exploitation trade-off:
+```python
+tau = max(1.0 * (1 - global_step / args.total_timesteps), 0.01)
+```
+
+## Theoretical Foundation
+
+### Problem with Standard C51
+Standard C51 can suffer from instability when multiple actions have similar expected rewards but different variances. The greedy selection can cause:
+- Frequent switching between actions with similar Q-values
+- Unstable distribution learning
+- Policy churn affecting convergence
+
+### ES-C51 Solution
+ES-C51 addresses these issues by:
+- Using Expected Sarsa updates that consider all possible actions
+- Weighting actions by their softmax probabilities
+- Reducing variance in target distribution construction
+- Providing more stable learning, especially early in training
+
+## Experimental Results
+
+### Environments Tested
+- **Gym Classic Control**: CartPole-v1, Acrobot-v1
+- **Atari Games**: 10 games from Atari-10 benchmark in both stochastic (v0) and deterministic (NoFrameskip-v4) versions
+
+### Key Findings
+- ES-C51 achieves higher mean reward than QL-C51 on **72.7%** of environments
+- **Deterministic environments**: More consistent improvements (median ~6-7%, range: -4.74% to 43.98%)
+- **Stochastic environments**: More varied results but still positive median improvement (~7%)
+- **Runtime**: Comparable to QL-C51, sometimes even faster due to streamlined updates
+
+## Usage
+
+### Running ES-C51 on Gym Environments
+```bash
+python c51_expected_sarsa.py --env-id CartPole-v1 --total-timesteps 500000
+```
+
+### Running ES-C51 on Atari Environments
+```bash
+python c51_atari_expected_sarsa.py --env-id BreakoutNoFrameskip-v4 --total-timesteps 10000000
+```
+
+### Running QL-C51 for Comparison
+```bash
+python c51.py --env-id CartPole-v1 --total-timesteps 500000
+python c51_atari.py --env-id BreakoutNoFrameskip-v4 --total-timesteps 10000000
+```
+
+## Hyperparameters
+
+### Gym Environments
+- `n_atoms`: 101
+- `v_min`: -100, `v_max`: 100
+- `learning_rate`: 2.5e-4
+- `batch_size`: 128
+- `buffer_size`: 10000
+
+### Atari Environments
+- `n_atoms`: 51
+- `v_min`: -10, `v_max`: 10
+- `learning_rate`: 2.5e-4
+- `batch_size`: 32
+- `buffer_size`: 1000000
+
+## Mathematical Foundation
+
+### Distributional Bellman Operator (ES-C51)
+```
+𝒯^π Z(s,a) = R(s,a) + γ ∑_{a'∈𝒜} π_τ(a'|s') · Z(s',a')
+```
+
+### Cross-Entropy Loss
+```
+ℒ(θ) = -∑ᵢ Z_target[i] * log(p_θ(s,a,zᵢ))
+```
+
+## Citation
+
+If you use this code in your research, please cite our paper:
+
+```bibtex
+@article{tandon2024esc51,
+  title={ES-C51: Expected Sarsa Based C51 Distributional Reinforcement Learning Algorithm},
+  author={Tandon, Rijul and Vamplew, Peter and Foale, Cameron},
+  journal={Neurocomputing},
+  year={2024},
+  note={Submitted}
+}
+```
+
+## Dependencies
+
+- gymnasium
+- torch
+- numpy
+- tyro
+- tensorboard
+- cleanrl_utils
+
+## Contact
+
+For questions about this implementation, please contact:
+- Rijul Tandon: letscomerijul@gmail.com
+- Peter Vamplew: p.vamplew@federation.edu.au
+- Cameron Foale: c.foale@federation.edu.au
+
+## License
+
+This code is released under the same license as CleanRL.

--- a/cleanrl/c51.py
+++ b/cleanrl/c51.py
@@ -1,4 +1,10 @@
 # docs and experiment results can be found at https://docs.cleanrl.dev/rl-algorithms/c51/#c51py
+#
+# MODIFICATION: This version uses softmax action selection instead of epsilon-greedy
+# for fair comparison with ES-C51 algorithm. Referred to as QL-C51 in the paper:
+# "ES-C51: Expected Sarsa Based C51 Distributional Reinforcement Learning Algorithm"
+# Authors: Rijul Tandon, Peter Vamplew, Cameron Foale (Neurocomputing, 2024)
+#
 import os
 import random
 import time
@@ -174,13 +180,17 @@ if __name__ == "__main__":
     # TRY NOT TO MODIFY: start the game
     obs, _ = envs.reset(seed=args.seed)
     for global_step in range(args.total_timesteps):
-        # ALGO LOGIC: put action logic here
-        epsilon = linear_schedule(args.start_e, args.end_e, args.exploration_fraction * args.total_timesteps, global_step)
-        if random.random() < epsilon:
-            actions = np.array([envs.single_action_space.sample() for _ in range(envs.num_envs)])
-        else:
-            actions, pmf = q_network.get_action(torch.Tensor(obs).to(device))
-            actions = actions.cpu().numpy()
+        tau = max(1.0 * (1 - global_step / args.total_timesteps*0.75), 0.01)
+        logits = q_network.network(torch.Tensor(obs).to(device))
+        batch_size = logits.shape[0]
+        n_actions = q_network.n
+        n_atoms = q_network.n_atoms
+        atoms = q_network.atoms
+        pmfs_all = torch.softmax(logits.view(batch_size, n_actions, n_atoms), dim=2)
+        q_values = (pmfs_all * atoms).sum(2)
+        # Use softmax policy for action selection
+        policy = torch.softmax(q_values / tau, dim=1)  # [batch_size, n_actions]
+        actions = torch.multinomial(policy, 1).squeeze(1).cpu().numpy()
 
         # TRY NOT TO MODIFY: execute the game and log data.
         next_obs, rewards, terminations, truncations, infos = envs.step(actions)
@@ -277,3 +287,17 @@ if __name__ == "__main__":
 
     envs.close()
     writer.close()
+
+    # Log runtime to CSV
+    # import csv
+    # runtime_csv = os.path.join(os.path.dirname(__file__), "run_time_comparison.csv")
+    # total_time = time.time() - start_time
+    # algo_name = args.exp_name
+    # seed = args.seed
+    # env = args.env_id
+    # file_exists = os.path.isfile(runtime_csv)
+    # with open(runtime_csv, "a", newline="") as csvfile:
+    #     writer = csv.writer(csvfile)
+    #     if not file_exists:
+    #         writer.writerow(["algo_name", "seed", "env", "total_time_sec"])
+    #     writer.writerow([algo_name, seed, env, total_time])

--- a/cleanrl/c51.py
+++ b/cleanrl/c51.py
@@ -180,7 +180,7 @@ if __name__ == "__main__":
     # TRY NOT TO MODIFY: start the game
     obs, _ = envs.reset(seed=args.seed)
     for global_step in range(args.total_timesteps):
-        tau = max(1.0 * (1 - global_step / args.total_timesteps*0.75), 0.01)
+        tau = max(1.0 * (1 - global_step / args.total_timesteps * 0.75), 0.01)
         logits = q_network.network(torch.Tensor(obs).to(device))
         batch_size = logits.shape[0]
         n_actions = q_network.n
@@ -244,7 +244,11 @@ if __name__ == "__main__":
                     old_val = (old_pmfs * q_network.atoms).sum(1)
                     writer.add_scalar("losses/q_values", old_val.mean().item(), global_step)
                     print("SPS:", int(global_step / (time.time() - start_time)))
-                    writer.add_scalar("charts/SPS", int(global_step / (time.time() - start_time)), global_step)
+                    writer.add_scalar(
+                        "charts/SPS",
+                        int(global_step / (time.time() - start_time)),
+                        global_step,
+                    )
 
                 # optimize the model
                 optimizer.zero_grad()
@@ -283,7 +287,14 @@ if __name__ == "__main__":
 
             repo_name = f"{args.env_id}-{args.exp_name}-seed{args.seed}"
             repo_id = f"{args.hf_entity}/{repo_name}" if args.hf_entity else repo_name
-            push_to_hub(args, episodic_returns, repo_id, "C51", f"runs/{run_name}", f"videos/{run_name}-eval")
+            push_to_hub(
+                args,
+                episodic_returns,
+                repo_id,
+                "C51",
+                f"runs/{run_name}",
+                f"videos/{run_name}-eval",
+            )
 
     envs.close()
     writer.close()

--- a/cleanrl/c51_atari.py
+++ b/cleanrl/c51_atari.py
@@ -205,7 +205,7 @@ if __name__ == "__main__":
     # TRY NOT TO MODIFY: start the game
     obs, _ = envs.reset(seed=args.seed)
     for global_step in range(args.total_timesteps):
-        tau = max(1.0 * (1 - global_step / args.total_timesteps*0.75), 0.01)
+        tau = max(1.0 * (1 - global_step / args.total_timesteps * 0.75), 0.01)
         logits = q_network.network(torch.Tensor(obs).to(device))
         batch_size = logits.shape[0]
         n_actions = q_network.n
@@ -269,7 +269,11 @@ if __name__ == "__main__":
                     old_val = (old_pmfs * q_network.atoms).sum(1)
                     writer.add_scalar("losses/q_values", old_val.mean().item(), global_step)
                     print("SPS:", int(global_step / (time.time() - start_time)))
-                    writer.add_scalar("charts/SPS", int(global_step / (time.time() - start_time)), global_step)
+                    writer.add_scalar(
+                        "charts/SPS",
+                        int(global_step / (time.time() - start_time)),
+                        global_step,
+                    )
 
                 # optimize the model
                 optimizer.zero_grad()
@@ -308,7 +312,14 @@ if __name__ == "__main__":
 
             repo_name = f"{args.env_id}-{args.exp_name}-seed{args.seed}"
             repo_id = f"{args.hf_entity}/{repo_name}" if args.hf_entity else repo_name
-            push_to_hub(args, episodic_returns, repo_id, "C51", f"runs/{run_name}", f"videos/{run_name}-eval")
+            push_to_hub(
+                args,
+                episodic_returns,
+                repo_id,
+                "C51",
+                f"runs/{run_name}",
+                f"videos/{run_name}-eval",
+            )
 
     envs.close()
     writer.close()

--- a/cleanrl/c51_atari_expected_sarsa.py
+++ b/cleanrl/c51_atari_expected_sarsa.py
@@ -1,9 +1,12 @@
-# docs and experiment results can be found at https://docs.cleanrl.dev/rl-algorithms/c51/#c51_ataripy
+# ES-C51: Expected Sarsa Based C51 Distributional Reinforcement Learning Algorithm
+# Implementation for Atari environments
 #
-# MODIFICATION: This version uses softmax action selection instead of epsilon-greedy
-# for fair comparison with ES-C51 algorithm. Referred to as QL-C51 in the paper:
+# This implements the ES-C51 algorithm described in:
 # "ES-C51: Expected Sarsa Based C51 Distributional Reinforcement Learning Algorithm"
 # Authors: Rijul Tandon, Peter Vamplew, Cameron Foale (Neurocomputing, 2024)
+#
+# Key innovation: Uses Expected Sarsa updates with softmax-weighted expectation
+# over all possible next actions, instead of greedy Q-learning updates.
 #
 import os
 import random
@@ -31,61 +34,32 @@ from cleanrl_utils.buffers import ReplayBuffer
 @dataclass
 class Args:
     exp_name: str = os.path.basename(__file__)[: -len(".py")]
-    """the name of this experiment"""
     seed: int = 1
-    """seed of the experiment"""
     torch_deterministic: bool = True
-    """if toggled, `torch.backends.cudnn.deterministic=False`"""
     cuda: bool = True
-    """if toggled, cuda will be enabled by default"""
     track: bool = False
-    """if toggled, this experiment will be tracked with Weights and Biases"""
     wandb_project_name: str = "cleanRL"
-    """the wandb's project name"""
     wandb_entity: str = None
-    """the entity (team) of wandb's project"""
     capture_video: bool = False
-    """whether to capture videos of the agent performances (check out `videos` folder)"""
     save_model: bool = False
-    """whether to save model into the `runs/{run_name}` folder"""
     upload_model: bool = False
-    """whether to upload the saved model to huggingface"""
     hf_entity: str = ""
-    """the user or org name of the model repository from the Hugging Face Hub"""
-
-    # Algorithm specific arguments
     env_id: str = "BreakoutNoFrameskip-v4"
-    """the id of the environment"""
     total_timesteps: int = 10000000
-    """total timesteps of the experiments"""
     learning_rate: float = 2.5e-4
-    """the learning rate of the optimizer"""
     num_envs: int = 1
-    """the number of parallel game environments"""
     n_atoms: int = 51
-    """the number of atoms"""
     v_min: float = -10
-    """the return lower bound"""
     v_max: float = 10
-    """the return upper bound"""
     buffer_size: int = 1000000
-    """the replay memory buffer size"""
     gamma: float = 0.99
-    """the discount factor gamma"""
     target_network_frequency: int = 10000
-    """the timesteps it takes to update the target network"""
     batch_size: int = 32
-    """the batch size of sample from the reply memory"""
     start_e: float = 1
-    """the starting epsilon for exploration"""
     end_e: float = 0.01
-    """the ending epsilon for exploration"""
     exploration_fraction: float = 0.10
-    """the fraction of `total-timesteps` it takes from start-e to go end-e"""
     learning_starts: int = 80000
-    """timestep to start learning"""
     train_frequency: int = 4
-    """the frequency of training"""
 
 
 def make_env(env_id, seed, idx, capture_video, run_name):
@@ -96,7 +70,6 @@ def make_env(env_id, seed, idx, capture_video, run_name):
         else:
             env = gym.make(env_id)
         env = gym.wrappers.RecordEpisodeStatistics(env)
-
         env = NoopResetEnv(env, noop_max=30)
         env = MaxAndSkipEnv(env, skip=4)
         env = EpisodicLifeEnv(env)
@@ -106,16 +79,14 @@ def make_env(env_id, seed, idx, capture_video, run_name):
         env = gym.wrappers.ResizeObservation(env, (84, 84))
         env = gym.wrappers.GrayScaleObservation(env)
         env = gym.wrappers.FrameStack(env, 4)
-
         env.action_space.seed(seed)
         return env
 
     return thunk
 
 
-# ALGO LOGIC: initialize agent here:
 class QNetwork(nn.Module):
-    def __init__(self, env, n_atoms=101, v_min=-100, v_max=100):
+    def __init__(self, env, n_atoms=51, v_min=-10, v_max=10):
         super().__init__()
         self.env = env
         self.n_atoms = n_atoms
@@ -136,7 +107,6 @@ class QNetwork(nn.Module):
 
     def get_action(self, x, action=None):
         logits = self.network(x / 255.0)
-        # probability mass function for each action
         pmfs = torch.softmax(logits.view(len(x), self.n, self.n_atoms), dim=2)
         q_values = (pmfs * self.atoms).sum(2)
         if action is None:
@@ -170,28 +140,19 @@ if __name__ == "__main__":
         "hyperparameters",
         "|param|value|\n|-|-|\n%s" % ("\n".join([f"|{key}|{value}|" for key, value in vars(args).items()])),
     )
-
-    # TRY NOT TO MODIFY: seeding
     random.seed(args.seed)
     np.random.seed(args.seed)
     torch.manual_seed(args.seed)
     torch.backends.cudnn.deterministic = args.torch_deterministic
-
-    print(torch.cuda.is_available())
-    print(torch.cuda.get_device_name(0) if torch.cuda.is_available() else "No GPU")
     device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
-
-    # env setup
     envs = gym.vector.SyncVectorEnv(
         [make_env(args.env_id, args.seed + i, i, args.capture_video, run_name) for i in range(args.num_envs)]
     )
     assert isinstance(envs.single_action_space, gym.spaces.Discrete), "only discrete action space is supported"
-
     q_network = QNetwork(envs, n_atoms=args.n_atoms, v_min=args.v_min, v_max=args.v_max).to(device)
     optimizer = optim.Adam(q_network.parameters(), lr=args.learning_rate, eps=0.01 / args.batch_size)
     target_network = QNetwork(envs, n_atoms=args.n_atoms, v_min=args.v_min, v_max=args.v_max).to(device)
     target_network.load_state_dict(q_network.state_dict())
-
     rb = ReplayBuffer(
         args.buffer_size,
         envs.single_observation_space,
@@ -201,10 +162,9 @@ if __name__ == "__main__":
         handle_timeout_termination=False,
     )
     start_time = time.time()
-
-    # TRY NOT TO MODIFY: start the game
     obs, _ = envs.reset(seed=args.seed)
     for global_step in range(args.total_timesteps):
+        # Decay tau from 1.0 to a small value (e.g., 0.01) over training
         tau = max(1.0 * (1 - global_step / args.total_timesteps*0.75), 0.01)
         logits = q_network.network(torch.Tensor(obs).to(device))
         batch_size = logits.shape[0]
@@ -213,73 +173,64 @@ if __name__ == "__main__":
         atoms = q_network.atoms
         pmfs_all = torch.softmax(logits.view(batch_size, n_actions, n_atoms), dim=2)
         q_values = (pmfs_all * atoms).sum(2)
-        # Use softmax policy for action selection
+        # Use softmax policy for action selection (for both expected sarsa and q-learning)
         policy = torch.softmax(q_values / tau, dim=1)  # [batch_size, n_actions]
         actions = torch.multinomial(policy, 1).squeeze(1).cpu().numpy()
 
-        # TRY NOT TO MODIFY: execute the game and log data.
         next_obs, rewards, terminations, truncations, infos = envs.step(actions)
-
-        # TRY NOT TO MODIFY: record rewards for plotting purposes
         if "final_info" in infos:
             for info in infos["final_info"]:
                 if info and "episode" in info:
                     print(f"global_step={global_step}, episodic_return={info['episode']['r']}")
                     writer.add_scalar("charts/episodic_return", info["episode"]["r"], global_step)
                     writer.add_scalar("charts/episodic_length", info["episode"]["l"], global_step)
-
-        # TRY NOT TO MODIFY: save data to reply buffer; handle `final_observation`
         real_next_obs = next_obs.copy()
         for idx, trunc in enumerate(truncations):
             if trunc:
                 real_next_obs[idx] = infos["final_observation"][idx]
         rb.add(obs, real_next_obs, actions, rewards, terminations, infos)
-
-        # TRY NOT TO MODIFY: CRUCIAL step easy to overlook
         obs = next_obs
-
-        # ALGO LOGIC: training.
         if global_step > args.learning_starts:
             if global_step % args.train_frequency == 0:
                 data = rb.sample(args.batch_size)
                 with torch.no_grad():
-                    _, next_pmfs = target_network.get_action(data.next_observations)
-                    next_atoms = data.rewards + args.gamma * target_network.atoms * (1 - data.dones)
-                    # projection
-                    delta_z = target_network.atoms[1] - target_network.atoms[0]
+                    # Decay tau for TD target calculation
+                    tau = max(1.0 * (1 - global_step / args.total_timesteps*0.75), 0.01)
+                    logits = target_network.network(data.next_observations / 255.0)
+                    batch_size = logits.shape[0]
+                    n_actions = target_network.n
+                    n_atoms = target_network.n_atoms
+                    atoms = target_network.atoms
+                    pmfs_all = torch.softmax(logits.view(batch_size, n_actions, n_atoms), dim=2)
+                    q_values = (pmfs_all * atoms).sum(2)
+                    # Use softmax policy for TD target (expected sarsa)
+                    policy = torch.softmax(q_values / tau, dim=1)  # [batch_size, n_actions]
+                    expected_next_pmfs = (policy.unsqueeze(2) * pmfs_all).sum(1)  # [batch_size, n_atoms]
+                    next_atoms = data.rewards + args.gamma * atoms * (1 - data.dones)
+                    delta_z = atoms[1] - atoms[0]
                     tz = next_atoms.clamp(args.v_min, args.v_max)
-
                     b = (tz - args.v_min) / delta_z
                     l = b.floor().clamp(0, args.n_atoms - 1)
                     u = b.ceil().clamp(0, args.n_atoms - 1)
-                    # (l == u).float() handles the case where bj is exactly an integer
-                    # example bj = 1, then the upper ceiling should be uj= 2, and lj= 1
-                    d_m_l = (u + (l == u).float() - b) * next_pmfs
-                    d_m_u = (b - l) * next_pmfs
-                    target_pmfs = torch.zeros_like(next_pmfs)
+                    d_m_l = (u + (l == u).float() - b) * expected_next_pmfs
+                    d_m_u = (b - l) * expected_next_pmfs
+                    target_pmfs = torch.zeros_like(expected_next_pmfs)
                     for i in range(target_pmfs.size(0)):
                         target_pmfs[i].index_add_(0, l[i].long(), d_m_l[i])
                         target_pmfs[i].index_add_(0, u[i].long(), d_m_u[i])
-
                 _, old_pmfs = q_network.get_action(data.observations, data.actions.flatten())
                 loss = (-(target_pmfs * old_pmfs.clamp(min=1e-5, max=1 - 1e-5).log()).sum(-1)).mean()
-
                 if global_step % 100 == 0:
                     writer.add_scalar("losses/loss", loss.item(), global_step)
                     old_val = (old_pmfs * q_network.atoms).sum(1)
                     writer.add_scalar("losses/q_values", old_val.mean().item(), global_step)
                     print("SPS:", int(global_step / (time.time() - start_time)))
                     writer.add_scalar("charts/SPS", int(global_step / (time.time() - start_time)), global_step)
-
-                # optimize the model
                 optimizer.zero_grad()
                 loss.backward()
                 optimizer.step()
-
-            # update target network
             if global_step % args.target_network_frequency == 0:
                 target_network.load_state_dict(q_network.state_dict())
-
     if args.save_model:
         model_path = f"runs/{run_name}/{args.exp_name}.cleanrl_model"
         model_data = {
@@ -302,16 +253,16 @@ if __name__ == "__main__":
         )
         for idx, episodic_return in enumerate(episodic_returns):
             writer.add_scalar("eval/episodic_return", episodic_return, idx)
-
         if args.upload_model:
             from cleanrl_utils.huggingface import push_to_hub
 
             repo_name = f"{args.env_id}-{args.exp_name}-seed{args.seed}"
             repo_id = f"{args.hf_entity}/{repo_name}" if args.hf_entity else repo_name
             push_to_hub(args, episodic_returns, repo_id, "C51", f"runs/{run_name}", f"videos/{run_name}-eval")
-
     envs.close()
     writer.close()
+
+    # Log runtime to CSV
     # import csv
     # runtime_csv = os.path.join(os.path.dirname(__file__), "run_time_comparison.csv")
     # total_time = time.time() - start_time

--- a/cleanrl/c51_atari_expected_sarsa.py
+++ b/cleanrl/c51_atari_expected_sarsa.py
@@ -165,7 +165,7 @@ if __name__ == "__main__":
     obs, _ = envs.reset(seed=args.seed)
     for global_step in range(args.total_timesteps):
         # Decay tau from 1.0 to a small value (e.g., 0.01) over training
-        tau = max(1.0 * (1 - global_step / args.total_timesteps*0.75), 0.01)
+        tau = max(1.0 * (1 - global_step / args.total_timesteps * 0.75), 0.01)
         logits = q_network.network(torch.Tensor(obs).to(device))
         batch_size = logits.shape[0]
         n_actions = q_network.n
@@ -195,7 +195,7 @@ if __name__ == "__main__":
                 data = rb.sample(args.batch_size)
                 with torch.no_grad():
                     # Decay tau for TD target calculation
-                    tau = max(1.0 * (1 - global_step / args.total_timesteps*0.75), 0.01)
+                    tau = max(1.0 * (1 - global_step / args.total_timesteps * 0.75), 0.01)
                     logits = target_network.network(data.next_observations / 255.0)
                     batch_size = logits.shape[0]
                     n_actions = target_network.n
@@ -225,7 +225,11 @@ if __name__ == "__main__":
                     old_val = (old_pmfs * q_network.atoms).sum(1)
                     writer.add_scalar("losses/q_values", old_val.mean().item(), global_step)
                     print("SPS:", int(global_step / (time.time() - start_time)))
-                    writer.add_scalar("charts/SPS", int(global_step / (time.time() - start_time)), global_step)
+                    writer.add_scalar(
+                        "charts/SPS",
+                        int(global_step / (time.time() - start_time)),
+                        global_step,
+                    )
                 optimizer.zero_grad()
                 loss.backward()
                 optimizer.step()
@@ -258,7 +262,14 @@ if __name__ == "__main__":
 
             repo_name = f"{args.env_id}-{args.exp_name}-seed{args.seed}"
             repo_id = f"{args.hf_entity}/{repo_name}" if args.hf_entity else repo_name
-            push_to_hub(args, episodic_returns, repo_id, "C51", f"runs/{run_name}", f"videos/{run_name}-eval")
+            push_to_hub(
+                args,
+                episodic_returns,
+                repo_id,
+                "C51",
+                f"runs/{run_name}",
+                f"videos/{run_name}-eval",
+            )
     envs.close()
     writer.close()
 

--- a/cleanrl/c51_expected_sarsa.py
+++ b/cleanrl/c51_expected_sarsa.py
@@ -172,7 +172,7 @@ if __name__ == "__main__":
     obs, _ = envs.reset(seed=args.seed)
     for global_step in range(args.total_timesteps):
         # Decay tau from 1.0 to a small value (e.g., 0.01) over training
-        tau = max(1.0 * (1 - global_step / args.total_timesteps*0.75), 0.01)
+        tau = max(1.0 * (1 - global_step / args.total_timesteps * 0.75), 0.01)
         logits = q_network.network(torch.Tensor(obs).to(device))
         batch_size = logits.shape[0]
         n_actions = q_network.n
@@ -202,7 +202,7 @@ if __name__ == "__main__":
                 data = rb.sample(args.batch_size)
                 with torch.no_grad():
                     # Decay tau for TD target calculation
-                    tau = max(1.0 * (1 - global_step / args.total_timesteps*0.75), 0.01)
+                    tau = max(1.0 * (1 - global_step / args.total_timesteps * 0.75), 0.01)
                     logits = target_network.network(data.next_observations)
                     batch_size = logits.shape[0]
                     n_actions = target_network.n
@@ -232,7 +232,11 @@ if __name__ == "__main__":
                     old_val = (old_pmfs * q_network.atoms).sum(1)
                     writer.add_scalar("losses/q_values", old_val.mean().item(), global_step)
                     print("SPS:", int(global_step / (time.time() - start_time)))
-                    writer.add_scalar("charts/SPS", int(global_step / (time.time() - start_time)), global_step)
+                    writer.add_scalar(
+                        "charts/SPS",
+                        int(global_step / (time.time() - start_time)),
+                        global_step,
+                    )
                 optimizer.zero_grad()
                 loss.backward()
                 optimizer.step()
@@ -265,7 +269,14 @@ if __name__ == "__main__":
 
             repo_name = f"{args.env_id}-{args.exp_name}-seed{args.seed}"
             repo_id = f"{args.hf_entity}/{repo_name}" if args.hf_entity else repo_name
-            push_to_hub(args, episodic_returns, repo_id, "C51", f"runs/{run_name}", f"videos/{run_name}-eval")
+            push_to_hub(
+                args,
+                episodic_returns,
+                repo_id,
+                "C51",
+                f"runs/{run_name}",
+                f"videos/{run_name}-eval",
+            )
     envs.close()
     writer.close()
 

--- a/cleanrl/c51_expected_sarsa.py
+++ b/cleanrl/c51_expected_sarsa.py
@@ -1,9 +1,12 @@
-# docs and experiment results can be found at https://docs.cleanrl.dev/rl-algorithms/c51/#c51_ataripy
+# ES-C51: Expected Sarsa Based C51 Distributional Reinforcement Learning Algorithm
+# Implementation for Gym environments
 #
-# MODIFICATION: This version uses softmax action selection instead of epsilon-greedy
-# for fair comparison with ES-C51 algorithm. Referred to as QL-C51 in the paper:
+# This implements the ES-C51 algorithm described in:
 # "ES-C51: Expected Sarsa Based C51 Distributional Reinforcement Learning Algorithm"
 # Authors: Rijul Tandon, Peter Vamplew, Cameron Foale (Neurocomputing, 2024)
+#
+# Key innovation: Uses Expected Sarsa updates with softmax-weighted expectation
+# over all possible next actions, instead of greedy Q-learning updates.
 #
 import os
 import random
@@ -18,13 +21,6 @@ import torch.optim as optim
 import tyro
 from torch.utils.tensorboard import SummaryWriter
 
-from cleanrl_utils.atari_wrappers import (
-    ClipRewardEnv,
-    EpisodicLifeEnv,
-    FireResetEnv,
-    MaxAndSkipEnv,
-    NoopResetEnv,
-)
 from cleanrl_utils.buffers import ReplayBuffer
 
 
@@ -54,37 +50,37 @@ class Args:
     """the user or org name of the model repository from the Hugging Face Hub"""
 
     # Algorithm specific arguments
-    env_id: str = "BreakoutNoFrameskip-v4"
+    env_id: str = "CartPole-v1"
     """the id of the environment"""
-    total_timesteps: int = 10000000
+    total_timesteps: int = 500000
     """total timesteps of the experiments"""
     learning_rate: float = 2.5e-4
     """the learning rate of the optimizer"""
     num_envs: int = 1
     """the number of parallel game environments"""
-    n_atoms: int = 51
+    n_atoms: int = 101
     """the number of atoms"""
-    v_min: float = -10
+    v_min: float = -100
     """the return lower bound"""
-    v_max: float = 10
+    v_max: float = 100
     """the return upper bound"""
-    buffer_size: int = 1000000
+    buffer_size: int = 10000
     """the replay memory buffer size"""
     gamma: float = 0.99
     """the discount factor gamma"""
-    target_network_frequency: int = 10000
+    target_network_frequency: int = 500
     """the timesteps it takes to update the target network"""
-    batch_size: int = 32
+    batch_size: int = 128
     """the batch size of sample from the reply memory"""
     start_e: float = 1
     """the starting epsilon for exploration"""
-    end_e: float = 0.01
+    end_e: float = 0.05
     """the ending epsilon for exploration"""
-    exploration_fraction: float = 0.10
+    exploration_fraction: float = 0.5
     """the fraction of `total-timesteps` it takes from start-e to go end-e"""
-    learning_starts: int = 80000
+    learning_starts: int = 10000
     """timestep to start learning"""
-    train_frequency: int = 4
+    train_frequency: int = 10
     """the frequency of training"""
 
 
@@ -96,24 +92,12 @@ def make_env(env_id, seed, idx, capture_video, run_name):
         else:
             env = gym.make(env_id)
         env = gym.wrappers.RecordEpisodeStatistics(env)
-
-        env = NoopResetEnv(env, noop_max=30)
-        env = MaxAndSkipEnv(env, skip=4)
-        env = EpisodicLifeEnv(env)
-        if "FIRE" in env.unwrapped.get_action_meanings():
-            env = FireResetEnv(env)
-        env = ClipRewardEnv(env)
-        env = gym.wrappers.ResizeObservation(env, (84, 84))
-        env = gym.wrappers.GrayScaleObservation(env)
-        env = gym.wrappers.FrameStack(env, 4)
-
         env.action_space.seed(seed)
         return env
 
     return thunk
 
 
-# ALGO LOGIC: initialize agent here:
 class QNetwork(nn.Module):
     def __init__(self, env, n_atoms=101, v_min=-100, v_max=100):
         super().__init__()
@@ -122,21 +106,15 @@ class QNetwork(nn.Module):
         self.register_buffer("atoms", torch.linspace(v_min, v_max, steps=n_atoms))
         self.n = env.single_action_space.n
         self.network = nn.Sequential(
-            nn.Conv2d(4, 32, 8, stride=4),
+            nn.Linear(np.array(env.single_observation_space.shape).prod(), 120),
             nn.ReLU(),
-            nn.Conv2d(32, 64, 4, stride=2),
+            nn.Linear(120, 84),
             nn.ReLU(),
-            nn.Conv2d(64, 64, 3, stride=1),
-            nn.ReLU(),
-            nn.Flatten(),
-            nn.Linear(3136, 512),
-            nn.ReLU(),
-            nn.Linear(512, self.n * n_atoms),
+            nn.Linear(84, self.n * n_atoms),
         )
 
     def get_action(self, x, action=None):
-        logits = self.network(x / 255.0)
-        # probability mass function for each action
+        logits = self.network(x)
         pmfs = torch.softmax(logits.view(len(x), self.n, self.n_atoms), dim=2)
         q_values = (pmfs * self.atoms).sum(2)
         if action is None:
@@ -170,41 +148,30 @@ if __name__ == "__main__":
         "hyperparameters",
         "|param|value|\n|-|-|\n%s" % ("\n".join([f"|{key}|{value}|" for key, value in vars(args).items()])),
     )
-
-    # TRY NOT TO MODIFY: seeding
     random.seed(args.seed)
     np.random.seed(args.seed)
     torch.manual_seed(args.seed)
     torch.backends.cudnn.deterministic = args.torch_deterministic
-
-    print(torch.cuda.is_available())
-    print(torch.cuda.get_device_name(0) if torch.cuda.is_available() else "No GPU")
     device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
-
-    # env setup
     envs = gym.vector.SyncVectorEnv(
         [make_env(args.env_id, args.seed + i, i, args.capture_video, run_name) for i in range(args.num_envs)]
     )
     assert isinstance(envs.single_action_space, gym.spaces.Discrete), "only discrete action space is supported"
-
     q_network = QNetwork(envs, n_atoms=args.n_atoms, v_min=args.v_min, v_max=args.v_max).to(device)
     optimizer = optim.Adam(q_network.parameters(), lr=args.learning_rate, eps=0.01 / args.batch_size)
     target_network = QNetwork(envs, n_atoms=args.n_atoms, v_min=args.v_min, v_max=args.v_max).to(device)
     target_network.load_state_dict(q_network.state_dict())
-
     rb = ReplayBuffer(
         args.buffer_size,
         envs.single_observation_space,
         envs.single_action_space,
         device,
-        optimize_memory_usage=True,
         handle_timeout_termination=False,
     )
     start_time = time.time()
-
-    # TRY NOT TO MODIFY: start the game
     obs, _ = envs.reset(seed=args.seed)
     for global_step in range(args.total_timesteps):
+        # Decay tau from 1.0 to a small value (e.g., 0.01) over training
         tau = max(1.0 * (1 - global_step / args.total_timesteps*0.75), 0.01)
         logits = q_network.network(torch.Tensor(obs).to(device))
         batch_size = logits.shape[0]
@@ -213,73 +180,64 @@ if __name__ == "__main__":
         atoms = q_network.atoms
         pmfs_all = torch.softmax(logits.view(batch_size, n_actions, n_atoms), dim=2)
         q_values = (pmfs_all * atoms).sum(2)
-        # Use softmax policy for action selection
+        # Use softmax policy for action selection (for both expected sarsa and q-learning)
         policy = torch.softmax(q_values / tau, dim=1)  # [batch_size, n_actions]
         actions = torch.multinomial(policy, 1).squeeze(1).cpu().numpy()
 
-        # TRY NOT TO MODIFY: execute the game and log data.
         next_obs, rewards, terminations, truncations, infos = envs.step(actions)
-
-        # TRY NOT TO MODIFY: record rewards for plotting purposes
         if "final_info" in infos:
             for info in infos["final_info"]:
                 if info and "episode" in info:
                     print(f"global_step={global_step}, episodic_return={info['episode']['r']}")
                     writer.add_scalar("charts/episodic_return", info["episode"]["r"], global_step)
                     writer.add_scalar("charts/episodic_length", info["episode"]["l"], global_step)
-
-        # TRY NOT TO MODIFY: save data to reply buffer; handle `final_observation`
         real_next_obs = next_obs.copy()
         for idx, trunc in enumerate(truncations):
             if trunc:
                 real_next_obs[idx] = infos["final_observation"][idx]
         rb.add(obs, real_next_obs, actions, rewards, terminations, infos)
-
-        # TRY NOT TO MODIFY: CRUCIAL step easy to overlook
         obs = next_obs
-
-        # ALGO LOGIC: training.
         if global_step > args.learning_starts:
             if global_step % args.train_frequency == 0:
                 data = rb.sample(args.batch_size)
                 with torch.no_grad():
-                    _, next_pmfs = target_network.get_action(data.next_observations)
-                    next_atoms = data.rewards + args.gamma * target_network.atoms * (1 - data.dones)
-                    # projection
-                    delta_z = target_network.atoms[1] - target_network.atoms[0]
+                    # Decay tau for TD target calculation
+                    tau = max(1.0 * (1 - global_step / args.total_timesteps*0.75), 0.01)
+                    logits = target_network.network(data.next_observations)
+                    batch_size = logits.shape[0]
+                    n_actions = target_network.n
+                    n_atoms = target_network.n_atoms
+                    atoms = target_network.atoms
+                    pmfs_all = torch.softmax(logits.view(batch_size, n_actions, n_atoms), dim=2)
+                    q_values = (pmfs_all * atoms).sum(2)
+                    # Use softmax policy for TD target (expected sarsa)
+                    policy = torch.softmax(q_values / tau, dim=1)  # [batch_size, n_actions]
+                    expected_next_pmfs = (policy.unsqueeze(2) * pmfs_all).sum(1)  # [batch_size, n_atoms]
+                    next_atoms = data.rewards + args.gamma * atoms * (1 - data.dones)
+                    delta_z = atoms[1] - atoms[0]
                     tz = next_atoms.clamp(args.v_min, args.v_max)
-
                     b = (tz - args.v_min) / delta_z
                     l = b.floor().clamp(0, args.n_atoms - 1)
                     u = b.ceil().clamp(0, args.n_atoms - 1)
-                    # (l == u).float() handles the case where bj is exactly an integer
-                    # example bj = 1, then the upper ceiling should be uj= 2, and lj= 1
-                    d_m_l = (u + (l == u).float() - b) * next_pmfs
-                    d_m_u = (b - l) * next_pmfs
-                    target_pmfs = torch.zeros_like(next_pmfs)
+                    d_m_l = (u + (l == u).float() - b) * expected_next_pmfs
+                    d_m_u = (b - l) * expected_next_pmfs
+                    target_pmfs = torch.zeros_like(expected_next_pmfs)
                     for i in range(target_pmfs.size(0)):
                         target_pmfs[i].index_add_(0, l[i].long(), d_m_l[i])
                         target_pmfs[i].index_add_(0, u[i].long(), d_m_u[i])
-
                 _, old_pmfs = q_network.get_action(data.observations, data.actions.flatten())
                 loss = (-(target_pmfs * old_pmfs.clamp(min=1e-5, max=1 - 1e-5).log()).sum(-1)).mean()
-
                 if global_step % 100 == 0:
                     writer.add_scalar("losses/loss", loss.item(), global_step)
                     old_val = (old_pmfs * q_network.atoms).sum(1)
                     writer.add_scalar("losses/q_values", old_val.mean().item(), global_step)
                     print("SPS:", int(global_step / (time.time() - start_time)))
                     writer.add_scalar("charts/SPS", int(global_step / (time.time() - start_time)), global_step)
-
-                # optimize the model
                 optimizer.zero_grad()
                 loss.backward()
                 optimizer.step()
-
-            # update target network
             if global_step % args.target_network_frequency == 0:
                 target_network.load_state_dict(q_network.state_dict())
-
     if args.save_model:
         model_path = f"runs/{run_name}/{args.exp_name}.cleanrl_model"
         model_data = {
@@ -302,16 +260,16 @@ if __name__ == "__main__":
         )
         for idx, episodic_return in enumerate(episodic_returns):
             writer.add_scalar("eval/episodic_return", episodic_return, idx)
-
         if args.upload_model:
             from cleanrl_utils.huggingface import push_to_hub
 
             repo_name = f"{args.env_id}-{args.exp_name}-seed{args.seed}"
             repo_id = f"{args.hf_entity}/{repo_name}" if args.hf_entity else repo_name
             push_to_hub(args, episodic_returns, repo_id, "C51", f"runs/{run_name}", f"videos/{run_name}-eval")
-
     envs.close()
     writer.close()
+
+    # Log runtime to CSV
     # import csv
     # runtime_csv = os.path.join(os.path.dirname(__file__), "run_time_comparison.csv")
     # total_time = time.time() - start_time


### PR DESCRIPTION
- Add c51_expected_sarsa.py: ES-C51 implementation for classic control environments
- Add c51_atari_expected_sarsa.py: ES-C51 implementation for Atari environments
- Modify c51.py: Update to use softmax action selection for fair comparison (QL-C51)
- Modify c51_atari.py: Update to use softmax action selection for fair comparison (QL-C51)
- Add ES_C51_README.md: Comprehensive documentation for ES-C51 algorithm

ES-C51 uses Expected SARSA updates with softmax-weighted expectation over all possible next actions, instead of greedy Q-learning updates. This provides better exploration and more stable learning in distributional RL settings.

Based on paper: 'ES-C51: Expected Sarsa Based C51 Distributional Reinforcement Learning Algorithm'
Authors: Rijul Tandon, Peter Vamplew, Cameron Foale (Neurocomputing, 2024)

## Description
<!--- Provide a general summary of your changes in here-->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [ ] New algorithm
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've read the [CONTRIBUTION](https://docs.cleanrl.dev/contribution/) guide (**required**).
- [ ] I have ensured `pre-commit run --all-files` passes (**required**).
- [ ] I have updated the tests accordingly (if applicable).
- [ ] I have updated the documentation and previewed the changes via `mkdocs serve`.
    - [ ] I have explained note-worthy implementation details.
    - [ ] I have explained the logged metrics.
    - [ ] I have added links to the original paper and related papers.

If you need to run benchmark experiments for a performance-impacting changes:

- [ ] I have contacted @vwxyzjn to obtain access to the [openrlbenchmark W&B team](https://wandb.ai/openrlbenchmark).
- [ ] I have used the [benchmark utility](/get-started/benchmark-utility/) to submit the tracked experiments to the [openrlbenchmark/cleanrl](https://wandb.ai/openrlbenchmark/cleanrl) W&B project, optionally with `--capture_video`.
- [ ] I have performed RLops with `python -m openrlbenchmark.rlops`.
    - For new feature or bug fix:
        - [ ] I have used the RLops utility to understand the performance impact of the changes and confirmed there is no regression.
    - For new algorithm:
        - [ ] I have created a table comparing my results against those from reputable sources (i.e., the original paper or other reference implementation).
    - [ ] I have added the learning curves generated by the `python -m openrlbenchmark.rlops` utility to the documentation.
    - [ ] I have added links to the tracked experiments in W&B, generated by `python -m openrlbenchmark.rlops ....your_args... --report`,  to the documentation.

