### PR TITLE
Security: Command injection via unsanitized Docker tag in shell command

### DIFF
--- a/cleanrl_utils/docker_build.py
+++ b/cleanrl_utils/docker_build.py
@@ -6,7 +6,6 @@ parser.add_argument("--tag", type=str, default="cleanrl:latest", help="the name 
 args = parser.parse_args()
 
 subprocess.run(
-    f"docker build -t {args.tag} .",
-    shell=True,
+    ["docker", "build", "-t", args.tag, "."],
     check=True,
 )

--- a/cleanrl_utils/submit_exp.py
+++ b/cleanrl_utils/submit_exp.py
@@ -51,8 +51,7 @@ args = parser.parse_args()
 if args.build:
     output_type_str = "--output=type=registry" if args.push else "--output=type=docker"
     subprocess.run(
-        f"docker buildx build {output_type_str} --platform {args.archs} -t {args.docker_tag} .",
-        shell=True,
+        ["docker", "buildx", "build", output_type_str, "--platform", args.archs, "-t", args.docker_tag, "."],
         check=True,
     )
 


### PR DESCRIPTION
## Problem

The script builds a shell command using an untrusted CLI argument (`--tag`) and executes it with `shell=True`. An attacker can inject additional shell metacharacters (e.g., `--tag "x; rm -rf /"`) to run arbitrary commands on the host.

**Severity**: `high`
**File**: `cleanrl_utils/docker_build.py`

## Solution

Avoid `shell=True` and pass arguments as a list: `subprocess.run(["docker", "build", "-t", args.tag, "."], check=True)`. Optionally validate `args.tag` against a strict Docker tag regex before execution.

## Changes

- `cleanrl_utils/docker_build.py` (modified)
- `cleanrl_utils/submit_exp.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
