### PR TITLE
fix: use single_action_space in DDPG for vectorized envs

### DIFF
--- a/cleanrl/ddpg_continuous_action.py
+++ b/cleanrl/ddpg_continuous_action.py
@@ -102,10 +102,10 @@ class Actor(nn.Module):
         self.fc_mu = nn.Linear(256, np.prod(env.single_action_space.shape))
         # action rescaling
         self.register_buffer(
-            "action_scale", torch.tensor((env.action_space.high - env.action_space.low) / 2.0, dtype=torch.float32)
+            "action_scale", torch.tensor((env.single_action_space.high - env.single_action_space.low) / 2.0, dtype=torch.float32)
         )
         self.register_buffer(
-            "action_bias", torch.tensor((env.action_space.high + env.action_space.low) / 2.0, dtype=torch.float32)
+            "action_bias", torch.tensor((env.single_action_space.high + env.single_action_space.low) / 2.0, dtype=torch.float32)
         )
 
     def forward(self, x):


### PR DESCRIPTION
## Bug
DDPG uses `envs.action_space` instead of `envs.single_action_space` when constructing networks, which gives incorrect shapes in vectorized environments.

## Fix
Changed to `single_action_space` to get the correct per-environment action dimensions.