### PR TITLE
Fix enjoy.py crash: re-add missing --capture_video argument

### DIFF
--- a/cleanrl_utils/enjoy.py
+++ b/cleanrl_utils/enjoy.py
@@ -20,6 +20,8 @@ def parse_args():
         help="the id of the environment")
     parser.add_argument("--eval-episodes", type=int, default=10,
         help="the number of evaluation episodes")
+    parser.add_argument("--capture_video", action="store_true", default=False,
+        help="whether to capture videos of the agent performances (check out `videos` folder)")
     args = parser.parse_args()
     # fmt: on
     return args


### PR DESCRIPTION
## Description

Fixes #497.

`cleanrl_utils/enjoy.py` passes `capture_video=args.capture_video` to `evaluate(...)` (line 42), but `--capture_video` was removed from `parse_args()`, so `args` never has that attribute. Any invocation of `enjoy.py` therefore crashes with `AttributeError: 'Namespace' object has no attribute 'capture_video'` — including the command shown in the Hugging Face integration docs/Colab:

```bash
python -m cleanrl_utils.enjoy --exp-name dqn_atari_jax --env-id BreakoutNoFrameskip-v4 --eval-episodes 2 --capture_video
```

This re-adds the `--capture_video` flag to the parser, matching the flag name used by the training scripts and the documented command.

## Verification

```
$ python -m cleanrl_utils.enjoy --help
...
  --capture_video       whether to capture videos of the agent performances (check out `videos` folder)
```

The documented command now parses instead of raising `AttributeError`.

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] New tests
- [ ] Documentation

## Checklist

- [x] Minimal change: one argument added, matching existing argparse style
- [x] Flag name (`--capture_video`) matches the training scripts and the docs command
