### PR TITLE
fix(enjoy): restore --capture-video argument removed in #424

### DIFF
--- a/cleanrl_utils/enjoy.py
+++ b/cleanrl_utils/enjoy.py
@@ -20,6 +20,8 @@ def parse_args():
         help="the id of the environment")
     parser.add_argument("--eval-episodes", type=int, default=10,
         help="the number of evaluation episodes")
+    parser.add_argument("--capture-video", action="store_true",
+        help="whether to capture videos of the agent performances (check out `videos` folder)")
     args = parser.parse_args()
     # fmt: on
     return args

--- a/docs/get-started/CleanRL_Huggingface_Integration_Demo.ipynb
+++ b/docs/get-started/CleanRL_Huggingface_Integration_Demo.ipynb
@@ -292,7 +292,7 @@
       "source": [
         "## Enjoy Utility\n",
         "\n",
-        "We have a simple way to load the model by running our \"enjoy\" utility, which automatically pull the model from 🤗 HuggingFace and run for a few episodes. It also produces a rendered video through the `--capture_video` flag. See more at our [📜 Documentation](https://docs.cleanrl.dev/get-started/zoo/)."
+        "We have a simple way to load the model by running our \"enjoy\" utility, which automatically pull the model from 🤗 HuggingFace and run for a few episodes. It also produces a rendered video through the `--capture-video` flag. See more at our [📜 Documentation](https://docs.cleanrl.dev/get-started/zoo/)."
       ]
     },
     {
@@ -338,7 +338,7 @@
         }
       ],
       "source": [
-        "!python -m cleanrl_utils.enjoy --exp-name dqn_atari_jax --env-id BreakoutNoFrameskip-v4 --eval-episodes 2 --capture_video"
+        "!python -m cleanrl_utils.enjoy --exp-name dqn_atari_jax --env-id BreakoutNoFrameskip-v4 --eval-episodes 2 --capture-video"
       ]
     },
     {


### PR DESCRIPTION
## Description

`cleanrl_utils/enjoy.py` references `args.capture_video` at line 42 but the corresponding `argparse` definition was removed during the tyro refactor in #424 — despite the PR's name, `enjoy.py` was never actually migrated to tyro and remained on raw `argparse`. As a result, any `python -m cleanrl_utils.enjoy ...` invocation crashes with `AttributeError: 'Namespace' object has no attribute 'capture_video'` immediately after the HuggingFace Hub model download succeeds.

This PR restores the `--capture-video` flag using the exact same pattern as the training scripts (`cleanrl/ppo.py`, `cleanrl/ddpg_continuous_action.py`, `cleanrl/sac_continuous_action.py`): `action="store_true"`, default `False`, byte-identical help text.

It also corrects `--capture_video` → `--capture-video` in `docs/get-started/CleanRL_Huggingface_Integration_Demo.ipynb` (two occurrences). `argparse` does not normalize underscores to hyphens, so the documented command in the notebook would have failed even after the Python fix.

### Verification

Reproduced the original crash on `master`: AttributeError: 'Namespace' object has no attribute 'capture_video'

After the fix:
- `python -m cleanrl_utils.enjoy --env-id CartPole-v1 --exp-name dqn --eval-episodes 1` → `args.capture_video = False`
- `python -m cleanrl_utils.enjoy --env-id CartPole-v1 --exp-name dqn --eval-episodes 1 --capture-video` → `args.capture_video = True`
- `python -m cleanrl_utils.enjoy --help` → now lists `--capture-video` with the correct help text

Note: I used `--exp-name dqn` for repro because `ppo` is not a registered key in `cleanrl_utils/evals/__init__.py`. The argparse-level fix is exp-name-independent.

### Out of scope (worth flagging separately)

- `enjoy.py` is the last `cleanrl_utils/` module still on raw `argparse`. A full tyro migration would be cleaner long-term but is intentionally not bundled here — mixing a refactor with a regression fix complicates review.
- `tests/test_enjoy.py` exists but is not wired into any CI workflow and its commands are malformed (`python enjoy.py --env ...` instead of `python -m cleanrl_utils.enjoy --env-id ...`). This is why the regression went uncaught for ~15 months. Happy to open a separate issue for this.

Closes #497

## Types of changes

- [x] Bug fix

## Checklist:

- [x] I've read the [CONTRIBUTION](https://docs.cleanrl.dev/contribution/) guide (**required**).
- [x] I have ensured `pre-commit run --all-files` passes (**required**).
- [x] No behavioral changes for users who don't pass `--capture-video` (default `False` matches pre-#424 behavior).