### PR TITLE
docs: fix PPO title, variable typo, baselines URL, and PQN doc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ You may also use a prebuilt development environment hosted in Gitpod:
 
 | Algorithm      | Variants Implemented |
 | ----------- | ----------- |
-| ✅ [Proximal Policy Gradient (PPO)](https://arxiv.org/pdf/1707.06347.pdf)  |  [`ppo.py`](https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/ppo.py),   [docs](https://docs.cleanrl.dev/rl-algorithms/ppo/#ppopy) |
+| ✅ [Proximal Policy Optimization (PPO)](https://arxiv.org/pdf/1707.06347.pdf)  |  [`ppo.py`](https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/ppo.py),   [docs](https://docs.cleanrl.dev/rl-algorithms/ppo/#ppopy) |
 | |  [`ppo_atari.py`](https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/ppo_atari.py),   [docs](https://docs.cleanrl.dev/rl-algorithms/ppo/#ppo_ataripy)
 | |  [`ppo_continuous_action.py`](https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/ppo_continuous_action.py),   [docs](https://docs.cleanrl.dev/rl-algorithms/ppo/#ppo_continuous_actionpy)
 | |  [`ppo_atari_lstm.py`](https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/ppo_atari_lstm.py),   [docs](https://docs.cleanrl.dev/rl-algorithms/ppo/#ppo_atari_lstmpy)

--- a/docs/blog/posts/cleanrl-v1.md
+++ b/docs/blog/posts/cleanrl-v1.md
@@ -35,7 +35,7 @@ Here is a list of the algorithm variants and their documentation:
 
 | Algorithm      | Variants Implemented |
 | ----------- | ----------- |
-| ✅ [Proximal Policy Gradient (PPO)](https://arxiv.org/pdf/1707.06347.pdf)  | :material-github: [`ppo.py`](https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/ppo.py),  :material-file-document: [docs](/rl-algorithms/ppo/#ppopy) |
+| ✅ [Proximal Policy Optimization (PPO)](https://arxiv.org/pdf/1707.06347.pdf)  | :material-github: [`ppo.py`](https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/ppo.py),  :material-file-document: [docs](/rl-algorithms/ppo/#ppopy) |
 | | :material-github: [`ppo_atari.py`](https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/ppo_atari.py),  :material-file-document: [docs](/rl-algorithms/ppo/#ppo_ataripy)
 | | :material-github: [`ppo_continuous_action.py`](https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/ppo_continuous_action.py),  :material-file-document: [docs](/rl-algorithms/ppo/#ppo_continuous_actionpy)
 | | :material-github: [`ppo_atari_lstm.py`](https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/ppo_atari_lstm.py),  :material-file-document: [docs](/rl-algorithms/ppo/#ppo_atari_lstmpy)

--- a/docs/rl-algorithms/overview.md
+++ b/docs/rl-algorithms/overview.md
@@ -2,7 +2,7 @@
 
 | Algorithm      | Variants Implemented |
 | ----------- | ----------- |
-| ✅ [Proximal Policy Gradient (PPO)](https://arxiv.org/pdf/1707.06347.pdf)  | :material-github: [`ppo.py`](https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/ppo.py),  :material-file-document: [docs](/rl-algorithms/ppo/#ppopy) |
+| ✅ [Proximal Policy Optimization (PPO)](https://arxiv.org/pdf/1707.06347.pdf)  | :material-github: [`ppo.py`](https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/ppo.py),  :material-file-document: [docs](/rl-algorithms/ppo/#ppopy) |
 | | :material-github: [`ppo_atari.py`](https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/ppo_atari.py),  :material-file-document: [docs](/rl-algorithms/ppo/#ppo_ataripy)
 | | :material-github: [`ppo_continuous_action.py`](https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/ppo_continuous_action.py),  :material-file-document: [docs](/rl-algorithms/ppo/#ppo_continuous_actionpy)
 | | :material-github: [`ppo_atari_lstm.py`](https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/ppo_atari_lstm.py),  :material-file-document: [docs](/rl-algorithms/ppo/#ppo_atari_lstmpy)

--- a/docs/rl-algorithms/ppg.md
+++ b/docs/rl-algorithms/ppg.md
@@ -59,7 +59,7 @@ Same as PPO:
 * `losses/policy_loss`: the mean policy loss across all data points
 * `losses/entropy`: the mean entropy value across all data points
 * `losses/old_approx_kl`: the approximate Kullback–Leibler divergence, measured by `(-logratio).mean()`, which corresponds to the k1 estimator in John Schulman’s blog post on [approximating KL](http://joschu.net/blog/kl-approx.html)
-* `losses/approx_kl`: better alternative to `olad_approx_kl` measured by `(logratio.exp() - 1) - logratio`, which corresponds to the k3 estimator in [approximating KL](http://joschu.net/blog/kl-approx.html)
+* `losses/approx_kl`: better alternative to `old_approx_kl` measured by `(logratio.exp() - 1) - logratio`, which corresponds to the k3 estimator in [approximating KL](http://joschu.net/blog/kl-approx.html)
 * `losses/clipfrac`: the fraction of the training data that triggered the clipped objective
 * `losses/explained_variance`: the explained variance for the value function
 

--- a/docs/rl-algorithms/ppo-rnd.md
+++ b/docs/rl-algorithms/ppo-rnd.md
@@ -3,7 +3,7 @@
 
 ## Overview
 
-RND is an exploration bonus for RL methods that's easy to implement and enables significant progress in some hard exploration Atari games such as Montezuma's Revenge. We use [Proximal Policy Gradient](/rl-algorithms/ppo/#ppopy) as our RL method as used by original paper's [implementation](https://github.com/openai/random-network-distillation)
+RND is an exploration bonus for RL methods that's easy to implement and enables significant progress in some hard exploration Atari games such as Montezuma's Revenge. We use [Proximal Policy Optimization](/rl-algorithms/ppo/#ppopy) as our RL method as used by original paper's [implementation](https://github.com/openai/random-network-distillation)
 
 
 Original paper: 

--- a/docs/rl-algorithms/ppo-trxl.md
+++ b/docs/rl-algorithms/ppo-trxl.md
@@ -75,7 +75,7 @@ As the recommended way, the requirements default to PyTorch's CUDA packages.
 * `losses/reconstruction_loss`: the mean observation reconstruction loss value across all data points
 * `losses/loss`: the mean of all summed losses across all data points
 * `losses/old_approx_kl`: the approximate Kullback–Leibler divergence, measured by `(-logratio).mean()`, which corresponds to the k1 estimator in John Schulman’s blog post on [approximating KL](http://joschu.net/blog/kl-approx.html)
-* `losses/approx_kl`: better alternative to `olad_approx_kl` measured by `(logratio.exp() - 1) - logratio`, which corresponds to the k3 estimator in [approximating KL](http://joschu.net/blog/kl-approx.html)
+* `losses/approx_kl`: better alternative to `old_approx_kl` measured by `(logratio.exp() - 1) - logratio`, which corresponds to the k3 estimator in [approximating KL](http://joschu.net/blog/kl-approx.html)
 * `losses/clipfrac`: the fraction of the training data that triggered the clipped objective
 * `losses/explained_variance`: the explained variance for the value function
 

--- a/docs/rl-algorithms/ppo.md
+++ b/docs/rl-algorithms/ppo.md
@@ -1,4 +1,4 @@
-# Proximal Policy Gradient (PPO)
+# Proximal Policy Optimization (PPO)
 
 
 ## Overview
@@ -73,7 +73,7 @@ Running `python cleanrl/ppo.py` will automatically record various metrics such a
 * `losses/policy_loss`: the mean policy loss across all data points
 * `losses/entropy`: the mean entropy value across all data points
 * `losses/old_approx_kl`: the approximate Kullback–Leibler divergence, measured by `(-logratio).mean()`, which corresponds to the k1 estimator in John Schulman’s blog post on [approximating KL](http://joschu.net/blog/kl-approx.html)
-* `losses/approx_kl`: better alternative to `olad_approx_kl` measured by `(logratio.exp() - 1) - logratio`, which corresponds to the k3 estimator in [approximating KL](http://joschu.net/blog/kl-approx.html)
+* `losses/approx_kl`: better alternative to `old_approx_kl` measured by `(logratio.exp() - 1) - logratio`, which corresponds to the k3 estimator in [approximating KL](http://joschu.net/blog/kl-approx.html)
 * `losses/clipfrac`: the fraction of the training data that triggered the clipped objective
 * `losses/explained_variance`: the explained variance for the value function
 
@@ -104,9 +104,9 @@ To run benchmark experiments, see :material-github: [benchmark/ppo.sh](https://g
 --8<-- "benchmark/ppo.sh:3:8"
 ```
 
-Below are the average episodic returns for `ppo.py`. To ensure the quality of the implementation, we compared the results against `openai/baselies`' PPO.
+Below are the average episodic returns for `ppo.py`. To ensure the quality of the implementation, we compared the results against `openai/baselines`' PPO.
 
-| Environment      | `ppo.py` | `openai/baselies`' PPO (Huang et al., 2022)[^1]
+| Environment      | `ppo.py` | `openai/baselines`' PPO (Huang et al., 2022)[^1]
 | ----------- | ----------- | ----------- |
 | CartPole-v1      | 490.04 ± 6.12     |497.54 ± 4.02  |
 | Acrobot-v1       | -86.36 ± 1.32     |  -81.82 ± 5.58 |
@@ -192,9 +192,9 @@ To run benchmark experiments, see :material-github: [benchmark/ppo.sh](https://g
 ```
 
 
-Below are the average episodic returns for `ppo_atari.py`. To ensure the quality of the implementation, we compared the results against `openai/baselies`' PPO.
+Below are the average episodic returns for `ppo_atari.py`. To ensure the quality of the implementation, we compared the results against `openai/baselines`' PPO.
 
-| Environment      | `ppo_atari.py` | `openai/baselies`' PPO (Huang et al., 2022)[^1]
+| Environment      | `ppo_atari.py` | `openai/baselines`' PPO (Huang et al., 2022)[^1]
 | ----------- | ----------- | ----------- |
 | BreakoutNoFrameskip-v4      | 414.66 ± 28.09     | 406.57 ± 31.554  |
 | PongNoFrameskip-v4   | 20.36 ± 0.20    |  20.512 ± 0.50 |
@@ -460,10 +460,10 @@ To run benchmark experiments, see :material-github: [benchmark/ppo.sh](https://g
 --8<-- "benchmark/ppo.sh:47:52"
 ```
 
-Below are the average episodic returns for `ppo_atari_lstm.py`. To ensure the quality of the implementation, we compared the results against `openai/baselies`' PPO.
+Below are the average episodic returns for `ppo_atari_lstm.py`. To ensure the quality of the implementation, we compared the results against `openai/baselines`' PPO.
 
 
-| Environment      | `ppo_atari_lstm.py` | `openai/baselies`' PPO (Huang et al., 2022)[^1]
+| Environment      | `ppo_atari_lstm.py` | `openai/baselines`' PPO (Huang et al., 2022)[^1]
 | ----------- | ----------- | ----------- |
 | BreakoutNoFrameskip-v4      | 128.92 ± 31.10    | 138.98 ± 50.76  |
 | PongNoFrameskip-v4   | 19.78 ± 1.58    | 19.79 ± 0.67 |
@@ -815,9 +815,9 @@ We try to match the default setting in [openai/train-procgen](https://github.com
 1. Reward scaling and reward clipping is used
 
 
-Below are the average episodic returns for `ppo_procgen.py`. To ensure the quality of the implementation, we compared the results against `openai/baselies`' PPO.
+Below are the average episodic returns for `ppo_procgen.py`. To ensure the quality of the implementation, we compared the results against `openai/baselines`' PPO.
 
-| Environment      | `ppo_procgen.py` | `openai/baselies`' PPO (Huang et al., 2022)[^1]
+| Environment      | `ppo_procgen.py` | `openai/baselines`' PPO (Huang et al., 2022)[^1]
 | ----------- | ----------- | ----------- |
 | StarPilot (easy)      | 30.99 ± 1.96      | 33.97 ± 7.86  |
 | BossFight (easy)   | 8.85 ± 0.33    |  9.35 ± 2.04 |

--- a/docs/rl-algorithms/pqn.md
+++ b/docs/rl-algorithms/pqn.md
@@ -247,7 +247,7 @@ See [related docs](/rl-algorithms/pqn/#explanation-of-the-logged-metrics) for `p
 
 ### Implementation details
 
-[pqn_atari_envpool_lstm.py](https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/pqn_atari_envpool_lstm.py) is based on the "5 LSTM implementation details" in [The 37 Implementation Details of Proximal Policy Optimization](https://iclr-blog-track.github.io/2022/03/25/pqn-implementation-details/), which are as follows:
+[pqn_atari_envpool_lstm.py](https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/pqn_atari_envpool_lstm.py) is based on the "5 LSTM implementation details" in [The 37 Implementation Details of Proximal Policy Optimization](https://iclr-blog-track.github.io/2022/03/25/ppo-implementation-details/), which are as follows:
 
 1. Layer initialization for LSTM layers (:material-github: [a2c/utils.py#L84-L86](https://github.com/openai/baselines/blob/ea25b9e8b234e6ee1bca43083f8f3cf974143998/baselines/a2c/utils.py#L84-L86))
 2. Initialize the LSTM states to be zeros (:material-github: [common/models.py#L179](https://github.com/openai/baselines/blob/ea25b9e8b234e6ee1bca43083f8f3cf974143998/baselines/common/models.py#L179))


### PR DESCRIPTION
## Description

Fixes four small documentation issues:

1. **Page title typo on [docs/rl-algorithms/ppo.md:1](docs/rl-algorithms/ppo.md):** `# Proximal Policy Gradient (PPO)` → `# Proximal Policy Optimization (PPO)`. The original paper (Schulman et al., 2017, arXiv:[1707.06347](https://arxiv.org/abs/1707.06347)) is titled *"Proximal Policy Optimization Algorithms"*, and this is how PPO is universally referred to. The same page already uses the correct name on line 11. Note that **PPG (Phasic Policy Gradient)** is a distinct algorithm with its own page at `docs/rl-algorithms/ppg.md` — unrelated. The same typo also occurs in `README.md`, `docs/rl-algorithms/overview.md`, `docs/rl-algorithms/ppo-rnd.md`, and `docs/blog/posts/cleanrl-v1.md`.

2. **Variable-name typo `olad_approx_kl` → `old_approx_kl`** in three docs (`ppo.md`, `ppg.md`, `ppo-trxl.md`). Matches the variable name used throughout the code (e.g. `cleanrl/ppo.py`).

3. **Repo-name typo `openai/baselies` → `openai/baselines`** (8 occurrences in `docs/rl-algorithms/ppo.md`).

4. **Broken URL in [docs/rl-algorithms/pqn.md](docs/rl-algorithms/pqn.md):** link to `https://iclr-blog-track.github.io/2022/03/25/pqn-implementation-details/` currently 404s. Corrected to `.../ppo-implementation-details/`, matching the 11+ other references in the repo to the same blog post (*The 37 Implementation Details of PPO* by Huang et al., 2022).

## Types of changes

- [x] Documentation

## Checklist:

- [x] I've read the [CONTRIBUTION](https://docs.cleanrl.dev/contribution/) guide (**required**).
- [x] I have ensured `pre-commit run --all-files` passes (**required**).
- [x] No behavioral changes (docs-only, not performance-impacting).